### PR TITLE
Fix deprecation warnings in tests for Django 1.7 ModelForms

### DIFF
--- a/tests/test_au/forms.py
+++ b/tests/test_au/forms.py
@@ -9,3 +9,5 @@ class AustralianPlaceForm(ModelForm):
     """ Form for storing an Australian place. """
     class Meta:
         model = AustralianPlace
+        fields = ('state', 'state_required', 'state_default', 'postcode', 'postcode_required', 'postcode_default',
+                  'phone', 'name')

--- a/tests/test_mk/forms.py
+++ b/tests/test_mk/forms.py
@@ -9,3 +9,4 @@ class MKPersonForm(ModelForm):
 
     class Meta:
         model = MKPerson
+        fields = ('first_name', 'last_name', 'umcn', 'id_number', 'municipality', 'municipality_req')

--- a/tests/test_mx/forms.py
+++ b/tests/test_mx/forms.py
@@ -9,3 +9,4 @@ class MXPersonProfileForm(ModelForm):
 
     class Meta:
         model = MXPersonProfile
+        fields = ('state', 'rfc', 'curp', 'zip_code', 'ssn')

--- a/tests/test_pk/forms.py
+++ b/tests/test_pk/forms.py
@@ -9,3 +9,5 @@ class PakistaniPlaceForm(ModelForm):
     """ Form for storing a Pakistani place. """
     class Meta:
         model = PakistaniPlace
+        fields = ('state', 'state_required', 'state_default', 'postcode', 'postcode_required', 'postcode_default',
+                  'phone', 'name')

--- a/tests/test_us/forms.py
+++ b/tests/test_us/forms.py
@@ -9,3 +9,4 @@ class USPlaceForm(ModelForm):
 
     class Meta:
         model = USPlace
+        fields = ('state', 'state_req', 'state_default', 'postal_code', 'name')


### PR DESCRIPTION
In Django 1.7, creating a ModelForm without specifying fields or exclude is deprecated. This is currently done in some localflavor tests. The easiest option would be to use `fields = "__all__"`, but this is not supported in 1.5.

With this update, tests work for me with Django 1.7 on Python 2.7.
