### PR TITLE
Added a formal deprecation policy to the project

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -57,6 +57,7 @@ Authors
 * Stefan Kjartansson
 * Thiago Avelino
 * Tino de Bruijn
+* Tom Forbes
 * Trey Hunner
 * Tyler Ball
 * Venelin Stoykov

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,23 @@ Changelog
 1.3   (unreleased)
 ------------------
 
+
+Deprecation Policy:
+
+- A formal deprecation policy has been introduced to make it easier for you to update to the latest version of
+  `django-localflavor`, and allows us to safely remove outdated functionality in a timely manner.
+
+  Features in localflavour that are deprecated raise a DeprecationWarning for two subsequent releases before being
+  removed. For example:
+
+    * Version 1.3 introduces some API changes that are detailed in the release notes. All changes will remain fully
+      compatible for *two* releases in the 6 month cycle, totalling one year. Usages of the deprecated APIs/modules
+      will throw a `DeprecationWarning` during this time, the message of which will explain what version the functionality
+      is being removed in.
+
+    * Version 1.5 will remove the deprecated portions of the API.
+
+
 New flavors:
 
 - Added local flavor for Bulgaria

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -236,8 +236,8 @@ if a government body makes a change to add, alter, or remove a province
 (or state, or county), that change will be reflected in localflavor in the
 next release.
 
-When a backwards-incompatible change is made (for example, the removal
-or renaming of a province) the localflavor in question will raise a
+When a backwards-incompatible change is made to a specific locale (for example,
+the removal or renaming of a province) the localflavor in question will raise a
 warning when that localflavor is imported. This provides a run-time
 indication that something may require attention.
 
@@ -252,6 +252,14 @@ localflavor you would use the following code::
                             category=RuntimeWarning,
                             module='localflavor.id')
     from localflavor.id import forms as id_forms
+
+Deprecation Policy
+------------------
+
+When non-internal parts of the project are deprecated a `DeprecationWarning` will be thrown upon use for
+the next two subsequent releases, after which they will be removed. The warning will explain how to safely update your
+code, and which version the functionality will be removed in.
+
 
 Indices and tables
 ==================


### PR DESCRIPTION
A formal deprecation policy is a good thing to add to this project. Features such as the phone number validation are much better served by dedicated packages like `django-phonenumber-field` (and `libphonenumber` underneath), and this is the first step towards that.

My RST skills are not top-notch, so I expect there are some formatting issues that need to be addressed before this can be merged, but the most important discussion is the policy itself. Word on the street is localflavor is moving to a 6 month release cycle, so I propose that we have a 2 release deprecation period before removing features which gives a year for people to discontinue use of deprecated features before their code explodes.

Thoughts?
