### PR TITLE
Better ZIP code validation for German ZIP codes.

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -18,6 +18,7 @@ Authors
 * Bruno M. Custódio
 * Claude Paroz
 * Daniel Roschka
+* Daniela Ponader
 * Douglas Miranda
 * Erik Romijn
 * Flavio Curella

--- a/localflavor/de/forms.py
+++ b/localflavor/de/forms.py
@@ -28,11 +28,8 @@ class DEZipCodeField(RegexField):
     }
 
     def __init__(self, max_length=None, min_length=None, *args, **kwargs):
-        super(DEZipCodeField, self).__init__(r'^\d{5}$',
-                                             max_length,
-                                             min_length,
-                                             *args,
-                                             **kwargs)
+        super(DEZipCodeField, self).__init__(r'^([0]{1}[1-9]{1}|[1-9]{1}[0-9]{1})[0-9]{3}$',
+                                             max_length, min_length, *args, **kwargs)
 
 
 class DEStateSelect(Select):

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -35,6 +35,7 @@ class DELocalFlavorTests(SimpleTestCase):
             '99423': '99423',
         }
         invalid = {
+            '00000': error_format,
             ' 99423': error_format,
         }
         self.assertFieldOutput(DEZipCodeField, valid, invalid)


### PR DESCRIPTION
Regex expression taken from:
http://www.fadoe.de/blog/archives/262-Regulaerer-Ausdruck-fuer-Deutsche-Postleitzahlen.html