### PR TITLE
Add configuration and TravisCI integration for prospector for style checking.

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,19 @@
+strictness: veryhigh
+doc-warnings: yes
+test-warnings: yes
+max-line-length: 120
+uses:
+  - django
+pylint:
+  disable:
+    - missing-docstring
+    - no-self-use
+pep257:
+  disable:
+    - D100
+    - D101
+    - D102
+    - D103
+    - D104
+    - D105
+    - D203

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
 matrix:
   include:
     - env: TOXENV=docs
+    - env: TOXENV=prospector
     - python: 2.7
       env: TOXENV=py27-1.7
     - python: 2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 args_are_paths = false
 envlist =
-    docs,
+    docs,prospector,
     {py27,py32,py33,py34}-{1.7,1.8},
     {py27,py34,py35}-{1.9,master}
 
@@ -30,3 +30,8 @@ deps =
 basepython = python2.7
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
+
+[testenv:prospector]
+deps = prospector
+basepython = python2.7
+commands = prospector --zero-exit {toxinidir}


### PR DESCRIPTION
This commit adds prospector configuration and TravisCI integration for style
checking.
Warnings for missing docstrings are disabled and line length is set to 120
characters.

The TravisCI job is currently configured to run like the `docs` job in addition to the tests of the code itself. It's configured to not fail the build if style violations are found. Enabling builds failing for style violations is as easy as removing the `--zero-exit` from the `tox.ini`.