### PR TITLE
Enhanced kwargs parameters for FRFormField

### DIFF
--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -30,9 +30,9 @@ class FRZipCodeField(RegexField):
     }
 
     def __init__(self, *args, **kwargs):
-        kwargs['label'] = kwargs.get('label', _('Zip code'))
-        kwargs['max_length'] = kwargs.get('max_length', 5)
-        kwargs['min_length'] = kwargs.get('min_length', 5)
+        kwargs.setdefault('label', _('Zip code'))
+        kwargs['max_length'] = 5
+        kwargs['min_length'] = 5
         super(FRZipCodeField, self).__init__(r'^\d{5}$', *args, **kwargs)
 
 
@@ -50,9 +50,9 @@ class FRPhoneNumberField(CharField):
     }
 
     def __init__(self, *args, **kwargs):
-        kwargs['label'] = kwargs.get('label', _('Phone number'))
-        kwargs['max_length'] = kwargs.get('max_length', 14)
-        kwargs['min_length'] = kwargs.get('min_length', 10)
+        kwargs.setdefault('label', _('Phone number'))
+        kwargs['max_length'] = 14
+        kwargs['min_length'] = 10
         super(FRPhoneNumberField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
@@ -109,7 +109,7 @@ class FRDepartmentField(CharField):
     widget = FRDepartmentSelect
 
     def __init__(self, *args, **kwargs):
-        kwargs['label'] = _('Select Department')
+        kwargs.setdefault('label', _('Select Department'))
         super(FRDepartmentField, self).__init__(*args, **kwargs)
 
 
@@ -120,7 +120,7 @@ class FRRegionField(CharField):
     widget = FRRegionSelect
 
     def __init__(self, *args, **kwargs):
-        kwargs['label'] = _('Select Region')
+        kwargs.setdefault('label', _('Select Region'))
         super(FRRegionField, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
see my issue :

https://github.com/django/django-localflavor/issues/101

label kwarg must not be fixed. In django.contrib.localflavor, we could change field label.

Actually, with 3 FRPhoneNumberField, three have 'PhoneNumber' in label...
