### PR TITLE
Drop support for django 1.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     - python: 3.5
       env: TOXENV=isort
     - python: 2.7
-      env: TOXENV=py27-1.7
-    - python: 2.7
       env: TOXENV=py27-1.8
     - python: 2.7
       env: TOXENV=py27-1.9
@@ -21,15 +19,9 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-master
     - python: 3.2
-      env: TOXENV=py32-1.7
-    - python: 3.2
       env: TOXENV=py32-1.8
     - python: 3.3
-      env: TOXENV=py33-1.7
-    - python: 3.3
       env: TOXENV=py33-1.8
-    - python: 3.4
-      env: TOXENV=py34-1.7
     - python: 3.4
       env: TOXENV=py34-1.8
     - python: 3.4

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,20 +36,20 @@ the ``-l`` option::
 
     $ tox -l
     docs
-    py27-1.7
     py27-1.8
-    py32-1.7
     py32-1.8
-    py33-1.7
     py33-1.8
-    py34-1.7
     py34-1.8
+    py27-1.9
     py27-master
+    py34-1.9
     py34-master
+    py35-1.9
+    py35-master
 
 You can run each environment with the ``-e`` option::
 
-    $ tox -e py27-1.7  # runs the tests only on Pyton 2.7 and Django 1.7.x
+    $ tox -e py27-1.8  # runs the tests only on Pyton 2.7 and Django 1.8.x
 
 Optionally you can also specify a country whose tests you want to run::
 
@@ -57,7 +57,7 @@ Optionally you can also specify a country whose tests you want to run::
 
 And combine both options::
 
-    $ COUNTRY=us tox -e py27-1.7
+    $ COUNTRY=us tox -e py27-1.8
 
 __ https://github.com/django/django-localflavor/issues
 __ https://tox.readthedocs.io/en/latest/install.html

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Modifications to existing flavors:
 
 Other changes:
 
+- Drop support for Django 1.7
+  (`gh-218 <https://github.com/django/django-localflavor/pull/218>`_).
 - Ensure the migration framework generates schema migrations for model fields that change the max_length
   (`gh-257 <https://github.com/django/django-localflavor/pull/257>`_). Users will need to generate migrations for any
   model fields they use with 'makemigrations'.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 args_are_paths = false
 envlist =
     docs,prospector,isort
-    {py27,py32,py33,py34}-{1.7,1.8},
+    {py27,py32,py33,py34}-1.8,
     {py27,py34,py35}-{1.9,1.10,master}
 
 [testenv]
@@ -17,7 +17,6 @@ pip_pre = true
 commands =
     invoke test {posargs}
 deps =
-    1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11


### PR DESCRIPTION
Django 1.7 isn't supported anymore so I don't think that we should continue to test against it. Thoughts / comments are welcome.
