### PR TITLE
SIRET : cleaning dashes and spaces added in prepare_value

### DIFF
--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -238,7 +238,11 @@ class FRSIRETField(FRSIRENENumberMixin, CharField):
     }
 
     def clean(self, value):
+        if value not in EMPTY_VALUES:
+            value = value.replace(' ', '').replace('-', '')
+
         ret = super(FRSIRETField, self).clean(value)
+
         if not luhn(ret[:9]):
             raise ValidationError(self.error_messages['invalid'])
         return ret


### PR DESCRIPTION
Spaces added on prepare_value was not removed on submit causing a validation error to be raised. 
To submit a form with a SIRET field user had to manually remove spaces in the SIRET at each submit even if the SIRET was coming from database and previously successfully validated.
