### PR TITLE
Update italian telephone number regular expression

### DIFF
--- a/localflavor/it/forms.py
+++ b/localflavor/it/forms.py
@@ -17,7 +17,7 @@ from .it_region import REGION_CHOICES
 from .util import vat_number_validation, ssn_validation
 
 
-phone_digits_re = re.compile(r'^(?:\+?39)?((06)(\d{8})|(3\d{2})(\d{6,8}))$')
+phone_digits_re = re.compile(r'^(?:\+?39)?((0\d{1,3})(\d{4,8})|(3\d{2})(\d{6,8}))$')
 
 
 class ITZipCodeField(RegexField):


### PR DESCRIPTION
The old regular expression works only for Rome.
For reference see http://en.wikipedia.org/wiki/List_of_dialling_codes_in_Italy
