### PR TITLE
Replaced smart_text by force_text

### DIFF
--- a/localflavor/au/forms.py
+++ b/localflavor/au/forms.py
@@ -9,7 +9,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .au_states import STATE_CHOICES
@@ -49,7 +49,7 @@ class AUPhoneNumberField(CharField):
         super(AUPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\(|\)|\s+|-)', '', smart_text(value))
+        value = re.sub('(\(|\)|\s+|-)', '', force_text(value))
         phone_match = PHONE_DIGITS_RE.search(value)
         if phone_match:
             return '%s' % phone_match.group(1)

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -10,12 +10,8 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, CharField, Select
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_unicode as smart_text
 
 from .br_states import STATE_CHOICES
 
@@ -57,7 +53,7 @@ class BRPhoneNumberField(Field):
         super(BRPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\(|\)|\s+)', '', smart_text(value))
+        value = re.sub('(\(|\)|\s+)', '', force_text(value))
         m = phone_digits_re.search(value)
         if m:
             return '%s-%s-%s' % (m.group(1), m.group(2), m.group(3))
@@ -93,10 +89,10 @@ class BRStateChoiceField(Field):
         value = super(BRStateChoiceField, self).clean(value)
         if value in EMPTY_VALUES:
             value = ''
-        value = smart_text(value)
+        value = force_text(value)
         if value == '':
             return value
-        valid_values = set([smart_text(k) for k, v in self.widget.choices])
+        valid_values = set([force_text(k) for k, v in self.widget.choices])
         if value not in valid_values:
             raise ValidationError(self.error_messages['invalid'])
         return value

--- a/localflavor/ca/forms.py
+++ b/localflavor/ca/forms.py
@@ -9,7 +9,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, CharField, Select
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from localflavor.generic.checksums import luhn
 
@@ -55,7 +55,7 @@ class CAPhoneNumberField(Field):
         super(CAPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\(|\)|\s+)', '', smart_text(value))
+        value = re.sub('(\(|\)|\s+)', '', force_text(value))
         m = phone_digits_re.search(value)
         if m:
             return '%s-%s-%s' % (m.group(1), m.group(2), m.group(3))

--- a/localflavor/ch/forms.py
+++ b/localflavor/ch/forms.py
@@ -9,7 +9,7 @@ import re
 from django.core.validators import EMPTY_VALUES, RegexValidator
 from django.forms import ValidationError
 from django.forms.fields import CharField, Field, RegexField, Select
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .ch_states import STATE_CHOICES
@@ -54,7 +54,7 @@ class CHPhoneNumberField(Field):
         super(CHPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\.|\s|/|-)', '', smart_text(value))
+        value = re.sub('(\.|\s|/|-)', '', force_text(value))
         m = phone_digits_re.search(value)
         if m:
             return '%s %s %s %s' % (value[0:3], value[3:6], value[6:8], value[8:10])

--- a/localflavor/cl/forms.py
+++ b/localflavor/cl/forms.py
@@ -8,7 +8,7 @@ from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 
 from .cl_regions import REGION_CHOICES
 
@@ -78,7 +78,7 @@ class CLRutField(RegexField):
         Turns the RUT into one normalized format. Returns a (rut, verifier)
         tuple.
         """
-        rut = smart_text(rut).replace(' ', '').replace('.', '').replace('-', '')
+        rut = force_text(rut).replace(' ', '').replace('.', '').replace('-', '')
         return rut[:-1], rut[-1].upper()
 
     def _format(self, code, verifier=None):

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -9,7 +9,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from localflavor.generic.checksums import luhn
 
@@ -61,7 +61,7 @@ class FRPhoneNumberField(CharField):
         value = super(FRPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\.|\s)', '', smart_text(value))
+        value = re.sub('(\.|\s)', '', force_text(value))
         m = self.phone_digits_re.search(value)
         if m:
             return '%s %s %s %s %s' % (

--- a/localflavor/gr/forms.py
+++ b/localflavor/gr/forms.py
@@ -3,16 +3,10 @@ Greek-specific forms helpers
 """
 import re
 
-from django.forms.fields import RegexField, Field
-from django.utils.translation import ugettext_lazy as _
-
 from django.core.validators import EMPTY_VALUES
-from django.forms import ValidationError
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_unicode as smart_text
+from django.forms import RegexField, Field, ValidationError
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy as _
 
 
 NUMERIC_RE = re.compile('^\d+$')
@@ -51,7 +45,7 @@ class GRTaxNumberCodeField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        val = re.sub('[\-\s\(\)]', '', smart_text(value))
+        val = re.sub('[\-\s\(\)]', '', force_text(value))
         if(len(val) < 9):
             raise ValidationError(self.error_messages['invalid'])
         if not all(char.isdigit() for char in val):
@@ -84,7 +78,7 @@ class GRPhoneNumberField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        phone_nr = re.sub('[\-\s\(\)]', '', smart_text(value))
+        phone_nr = re.sub('[\-\s\(\)]', '', force_text(value))
 
         if len(phone_nr) == 10 and NUMERIC_RE.search(phone_nr):
             return value
@@ -109,7 +103,7 @@ class GRMobilePhoneNumberField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        phone_nr = re.sub('[\-\s\(\)]', '', smart_text(value))
+        phone_nr = re.sub('[\-\s\(\)]', '', force_text(value))
 
         if len(phone_nr) == 10 and NUMERIC_RE.search(phone_nr) and phone_nr.startswith('69'):
             return value

--- a/localflavor/hk/forms.py
+++ b/localflavor/hk/forms.py
@@ -8,7 +8,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import CharField
 from django.forms import ValidationError
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -53,7 +53,7 @@ class HKPhoneNumberField(CharField):
         if value in EMPTY_VALUES:
             return ''
 
-        value = re.sub('(\(|\)|\s+|\+)', '', smart_text(value))
+        value = re.sub('(\(|\)|\s+|\+)', '', force_text(value))
         m = hk_phone_digits_re.search(value)
         if not m:
             raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/hr/forms.py
+++ b/localflavor/hr/forms.py
@@ -10,7 +10,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, Select, RegexField
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .hr_choices import (HR_LICENSE_PLATE_PREFIX_CHOICES, HR_COUNTY_CHOICES,
@@ -158,7 +158,7 @@ class HRLicensePlateField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        value = re.sub(r'[\s\-]+', '', smart_text(value.strip())).upper()
+        value = re.sub(r'[\s\-]+', '', force_text(value.strip())).upper()
 
         matches = plate_re.search(value)
         if matches is None:
@@ -224,7 +224,7 @@ class HRPhoneNumberField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        value = re.sub(r'[\-\s\(\)]', '', smart_text(value))
+        value = re.sub(r'[\-\s\(\)]', '', force_text(value))
 
         matches = phone_re.search(value)
         if matches is None:

--- a/localflavor/id_/forms.py
+++ b/localflavor/id_/forms.py
@@ -11,7 +11,7 @@ from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, Select
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 
 
 postcode_re = re.compile(r'^[1-9]\d{4}$')
@@ -77,10 +77,10 @@ class IDPhoneNumberField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        phone_number = re.sub(r'[\-\s\(\)]', '', smart_text(value))
+        phone_number = re.sub(r'[\-\s\(\)]', '', force_text(value))
 
         if phone_re.search(phone_number):
-            return smart_text(value)
+            return force_text(value)
 
         raise ValidationError(self.error_messages['invalid'])
 
@@ -120,7 +120,7 @@ class IDLicensePlateField(Field):
             return ''
 
         plate_number = re.sub(r'\s+', ' ',
-                              smart_text(value.strip())).upper()
+                              force_text(value.strip())).upper()
 
         matches = plate_re.search(plate_number)
         if matches is None:
@@ -181,7 +181,7 @@ class IDNationalIdentityNumberField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        value = re.sub(r'[\s.]', '', smart_text(value))
+        value = re.sub(r'[\s.]', '', force_text(value))
 
         if not nik_re.search(value):
             raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/in_/forms.py
+++ b/localflavor/in_/forms.py
@@ -9,7 +9,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, CharField, Select
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .in_states import STATES_NORMALIZED, STATE_CHOICES
@@ -87,7 +87,7 @@ class INStateField(Field):
             pass
         else:
             try:
-                return smart_text(STATES_NORMALIZED[value.strip().lower()])
+                return force_text(STATES_NORMALIZED[value.strip().lower()])
             except KeyError:
                 pass
         raise ValidationError(self.error_messages['invalid'])
@@ -168,7 +168,7 @@ class INPhoneNumberField(CharField):
         value = super(INPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = smart_text(value)
+        value = force_text(value)
         m = phone_digits_re.match(value)
         if m:
             return '%s' % (value)

--- a/localflavor/is_/forms.py
+++ b/localflavor/is_/forms.py
@@ -8,13 +8,7 @@ from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField
 from django.forms.widgets import Select
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    # Attempt to import from a lesser version
-    from django.utils.encoding import smart_unicode as smart_text
-
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .is_postalcodes import IS_POSTALCODES
@@ -65,7 +59,7 @@ class ISIdNumberField(RegexField):
         Takes in the value in canonical form and returns it in the common
         display format.
         """
-        return smart_text(value[:6] + '-' + value[6:])
+        return force_text(value[:6] + '-' + value[6:])
 
 
 class ISPhoneNumberField(RegexField):

--- a/localflavor/it/forms.py
+++ b/localflavor/it/forms.py
@@ -9,7 +9,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, Select, CharField
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .it_province import PROVINCE_CHOICES
@@ -133,7 +133,7 @@ class ITPhoneNumberField(CharField):
         super(ITPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub(r'[^\+\d]', '', smart_text(value))
+        value = re.sub(r'[^\+\d]', '', force_text(value))
         m = phone_digits_re.match(value)
         if m:
             return '%s %s' % tuple(group for group in m.groups()[1:] if group)

--- a/localflavor/it/util.py
+++ b/localflavor/it/util.py
@@ -1,4 +1,4 @@
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -57,16 +57,16 @@ def vat_number_validation(vat_number):
     check_digit = vat_number_check_digit(vat_number[0:10])
     if vat_number[10] != check_digit:
         raise ValueError(_('Check digit does not match.'))
-    return smart_text(vat_number)
+    return force_text(vat_number)
 
 
 def vat_number_check_digit(vat_number):
     "Calculate Italian VAT number check digit."
-    normalized_vat_number = smart_text(vat_number).zfill(10)
+    normalized_vat_number = force_text(vat_number).zfill(10)
     total = 0
     for i in range(0, 10, 2):
         total += int(normalized_vat_number[i])
     for i in range(1, 11, 2):
         quotient, remainder = divmod(int(normalized_vat_number[i]) * 2, 10)
         total += quotient + remainder
-    return smart_text((10 - total % 10) % 10)
+    return force_text((10 - total % 10) % 10)

--- a/localflavor/nl/validators.py
+++ b/localflavor/nl/validators.py
@@ -5,7 +5,7 @@ import re
 
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -66,7 +66,7 @@ class NLPhoneNumberFieldValidator(object):
     """
 
     def __call__(self, value):
-        phone_nr = re.sub('[\-\s\(\)]', '', smart_text(value))
+        phone_nr = re.sub('[\-\s\(\)]', '', force_text(value))
         numeric_re = re.compile('^\d+$')
 
         if len(phone_nr) == 10 and numeric_re.search(phone_nr):

--- a/localflavor/pk/forms.py
+++ b/localflavor/pk/forms.py
@@ -8,7 +8,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .pk_states import STATE_CHOICES
@@ -47,7 +47,7 @@ class PKPhoneNumberField(CharField):
         super(PKPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\(|\)|\s+|-)', '', smart_text(value))
+        value = re.sub('(\(|\)|\s+|-)', '', force_text(value))
         phone_match = PHONE_DIGITS_RE.search(value)
         if phone_match:
             return '%s' % phone_match.group(1)

--- a/localflavor/pt/forms.py
+++ b/localflavor/pt/forms.py
@@ -13,7 +13,7 @@ from .pt_regions import REGION_CHOICES
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, Select
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from re import compile as regex_compile, sub as regex_replace
 
@@ -89,7 +89,7 @@ class PTPhoneNumberField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        value = regex_replace('(\.|\s)', '', smart_text(value))
+        value = regex_replace('(\.|\s)', '', force_text(value))
         match = PHONE_NUMBER_REGEX.search(value)
 
         if not match:

--- a/localflavor/sg/forms.py
+++ b/localflavor/sg/forms.py
@@ -9,7 +9,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -54,7 +54,7 @@ class SGPhoneNumberField(CharField):
         super(SGPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\(|\)|\s+|-)', '', smart_text(value))
+        value = re.sub('(\(|\)|\s+|-)', '', force_text(value))
         phone_match = PHONE_DIGITS_RE.search(value)
         if phone_match:
             return '%s' % phone_match.group()
@@ -89,7 +89,7 @@ class SGNRIC_FINField(CharField):
         super(SGNRIC_FINField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\s+)', '', smart_text(value.upper()))
+        value = re.sub('(\s+)', '', force_text(value.upper()))
         match = NRIC_FIN_RE.search(value)
         if not match:
             raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/tr/forms.py
+++ b/localflavor/tr/forms.py
@@ -5,7 +5,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, Select, CharField
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .tr_provinces import PROVINCE_CHOICES
@@ -53,7 +53,7 @@ class TRPhoneNumberField(CharField):
         super(TRPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\(|\)|\s+)', '', smart_text(value))
+        value = re.sub('(\(|\)|\s+)', '', force_text(value))
         m = phone_digits_re.search(value)
         if m:
             return '%s%s' % (m.group(2), m.group(4))

--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -9,7 +9,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, Select, CharField
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -56,7 +56,7 @@ class USPhoneNumberField(CharField):
         super(USPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
-        value = re.sub('(\(|\)|\s+)', '', smart_text(value))
+        value = re.sub('(\(|\)|\s+)', '', force_text(value))
         m = phone_digits_re.search(value)
         if m:
             return '%s-%s-%s' % (m.group(1), m.group(2), m.group(3))


### PR DESCRIPTION
smart_text is only useful when handling strings which shouldn't be
forced to unicode when lazy, which isn't the case here.