### PR TITLE
Switch from coveralls to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ cache:
     - $HOME/.wheels
 install:
     - mkdir -p $PIP_WHEEL_DIR
-    - pip wheel -r tests/requirements.txt coveralls
-    - pip install coveralls tox
+    - pip wheel -r tests/requirements.txt codecov
+    - pip install codecov tox
 script:
   - tox
-after_success: coveralls
+after_success: codecov

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ django-localflavor
 .. image:: https://img.shields.io/travis/django/django-localflavor.svg
     :target: http://travis-ci.org/django/django-localflavor
 
-.. image:: https://img.shields.io/coveralls/django/django-localflavor.svg
-   :target: https://coveralls.io/r/django/django-localflavor
+.. image:: https://img.shields.io/codecov/c/github/django/django-localflavor/master.svg
+   :target: http://codecov.io/github/django/django-localflavor?branch=master
 
 .. image:: https://readthedocs.org/projects/django-localflavor/badge/?version=latest&style=plastic
    :target: http://django-localflavor.readthedocs.org/en/latest/


### PR DESCRIPTION
Unlike Coveralls, codecov supports branch coverage.  There is also a Chrome plugin that overlays coverage reports on diffs and file contents.