### PR TITLE
Added CNPJ and CPF validation formats

### DIFF
--- a/tests/test_br.py
+++ b/tests/test_br.py
@@ -25,23 +25,22 @@ class BRLocalFlavorTests(SimpleTestCase):
 
     def test_BRCNPJField(self):
         error_format = ['Invalid CNPJ number.']
-        error_numbersonly = ['This field requires only numbers.']
         valid = {
             '64.132.916/0001-88': '64.132.916/0001-88',
             '64-132-916/0001-88': '64-132-916/0001-88',
             '64132916/0001-88': '64132916/0001-88',
         }
         invalid = {
+            '../-12345678901210': error_format,
             '12-345-678/9012-10': error_format,
             '12.345.678/9012-10': error_format,
             '12345678/9012-10': error_format,
-            '64.132.916/0001-XX': error_numbersonly,
+            '64.132.916/0001-XX': error_format,
         }
         self.assertFieldOutput(BRCNPJField, valid, invalid)
 
     def test_BRCPFField(self):
         error_format = ['Invalid CPF number.']
-        error_numbersonly = ['This field requires only numbers.']
         error_atmost_chars = ['Ensure this value has at most 14 characters (it has 15).']
         error_atleast_chars = ['Ensure this value has at least 11 characters (it has 10).']
         error_atmost = ['This field requires at most 11 digits or 14 characters.']
@@ -52,6 +51,7 @@ class BRLocalFlavorTests(SimpleTestCase):
             '84828509895': '84828509895',
         }
         invalid = {
+            '..-48929465454': error_format,
             '489.294.654-54': error_format,
             '295.669.575-98': error_format,
             '111.111.111-11': error_format,
@@ -59,7 +59,7 @@ class BRLocalFlavorTests(SimpleTestCase):
             '222.222.222-22': error_format,
             '22222222222': error_format,
             '539.315.127-22': error_format,
-            '375.788.573-XX': error_numbersonly,
+            '375.788.573-XX': error_format,
             '375.788.573-000': error_atmost_chars,
             '123.456.78': error_atleast_chars,
             '123456789555': error_atmost,


### PR DESCRIPTION
Changed the re.sub to avoid cleaning CNPJ and CPF numbers sent in the wrong format.

Removed errors_numbersonly since the regex will take care of validating and raising a ValidationError with the error_format message.

If the message of errors_numbersonly error must be kept, just let me know.