### PR TITLE
Set int to value

### DIFF
--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -128,9 +128,9 @@ class BRCPFField(CharField):
             return ''
         orig_value = value[:]
         if not value.isdigit():
-            value = re.sub("[-\.]", "", value)
+            value = re.sub("[-\. ]", "", value)
         try:
-            value = str(int(value))
+            int(value)
         except ValueError:
             raise ValidationError(self.error_messages['digits_only'])
         if len(value) != 11:


### PR DESCRIPTION
This force to set the int to variable `value`. It failed in cases where spaces exists inside the CPF number, like: '123      '
