### PR TITLE
Fix REGON validation.

### DIFF
--- a/localflavor/pl/forms.py
+++ b/localflavor/pl/forms.py
@@ -205,7 +205,13 @@ class PLREGONField(RegexField):
 
         for table in weights:
             checksum = sum([int(n) * w for n, w in zip(number, table)])
-            if checksum % 11 % 10:
+
+            mod_result = checksum % 11
+
+            if mod_result == 10 and number[-1] != '0':
+                return False
+
+            if mod_result % 10:
                 return False
 
         return bool(weights)

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -471,11 +471,20 @@ class PLLocalFlavorTests(SimpleTestCase):
         valid = {
             '12345678512347': '12345678512347',
             '590096454': '590096454',
+
+            # A special case where the checksum == 10 and the control
+            # digit == '0'
+            '391023200': '391023200',
         }
         invalid = {
             '123456784': error_checksum,
             '12345678412342': error_checksum,
             '590096453': error_checksum,
+
+            # A special case where the checksum == 10,
+            # but the control digit != '0'
+            '111111111': error_checksum,
+
             '590096': error_format,
         }
         self.assertFieldOutput(PLREGONField, valid, invalid)


### PR DESCRIPTION
- There is a special case when the result of modulo 11 division equals
  to 10. In this case, the correct checksum is 0. Taken from:
  http://wipos.p.lodz.pl/zylla/ut/nip-rego.html#regon
