### PR TITLE
Strip field in order to avoid int conversion crash

### DIFF
--- a/localflavor/ro/forms.py
+++ b/localflavor/ro/forms.py
@@ -36,7 +36,7 @@ class ROCIFField(RegexField):
         """
         CIF validation
         """
-        value = super(ROCIFField, self).clean(value)
+        value = super(ROCIFField, self).clean(value).strip()
         if value in EMPTY_VALUES:
             return ''
         # strip RO part

--- a/tests/test_ro.py
+++ b/tests/test_ro.py
@@ -63,6 +63,7 @@ class ROLocalFlavorTests(SimpleTestCase):
         error_atleast = ['Ensure this value has at least 2 characters (it has 1).']
         valid = {
             '21694681': '21694681',
+            '21694681 ': '21694681',
             'RO21694681': '21694681',
         }
         invalid = {


### PR DESCRIPTION
If the CIF ended with a space the validation crashed with this error: invalid literal for int() with base 10: ''