### PR TITLE
Proposal: Use libphonenumber for phone number validation

### DIFF
--- a/localflavor/au/forms.py
+++ b/localflavor/au/forms.py
@@ -6,11 +6,10 @@ from __future__ import absolute_import, unicode_literals
 
 import re
 
-from django.core.validators import EMPTY_VALUES
-from django.forms import ValidationError
-from django.forms.fields import CharField, RegexField, Select
-from django.utils.encoding import smart_text
+from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor.generic.forms import PhoneNumberField
 
 from .au_states import STATE_CHOICES
 
@@ -32,28 +31,17 @@ class AUPostCodeField(RegexField):
                                               max_length, min_length, *args, **kwargs)
 
 
-class AUPhoneNumberField(CharField):
+class AUPhoneNumberField(PhoneNumberField):
     """
     A form field that validates input as an Australian phone number.
 
     Valid numbers have ten digits.
     """
+    region = 'AU'
+
     default_error_messages = {
         'invalid': 'Phone numbers must contain 10 digits.',
     }
-
-    def clean(self, value):
-        """
-        Validate a phone number. Strips parentheses, whitespace and hyphens.
-        """
-        super(AUPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
-        value = re.sub('(\(|\)|\s+|-)', '', smart_text(value))
-        phone_match = PHONE_DIGITS_RE.search(value)
-        if phone_match:
-            return '%s' % phone_match.group(1)
-        raise ValidationError(self.error_messages['invalid'])
 
 
 class AUStateSelect(Select):

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(
     author_email='foundation@djangoproject.com',
     packages=find_packages(exclude=['tests', 'tests.*']),
     package_data=find_package_data(),
+    install_requires=['phonenumbers'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 invoke==0.11.1
 coverage==3.7.1
 flake8==2.2.5
+phonenumbers==7.2.2
 six==1.10.0

--- a/tests/test_au/tests.py
+++ b/tests/test_au/tests.py
@@ -93,16 +93,19 @@ class AULocalflavorTests(TestCase):
     def test_AUPhoneNumberField(self):
         error_format = ['Phone numbers must contain 10 digits.']
         valid = {
-            '1234567890': '1234567890',
+            '61234567890': '0234567890',
             '0213456789': '0213456789',
             '02 13 45 67 89': '0213456789',
             '(02) 1345 6789': '0213456789',
             '(02) 1345-6789': '0213456789',
             '(02)1345-6789': '0213456789',
             '0408 123 456': '0408123456',
+            '1800DJANGO': '1800352646',
+            '131122': '131122',
+            '1300111222': '1300111222',
         }
         invalid = {
             '123': error_format,
-            '1800DJANGO': error_format,
+            '88884444': error_format,
         }
         self.assertFieldOutput(AUPhoneNumberField, valid, invalid)


### PR DESCRIPTION
The phone number validation rules are quite simple at the moment. For example, Australian numbers must be 10 digits.

This PR uses the excellent [port of `libphonenumber`](https://github.com/daviddrysdale/python-phonenumbers) to have thorough phone number validation for just about every location.

I've included the option to allow/disallow international numbers as part of the validation, and to be able to choose which number types to allow (e.g. mobile only, land line only, etc.)

I've only included the new validation in the Australian phone number field for now however if this is accepted, we can easily add it to other countries too.