### PR TITLE
Drop support for Django 1.5 / 1.6 and Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,6 @@ env:
 matrix:
   include:
     - env: TOXENV=docs
-    - python: 2.6
-      env: TOXENV=py26-1.5
-    - python: 2.6
-      env: TOXENV=py26-1.6
-    - python: 2.7
-      env: TOXENV=py27-1.5
-    - python: 2.7
-      env: TOXENV=py27-1.6
     - python: 2.7
       env: TOXENV=py27-1.7
     - python: 2.7
@@ -24,25 +16,13 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-master
     - python: 3.2
-      env: TOXENV=py32-1.5
-    - python: 3.2
-      env: TOXENV=py32-1.6
-    - python: 3.2
       env: TOXENV=py32-1.7
     - python: 3.2
       env: TOXENV=py32-1.8
     - python: 3.3
-      env: TOXENV=py33-1.5
-    - python: 3.3
-      env: TOXENV=py33-1.6
-    - python: 3.3
       env: TOXENV=py33-1.7
     - python: 3.3
       env: TOXENV=py33-1.8
-    - python: 3.4
-      env: TOXENV=py34-1.5
-    - python: 3.4
-      env: TOXENV=py34-1.6
     - python: 3.4
       env: TOXENV=py34-1.7
     - python: 3.4

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -35,18 +35,21 @@ The previous command will run the tests in different combinations of Python
 the ``-l`` option::
 
     $ tox -l
-    py26-1.5
-    py26-1.6
-    py27-1.5
-    py27-1.6
-    py32-1.5
-    py32-1.6
-    py33-1.5
-    py33-1.6
+    docs
+    py27-1.7
+    py27-1.8
+    py32-1.7
+    py32-1.8
+    py33-1.7
+    py33-1.8
+    py34-1.7
+    py34-1.8
+    py27-master
+    py34-master
 
 You can run each environment with the ``-e`` option::
 
-    $ tox -e py27-1.6  # runs the tests only on Pyton 2.7 and Django 1.6.x
+    $ tox -e py27-1.7  # runs the tests only on Pyton 2.7 and Django 1.7.x
 
 Optionally you can also specify a country whose tests you want to run::
 
@@ -54,7 +57,7 @@ Optionally you can also specify a country whose tests you want to run::
 
 And combine both options::
 
-    $ COUNTRY=us tox -e py27-1.6
+    $ COUNTRY=us tox -e py27-1.7
 
 __ https://github.com/django/django-localflavor/issues
 __ http://tox.readthedocs.org/en/latest/install.html

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,11 @@ Modifications to existing flavors:
 
 - None
 
+Other changes:
+
+- Drop support for Django 1.5, Django 1.6 and Python 2.6
+  (`gh-170 <https://github.com/django/django-localflavor/pull/170>`_).
+
 1.2   (2015-11-27)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 invoke==0.11.1
 coverage==3.7.1
 flake8==2.2.5
-django-discover-runner==1.0
 six==1.8.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 invoke==0.11.1
 coverage==3.7.1
 flake8==2.2.5
-six==1.8.0
+six==1.10.0

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 
 DATABASES = {
     'default': {
@@ -17,11 +16,6 @@ INSTALLED_APPS = [
     'tests.test_us',
     'tests.test_pk',
 ]
-
-import django
-
-if django.VERSION[:2] < (1, 6):
-    TEST_RUNNER = 'discover_runner.DiscoverRunner'
 
 SECRET_KEY = 'spam-spam-spam-spam'
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,11 @@
 args_are_paths = false
 envlist =
     docs,
-    py26-{1.5,1.6},
-    {py27,py32,py33,py34}-{1.5,1.6,1.7,1.8},
+    {py27,py32,py33,py34}-{1.7,1.8},
     {py27,py34,py35}-{1.9,master}
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py32: python3.2
     py33: python3.3
@@ -19,8 +17,6 @@ pip_pre = true
 commands =
     invoke test {posargs}
 deps =
-    1.5: Django>=1.5,<1.6
-    1.6: Django>=1.6,<1.7
     1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
     1.9: Django==1.9rc2


### PR DESCRIPTION
Motivated by the unknown Django 1.5 test errors in #152, I propose we drop support for unsupported versions of Django (1.5 and 1.6) which means we can also drop Python 2.6 support. This would be for the next release of localflavor (1.2). I'm curious to hear what people think about this.