### PR TITLE
Estonian local flavor: added business registry code field

### DIFF
--- a/localflavor/ee/forms.py
+++ b/localflavor/ee/forms.py
@@ -94,6 +94,8 @@ class EEPersonalIdentificationCode(Field):
 class EEBusinessRegistryCode(Field):
     """A form field that validates input as an
     Estonian business registration code.
+
+    .. versionadded:: 1.2
     """
     default_error_messages = {
         'invalid_format': _('Enter an 8-digit Estonian business registry code.'),

--- a/localflavor/ee/forms.py
+++ b/localflavor/ee/forms.py
@@ -13,7 +13,7 @@ from .ee_counties import COUNTY_CHOICES
 
 idcode = re.compile(r'^([1-6])(\d\d)(\d\d)(\d\d)(?:\d{3})(\d)$')
 zipcode = re.compile(r'^[1-9]\d{4}$')
-bregcode = re.compile(r'^(?:\d{7})(\d)$')
+bregcode = re.compile(r'^([1-9])(?:\d{6})(\d)$')
 
 
 class EEZipCodeField(RegexField):
@@ -49,7 +49,7 @@ class EEPersonalIdentificationCode(Field):
 
     @staticmethod
     def ee_checksum(value):
-        """Takes a string of 10 digits as input, returns check digit."""
+        """Takes a string of digits as input, returns check digit."""
 
         for i in (1, 3):
             check = 0
@@ -100,10 +100,6 @@ class EEBusinessRegistryCode(Field):
         'invalid': _('Enter a valid Estonian business registry code.'),
     }
 
-    @staticmethod
-    def ee_checksum(value):
-        return EEPersonalIdentificationCode.ee_checksum(value)
-
     def clean(self, value):
         value = super(EEBusinessRegistryCode, self).clean(value)
         if value in EMPTY_VALUES:
@@ -114,9 +110,9 @@ class EEBusinessRegistryCode(Field):
         if not match:
             raise ValidationError(self.error_messages['invalid_format'])
 
-        check = int(match.group(1))
+        check = int(match.group(2))
 
-        if check != self.ee_checksum(value[:7]):
+        if check != EEPersonalIdentificationCode.ee_checksum(value[:7]):
             raise ValidationError(self.error_messages['invalid'])
 
         return value

--- a/localflavor/ee/forms.py
+++ b/localflavor/ee/forms.py
@@ -38,7 +38,7 @@ class EECountySelect(Select):
 
 
 class EEPersonalIdentificationCode(Field):
-    """A form field that validates input as a Estonian personal identification code.
+    """A form field that validates input as an Estonian personal identification code.
 
     See: https://www.riigiteataja.ee/akt/106032012004
     """
@@ -91,7 +91,7 @@ class EEPersonalIdentificationCode(Field):
         return value
 
 
-class EEBusinessRegistryCode(EEPersonalIdentificationCode, Field):
+class EEBusinessRegistryCode(Field):
     """A form field that validates input as an
     Estonian business registration code.
     """
@@ -99,6 +99,10 @@ class EEBusinessRegistryCode(EEPersonalIdentificationCode, Field):
         'invalid_format': _('Enter an 8-digit Estonian business registry code.'),
         'invalid': _('Enter a valid Estonian business registry code.'),
     }
+
+    @staticmethod
+    def ee_checksum(value):
+        return EEPersonalIdentificationCode.ee_checksum(value)
 
     def clean(self, value):
         value = super(EEBusinessRegistryCode, self).clean(value)

--- a/localflavor/ee/forms.py
+++ b/localflavor/ee/forms.py
@@ -13,7 +13,7 @@ from .ee_counties import COUNTY_CHOICES
 
 idcode = re.compile(r'^([1-6])(\d\d)(\d\d)(\d\d)(?:\d{3})(\d)$')
 zipcode = re.compile(r'^[1-9]\d{4}$')
-bregcode = re.compile(r'^([1-9])(?:\d{6})(\d)$')
+bregcode = re.compile(r'^[1-9]\d{7}$')
 
 
 class EEZipCodeField(RegexField):
@@ -110,7 +110,7 @@ class EEBusinessRegistryCode(Field):
         if not match:
             raise ValidationError(self.error_messages['invalid_format'])
 
-        check = int(match.group(2))
+        check = int(value[7])
 
         if check != EEPersonalIdentificationCode.ee_checksum(value[:7]):
             raise ValidationError(self.error_messages['invalid'])

--- a/tests/test_ee.py
+++ b/tests/test_ee.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.test import SimpleTestCase
 
 from localflavor.ee.forms import (EEZipCodeField, EEPersonalIdentificationCode,
-                                  EECountySelect)
+                                  EECountySelect, EEBusinessRegistryCode)
 
 
 class EELocalFlavorTests(SimpleTestCase):
@@ -59,3 +59,17 @@ class EELocalFlavorTests(SimpleTestCase):
             '61402291232': invalid,  # not leap year
         }
         self.assertFieldOutput(EEPersonalIdentificationCode, valid, invalid)
+
+    def test_EEBusinessRegistryCode(self):
+        invalid = ['Enter a valid Estonian business registry code.']
+        invalid_format = ['Enter an 8-digit Estonian business registry code.']
+        valid = {
+            '80053370': '80053370',
+            '11694365': '11694365',  # checksum base 1
+            '10223576': '10223576',  # checksum base 3
+        }
+        invalid = {
+            '4329865': invalid_format,
+            '33333333': invalid,  # invalid checksum
+        }
+        self.assertFieldOutput(EEBusinessRegistryCode, valid, invalid)


### PR DESCRIPTION
I've added the field to validate the Estonian business registry code (äriregistri registrikood).

Although I couldn't find a standard or a legitimate source for the business registry code structure, it seems to have the same checksum method as the personal identification code. Even though its 8 characters long, the basic math would make sense (just imagine the last 3 non-checksum numbers being 0's). After testing a fair bit of known correct codes, the checksum works.

The `EEBusinessRegistryCode` field itself behaves in a very similar manner to the existing `EEPersonalIdentificationCode` field.