### PR TITLE
Adding Ceuta and Melilla to region choices

### DIFF
--- a/localflavor/es/es_regions.py
+++ b/localflavor/es/es_regions.py
@@ -20,4 +20,6 @@ REGION_CHOICES = (
     ('MU', _('Region of Murcia')),
     ('NA', _('Foral Community of Navarre')),
     ('VC', _('Valencian Community')),
+    ('CE', _('Autonomous city of Ceuta')),
+    ('ML', _('Autonomous city of Mellila')),
 )

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -28,6 +28,8 @@ class ESLocalFlavorTests(SimpleTestCase):
 <option value="MU">Region of Murcia</option>
 <option value="NA">Foral Community of Navarre</option>
 <option value="VC">Valencian Community</option>
+<option value="CE">Autonomous city of Ceuta</option>
+<option value="ML">Autonomous city of Mellila</option>
 </select>'''
         self.assertHTMLEqual(f.render('regions', 'CT'), out)
 


### PR DESCRIPTION
(Previously django/django-localflavor-es#1)

The autonomous cities are listed as provinces, but they should be valid region choices as well (http://en.wikipedia.org/wiki/Autonomous_communities_of_Spain). The new choice values are the cities' respective ISO 3166-2 codes.
