### PR TITLE
Add checksums module from django.utils.checksums

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,6 +23,7 @@ Authors
 * Grzes Furga
 * Honza Král
 * Horst Gutmann
+* Jaap Roes
 * Jacob Kaplan-Moss
 * James Bennett
 * Jannis Leidel

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ Other modifications to existing flavors:
 - Rejected US SSN starting with 9 (gh-35)
 - Rejected Brazilian CPF number when all numbers all numbers are equal (gh-103)
 
+Other changes:
+
+- Added checksums module (from Django) providing a Luhn validator (gh-122)
 
 1.0.0 (2013-07-29)
 ------------------

--- a/docs/generic.rst
+++ b/docs/generic.rst
@@ -13,6 +13,14 @@ Models
 .. automodule:: localflavor.generic.models
     :members:
 
+Checksums
+---------
+
+.. automodule:: localflavor.generic.checksums
+    :members:
+
+.. versionadded:: 1.1
+
 Data
 ----
 

--- a/localflavor/ca/forms.py
+++ b/localflavor/ca/forms.py
@@ -11,6 +11,7 @@ from django.forms import ValidationError
 from django.forms.fields import Field, CharField, Select
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
+from localflavor.generic.checksums import luhn
 
 
 phone_digits_re = re.compile(r'^(?:1-?)?(\d{3})[-\.]?(\d{3})[-\.]?(\d{4})$')
@@ -131,28 +132,6 @@ class CASocialInsuranceNumberField(Field):
             match.group(1),
             match.group(2),
             match.group(3))
-        if not self.luhn_checksum_is_valid(check_number):
+        if not luhn(check_number):
             raise ValidationError(self.error_messages['invalid'])
         return number
-
-    def luhn_checksum_is_valid(self, number):
-        """
-        Checks to make sure that the SIN passes a luhn mod-10 checksum
-        See: http://en.wikipedia.org/wiki/Luhn_algorithm
-        """
-
-        sum = 0
-        num_digits = len(number)
-        oddeven = num_digits & 1
-
-        for count in range(0, num_digits):
-            digit = int(number[count])
-
-            if not ((count & 1) ^ oddeven):
-                digit = digit * 2
-            if digit > 9:
-                digit = digit - 9
-
-            sum = sum + digit
-
-        return ((sum % 10) == 0)

--- a/localflavor/generic/checksums.py
+++ b/localflavor/generic/checksums.py
@@ -1,0 +1,25 @@
+"""
+Common checksum routines.
+"""
+
+__all__ = ['luhn']
+
+from django.utils import six
+
+LUHN_ODD_LOOKUP = (0, 2, 4, 6, 8, 1, 3, 5, 7, 9)  # sum_of_digits(index * 2)
+
+
+def luhn(candidate):
+    """
+    Checks a candidate number for validity according to the Luhn
+    algorithm (used in validation of, for example, credit cards).
+    Both numeric and string candidates are accepted.
+    """
+    if not isinstance(candidate, six.string_types):
+        candidate = str(candidate)
+    try:
+        evens = sum(int(c) for c in candidate[-1::-2])
+        odds = sum(LUHN_ODD_LOOKUP[int(c)] for c in candidate[-2::-2])
+        return ((evens + odds) % 10 == 0)
+    except ValueError:  # Raised if an int conversion fails
+        return False

--- a/localflavor/hr/forms.py
+++ b/localflavor/hr/forms.py
@@ -15,6 +15,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from .hr_choices import (HR_LICENSE_PLATE_PREFIX_CHOICES, HR_COUNTY_CHOICES,
                          HR_PHONE_NUMBER_PREFIX_CHOICES)
+from localflavor.generic.checksums import luhn
 
 
 jmbg_re = re.compile(r'^(?P<dd>\d{2})(?P<mm>\d{2})(?P<yyy>\d{3})' +
@@ -273,8 +274,7 @@ class HRJMBAGField(Field):
             raise ValidationError(self.error_messages['copy'])
 
         # Validate checksum using Luhn algorithm.
-        num = [int(x) for x in value]
-        if not sum(num[::-2] + [sum(divmod(d * 2, 10)) for d in num[-2::-2]]) % 10 == 0:
+        if not luhn(value):
             raise ValidationError(self.error_messages['invalid'])
 
         return '%s' % value

--- a/localflavor/il/forms.py
+++ b/localflavor/il/forms.py
@@ -7,8 +7,8 @@ import re
 from django.core.exceptions import ValidationError
 from django.core.validators import EMPTY_VALUES
 from django.forms.fields import RegexField, Field
-from django.utils.checksums import luhn
 from django.utils.translation import ugettext_lazy as _
+from localflavor.generic.checksums import luhn
 
 id_number_re = re.compile(r'^(?P<number>\d{1,8})-?(?P<check>\d)$')
 mobile_phone_number_re = re.compile(r'^(\()?0?(5[02-9])(?(1)\))-?\d{7}$')  # including palestinian mobile carriers

--- a/tests/test_checksums.py
+++ b/tests/test_checksums.py
@@ -1,0 +1,30 @@
+import unittest
+
+from localflavor.generic import checksums
+
+
+class TestUtilsChecksums(unittest.TestCase):
+
+    def check_output(self, function, value, output=None):
+        """
+        Check that function(value) equals output.  If output is None,
+        check that function(value) equals value.
+        """
+        if output is None:
+            output = value
+        self.assertEqual(function(value), output)
+
+    def test_luhn(self):
+        f = checksums.luhn
+        items = (
+            (4111111111111111, True), ('4111111111111111', True),
+            (4222222222222, True), (378734493671000, True),
+            (5424000000000015, True), (5555555555554444, True),
+            (1008, True), ('0000001008', True), ('000000001008', True),
+            (4012888888881881, True), (1234567890123456789012345678909, True),
+            (4111111111211111, False), (42222222222224, False),
+            (100, False), ('100', False), ('0000100', False),
+            ('abc', False), (None, False), (object(), False),
+        )
+        for value, output in items:
+            self.check_output(f, value, output)


### PR DESCRIPTION
[Django ticket #23613](https://code.djangoproject.com/ticket/23613) calls out `django.utils.checksums` for being unused and suggest moving it to django-localflavor.

This pull request includes the checksums module from django, the associated testcase and replaces uses of the luhn algorithm in localflavor with calls to the `luhn` function.

I didn't fully comprehend the implementation of the Luhn algorithm `se.utils.id_number_checksum` so I left that one alone.
