### PR TITLE
Test against Django trunk with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,24 @@
 [tox]
 args_are_paths = false
 envlist =
-    py26, py26-1.5, py26-1.6,
-    py27, py27-1.5, py27-1.6,
-    py32, py32-1.5, py32-1.6,
-    py33, py33-1.5, py33-1.6,
+    py26-1.5, py26-1.6,
+    py27-1.5, py27-1.6, py27-master,
+    py32-1.5, py32-1.6, py32-master,
+    py33-1.5, py33-1.6, py33-master
 
 [testenv]
 usedevelop = true
 commands =
     invoke test {posargs}
-django =
-    https://github.com/django/django/archive/master.zip
-    -r{toxinidir}/tests/requirements.txt
 django15 =
     Django>=1.5,<1.6
     -r{toxinidir}/tests/requirements.txt
 django16 =
     Django>=1.6,<1.7
     -r{toxinidir}/tests/requirements.txt
-
-[testenv:py26]
-basepython = python2.6
-deps = {[testenv]django}
+djangomaster =
+    https://github.com/django/django/archive/master.zip
+    -r{toxinidir}/tests/requirements.txt
 
 [testenv:py26-1.5]
 basepython = python2.6
@@ -32,10 +28,6 @@ deps = {[testenv]django15}
 basepython = python2.6
 deps = {[testenv]django16}
 
-[testenv:py27]
-basepython = python2.7
-deps = {[testenv]django}
-
 [testenv:py27-1.5]
 basepython = python2.7
 deps = {[testenv]django15}
@@ -44,9 +36,9 @@ deps = {[testenv]django15}
 basepython = python2.7
 deps = {[testenv]django16}
 
-[testenv:py32]
-basepython = python3.2
-deps = {[testenv]django}
+[testenv:py27-master]
+basepython = python2.7
+deps = {[testenv]djangomaster}
 
 [testenv:py32-1.5]
 basepython = python3.2
@@ -56,9 +48,9 @@ deps = {[testenv]django15}
 basepython = python3.2
 deps = {[testenv]django16}
 
-[testenv:py33]
-basepython = python3.3
-deps = {[testenv]django}
+[testenv:py32-master]
+basepython = python3.2
+deps = {[testenv]djangomaster}
 
 [testenv:py33-1.5]
 basepython = python3.3
@@ -67,3 +59,7 @@ deps = {[testenv]django15}
 [testenv:py33-1.6]
 basepython = python3.3
 deps = {[testenv]django16}
+
+[testenv:py33-master]
+basepython = python3.3
+deps = {[testenv]djangomaster}


### PR DESCRIPTION
I like testing against Django trunk to ensure future-proof code.

Thoughts on this?

Should I name the envs as `pyXY-trunk` or is `pyXY` sufficient?
