### PR TITLE
Fixed PERUCField using RegexField instead of CharField

### DIFF
--- a/localflavor/pe/forms.py
+++ b/localflavor/pe/forms.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
-from django.forms.fields import RegexField, CharField, Select
+from django.forms.fields import CharField, Select
 from django.utils.translation import ugettext_lazy as _
 
 from .pe_region import REGION_CHOICES
@@ -49,7 +49,7 @@ class PEDNIField(CharField):
         return value
 
 
-class PERUCField(RegexField):
+class PERUCField(CharField):
     """
     This field validates a RUC (Registro Unico de Contribuyentes). A RUC is of
     the form XXXXXXXXXXX.


### PR DESCRIPTION
In `localflavor.pe.forms.PERUCField` the `__init__` call had the wrong arguments. The first is a regular expression as in the other forms and the django API.

Using this form as it is raises an `AttributeError`: 

``` traceback
  File "/home/vagrant/.Envs/a/lib/python2.7/site-packages/localflavor/pe/forms.py", line 70, in clean
    value = super(PERUCField, self).clean(value)
  File "/home/vagrant/.Envs/a/lib/python2.7/site-packages/django/forms/fields.py", line 152, in clean
    self.run_validators(value)
  File "/home/vagrant/.Envs/a/lib/python2.7/site-packages/django/forms/fields.py", line 135, in run_validators
    v(value)
  File "/home/vagrant/.Envs/a/lib/python2.7/site-packages/django/core/validators.py", line 49, in __call__
    if not (self.inverse_match is not bool(self.regex.search(
AttributeError: 'int' object has no attribute 'search'
```