### PR TITLE
Do not throw exception when greek tax number contains...

### DIFF
--- a/localflavor/gr/forms.py
+++ b/localflavor/gr/forms.py
@@ -54,6 +54,8 @@ class GRTaxNumberCodeField(Field):
         val = re.sub('[\-\s\(\)]', '', smart_text(value))
         if(len(val) < 9):
             raise ValidationError(self.error_messages['invalid'])
+        if not all(char.isdigit() for char in val):
+            raise ValidationError(self.error_messages['invalid'])
         if not self.allow_test_value and val == '000000000':
             raise ValidationError(self.error_messages['invalid'])
         digits = list(map(int, val))

--- a/tests/test_gr.py
+++ b/tests/test_gr.py
@@ -25,6 +25,7 @@ class GRLocalFlavorTests(SimpleTestCase):
             '123 32 12 3213': error,
             '32 123 5345': error,
             '0': error,
+            'abc': error,
             '00000': error,
             '000000000': error,
             '1111111': error,
@@ -33,6 +34,7 @@ class GRLocalFlavorTests(SimpleTestCase):
             '999999999': error,
             '123123123': error,
             '321000123': error,
+            'd21000123': error,
         }
         self.assertFieldOutput(GRTaxNumberCodeField, valid, invalid)
 
@@ -52,6 +54,7 @@ class GRLocalFlavorTests(SimpleTestCase):
             '124567': error,
             '1345': error,
             '134115': error,
+            'b231a': error,
         }
         self.assertFieldOutput(GRPostalCodeField, valid, invalid)
 
@@ -67,6 +70,7 @@ class GRLocalFlavorTests(SimpleTestCase):
             '124567': error,
             '21092929211': error,
             '661232123': error,
+            '694555555a': error,
 
         }
         self.assertFieldOutput(GRPhoneNumberField, valid, invalid)


### PR DESCRIPTION
non-digits but instead show error message. Also, add test for that
bug and add tests for phone number and zip code (no fixes needed
for these).