### PR TITLE
Adds deconstruct methods to the US flavor.

### DIFF
--- a/localflavor/us/models.py
+++ b/localflavor/us/models.py
@@ -17,6 +17,12 @@ class USStateField(CharField):
         kwargs['max_length'] = 2
         super(USStateField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(USStateField, self).deconstruct()
+        del kwargs["choices"]
+        del kwargs["max_length"]
+        return name, path, args, kwargs
+
 
 class USPostalCodeField(CharField):
     """"
@@ -35,6 +41,12 @@ class USPostalCodeField(CharField):
         kwargs['choices'] = USPS_CHOICES
         kwargs['max_length'] = 2
         super(USPostalCodeField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(USPostalCodeField, self).deconstruct()
+        del kwargs["choices"]
+        del kwargs["max_length"]
+        return name, path, args, kwargs
 
 
 class USZipCodeField(CharField):
@@ -57,6 +69,11 @@ class USZipCodeField(CharField):
         kwargs['max_length'] = 10
         super(USZipCodeField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(USZipCodeField, self).deconstruct()
+        del kwargs["max_length"]
+        return name, path, args, kwargs
+
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.USZipCodeField}
         defaults.update(kwargs)
@@ -73,6 +90,11 @@ class PhoneNumberField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 20
         super(PhoneNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(PhoneNumberField, self).deconstruct()
+        del kwargs["max_length"]
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         from localflavor.us.forms import USPhoneNumberField
@@ -93,6 +115,11 @@ class USSocialSecurityNumberField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 11
         super(USSocialSecurityNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(USSocialSecurityNumberField, self).deconstruct()
+        del kwargs["max_length"]
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         from localflavor.us.forms import (USSocialSecurityNumberField as

--- a/tests/test_us/tests.py
+++ b/tests/test_us/tests.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 
-from localflavor.us.forms import (USZipCodeField, USPhoneNumberField,
-                                  USStateField, USStateSelect,
-                                  USSocialSecurityNumberField)
+from localflavor.us import forms
+from localflavor.us import models
 
 from .forms import USPlaceForm
 
@@ -187,7 +186,7 @@ class USLocalFlavorTests(TestCase):
         self.assertHTMLEqual(str(self.form['postal_code']), usps_select_html)
 
     def test_USStateSelect(self):
-        f = USStateSelect()
+        f = forms.USStateSelect()
         out = '''<select name="state">
 <option value="AL">Alabama</option>
 <option value="AK">Alaska</option>
@@ -265,7 +264,7 @@ class USLocalFlavorTests(TestCase):
             '6060-1234': error_format,
             '60606-': error_format,
         }
-        self.assertFieldOutput(USZipCodeField, valid, invalid)
+        self.assertFieldOutput(forms.USZipCodeField, valid, invalid)
 
     def test_USZipCodeField_formfield(self):
         """Test that the full US ZIP code field is really the full list."""
@@ -288,7 +287,7 @@ class USLocalFlavorTests(TestCase):
             '555-1212': error_format,
             '312-55-1212': error_format,
         }
-        self.assertFieldOutput(USPhoneNumberField, valid, invalid)
+        self.assertFieldOutput(forms.USPhoneNumberField, valid, invalid)
 
     def test_USStateField(self):
         error_invalid = ['Enter a U.S. state or territory.']
@@ -301,7 +300,7 @@ class USLocalFlavorTests(TestCase):
         invalid = {
             60606: error_invalid,
         }
-        self.assertFieldOutput(USStateField, valid, invalid)
+        self.assertFieldOutput(forms.USStateField, valid, invalid)
 
     def test_USSocialSecurityNumberField(self):
         error_invalid = ['Enter a valid U.S. Social Security number in XXX-XX-XXXX format.']
@@ -315,4 +314,18 @@ class USLocalFlavorTests(TestCase):
             '900-12-3456': error_invalid,
             '999-98-7652': error_invalid,
         }
-        self.assertFieldOutput(USSocialSecurityNumberField, valid, invalid)
+        self.assertFieldOutput(forms.USSocialSecurityNumberField, valid, invalid)
+
+    def test_deconstruct_methods(self):
+        classes = (models.USStateField, models.USPostalCodeField,
+                   models.USZipCodeField, models.PhoneNumberField,
+                   models.USSocialSecurityNumberField)
+        for cls in classes:
+            test_instance = cls()
+            name, path, args, kwargs = test_instance.deconstruct()
+            new_instance = cls(*args, **kwargs)
+            for attr in ('choices', 'max_length'):
+                self.assertEqual(
+                    getattr(test_instance, attr),
+                    getattr(new_instance, attr),
+                )

--- a/tests/test_us/tests.py
+++ b/tests/test_us/tests.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import django
 from django.test import TestCase
 
 from localflavor.us import forms
@@ -317,15 +318,17 @@ class USLocalFlavorTests(TestCase):
         self.assertFieldOutput(forms.USSocialSecurityNumberField, valid, invalid)
 
     def test_deconstruct_methods(self):
-        classes = (models.USStateField, models.USPostalCodeField,
-                   models.USZipCodeField, models.PhoneNumberField,
-                   models.USSocialSecurityNumberField)
-        for cls in classes:
-            test_instance = cls()
-            name, path, args, kwargs = test_instance.deconstruct()
-            new_instance = cls(*args, **kwargs)
-            for attr in ('choices', 'max_length'):
-                self.assertEqual(
-                    getattr(test_instance, attr),
-                    getattr(new_instance, attr),
-                )
+        """Test the deconstruct method that was added in Django 1.7"""
+        if django.VERSION > (1, 7):
+            classes = (models.USStateField, models.USPostalCodeField,
+                       models.USZipCodeField, models.PhoneNumberField,
+                       models.USSocialSecurityNumberField)
+            for cls in classes:
+                test_instance = cls()
+                name, path, args, kwargs = test_instance.deconstruct()
+                new_instance = cls(*args, **kwargs)
+                for attr in ('choices', 'max_length'):
+                    self.assertEqual(
+                        getattr(test_instance, attr),
+                        getattr(new_instance, attr),
+                    )


### PR DESCRIPTION
Format is cribbed from the `deconstruct` method's documentation, which provides clear examples for how to write these methods. To do this, I needed to import the models into the tests, which created some fun namespace problems.