### PR TITLE
Fix FRNationalIdentificationNumber validation for Corsica department

### DIFF
--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -157,9 +157,19 @@ class FRNationalIdentificationNumber(CharField):
         person_unique_number = match.group('person_unique_number')
         control_key = int(match.group('control_key'))
 
-        # Department number 98 is for Monaco, 20 doesn't exist
-        if department_of_origin in ['98', '20']:
+        # Department number 98 is for Monaco
+        if department_of_origin == '98':
             raise ValidationError(self.error_messages['invalid'])
+
+        # Departments number 20, 2A and 2B represent Corsica
+        if department_of_origin in ['20', '2A', '2B']:
+            # For people born before 1976, Corsica number was 20
+            if int(year_of_birth) < 76 and department_of_origin != '20':
+                raise ValidationError(self.error_messages['invalid'])
+            # For people born from 1976, Corsica dep number is either 2A or 2B
+            if (int(year_of_birth) > 75 and
+                    department_of_origin not in ['2A', '2B']):
+                raise ValidationError(self.error_messages['invalid'])
 
         # Overseas department numbers starts with 97 and are 3 digits long
         if department_of_origin == '97':

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -208,19 +208,38 @@ class FRLocalFlavorTests(SimpleTestCase):
         error_format = ['Enter a valid French National Identification number.']
         valid = {
             '869067543002289': '869067543002289',
-            '869069713002256': '869069713002256',   # Good Overseas
+            # Good Overseas
+            '869069713002256': '869069713002256',
+            # Good, old Corsica department number (20) with birthdate < 1976
+            '870062009002285': '870062009002285',
+            # Good, new Corsica department number (2A) with birthdate >= 1976
+            '882062A09002279': '882062A09002279',
+            # Good, new Corsica department number (2B) with birthdate >= 1976
+            '882062B09002279': '882062B09002279',
         }
         invalid = {
-            '369067543002289': error_format,    # Gender mismatch
-            '869069873002289': error_format,    # Bad Department
-            '878062073002289': error_format,    # Bad Department with birthdate
-            '869062A73002289': error_format,    # Bad Department with birthdate
-            '869069773002289': error_format,    # Bad overseas Department
-            '869069710002256': error_format,    # Good overseas Bad Commune
-            '869067500002289': error_format,    # Bad Commune
-            '869067543000009': error_format,    # Bad "Person Unique Number"
-            '869067543002298': error_format,    # Bad Control key
-            '869067443002289': error_format,    # Fails validation
+            # Gender mismatch
+            '369067543002289': error_format,
+            # Bad Department
+            '869069873002289': error_format,
+            # Fails, old Corsica department number (20) with birthdate > 1976
+            '880062009002280': error_format,
+            # Fails, new Corsica department number (2A) with birthdate < 1976
+            '874062A09002213': error_format,
+            # Fails, new Corsica department number (2B) with birthdate < 1976
+            '874062B09002213': error_format,
+            # Bad overseas Department
+            '869069773002289': error_format,
+            # Good overseas Bad Commune
+            '869069710002256': error_format,
+            # Bad Commune
+            '869067500002289': error_format,
+            # Bad "Person Unique Number"
+            '869067543000009': error_format,
+            # Bad Control key
+            '869067543002298': error_format,
+            # Fails validation
+            '869067443002289': error_format,
         }
         self.assertFieldOutput(FRNationalIdentificationNumber, valid, invalid)
 

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -213,6 +213,8 @@ class FRLocalFlavorTests(SimpleTestCase):
         invalid = {
             '369067543002289': error_format,    # Gender mismatch
             '869069873002289': error_format,    # Bad Department
+            '878062073002289': error_format,    # Bad Department with birthdate
+            '869062A73002289': error_format,    # Bad Department with birthdate
             '869069773002289': error_format,    # Bad overseas Department
             '869069710002256': error_format,    # Good overseas Bad Commune
             '869067500002289': error_format,    # Bad Commune


### PR DESCRIPTION
An error was made on the `FRNationalIdentificationNumber ` validation, department **20** (for Corsica) can't be ignored if birthdate is older than **1976**.

Before January 1976, department number for Corsica was 20. From 1976, Corsica has been divided into two number : 2A and 2B, as said on the [French departments page of wikipedia](https://fr.wikipedia.org/wiki/Département_français) : 
> In 1976, Corsica (number 20) was divided between the Corse-du-Sud (2A) and Haute-Corse (2B). (...) Social security numbers composition has changed for people born after 1 January 1976, the "20" has been replaced by "2A" or "2B".

Therefore we can't consider a French national identification number invalid if department number is **20** and birthdate **< 1976**.

For the record, this is not specified on the English version of the [French departments page of wikipedia](https://en.wikipedia.org/wiki/Departments_of_France).
 