### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+[*.bat]
+end_of_line = crlf


### PR DESCRIPTION
This dictates the basic universal code style of the project so users can configure their editors appropriately.

If a contributor has an EditorConfig plugin installed this file will teach their editor to conform to the required code style automatically.

This may result in the avoidance of minor code style bugs such as noted in #94.

See http://editorconfig.org for more information.
