### PR TITLE
161 add deconstruct to vaidators

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -29,6 +29,7 @@ Authors
 * Grzes Furga
 * Honza Král
 * Horst Gutmann
+* Ivan Fisun
 * Jaap Roes
 * Jacob Kaplan-Moss
 * Jan Pieter Waagmeester

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,8 @@ Modifications to existing flavors:
   (`gh-215 <https://github.com/django/django-localflavor/pull/215>`_).
 - Update regex in DEZipCodeField to prohibit invalid postal codes.
   (`gh-216 <https://github.com/django/django-localflavor/pull/216>`_).
+- Added deconstructor methods to validators.
+  (`gh-220 <https://github.com/django/django-localflavor/pull/220>`_).
 
 Other changes:
 

--- a/localflavor/nl/validators.py
+++ b/localflavor/nl/validators.py
@@ -5,6 +5,7 @@ import re
 
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
+from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
@@ -58,12 +59,17 @@ class NLSoFiNumberFieldValidator(RegexValidator):
             raise ValidationError(self.error_message)
 
 
+@deconstructible
 class NLPhoneNumberFieldValidator(object):
     """
     Validation for Dutch phone numbers.
 
     .. versionadded:: 1.3
     """
+
+    def __eq__(self, other):
+        # The is no outside modification of properties so this should always be true by default.
+        return True
 
     def __call__(self, value):
         phone_nr = re.sub('[\-\s\(\)]', '', force_text(value))

--- a/tests/test_generic/tests.py
+++ b/tests/test_generic/tests.py
@@ -132,6 +132,23 @@ class IBANTests(TestCase):
         for iban in invalid:
             self.assertRaisesMessage(ValidationError, invalid[iban], IBANValidator(), iban)
 
+    def test_iban_validator_deconstruct(self):
+        # Deconstruct method is required for django 1.7+ compatibility.
+        # Call to the deconstruct method to see if it exists and it doesn't throw an error.
+        IBANValidator().deconstruct()
+
+        test_cases = [
+            {'use_nordea_extensions': True, 'include_countries': ['IS', 'IT']},
+            {'use_nordea_extensions': True},
+            {'include_countries': ['IS', 'IT']},
+            {},
+        ]
+
+        for test_case in test_cases:
+            iban1 = IBANValidator(**test_case)
+            iban2 = IBANValidator(**test_case)
+            self.assertEqual(iban1, iban2, msg="IBAN validators with equal parameters are not equal.")
+
     def test_iban_fields(self):
         """ Test the IBAN model and form field. """
         valid = {
@@ -307,6 +324,15 @@ class BICTests(TestCase):
         for bic in invalid:
             self.assertRaisesMessage(ValidationError,  invalid[bic], BICValidator(), bic)
 
+    def test_bic_validator_deconstruct(self):
+        # Deconstruct method is required for django 1.7+ compatibility.
+        bic1 = BICValidator()
+        bic2 = BICValidator()
+        self.assertEqual(bic1, bic2, msg="BIC validators are not equal.")
+
+        # Call to the deconstruct method to see if it exists.
+        bic1.deconstruct()
+
     def test_form_field_formatting(self):
         bic_form_field = BICFormField()
         self.assertEqual(bic_form_field.prepare_value('deutdeff'), 'DEUTDEFF')
@@ -376,6 +402,23 @@ class EANTests(TestCase):
 
         for value in invalid:
             self.assertRaisesMessage(ValidationError,  error_message, validator, value)
+
+    def test_ean_validator_deconstruct(self):
+        # Deconstruct method is required for django 1.7+ compatibility.
+        # Call to the deconstruct method to see if it exists and it doesn't throw an error.
+        EANValidator().deconstruct()
+
+        test_cases = [
+            {'strip_nondigits': True, 'message': 'test'},
+            {'message': 'test'},
+            {'strip_nondigits': True},
+            {},
+        ]
+
+        for test_case in test_cases:
+            ean1 = EANValidator(**test_case)
+            ean2 = EANValidator(**test_case)
+            self.assertEqual(ean1, ean2, msg="EAN validators with equal parameters are not equal.")
 
     def test_ean_validator_strip_nondigits(self):
         valid = [

--- a/tests/test_nl/tests.py
+++ b/tests/test_nl/tests.py
@@ -62,6 +62,15 @@ class NLLocalFlavorValidatorTests(SimpleTestCase):
         ]
         self.assert_validator(validators.NLPhoneNumberFieldValidator(), valid, invalid)
 
+    def test_NLPhoneNumberValidator_deconstruct(self):
+        # Deconstruct method is required for django 1.7+ compatibility.
+        nlphone1 = validators.NLPhoneNumberFieldValidator()
+        nlphone2 = validators.NLPhoneNumberFieldValidator()
+        self.assertEqual(nlphone1, nlphone2, msg="NLPhoneNumberFieldValidator are not equal.")
+
+        # Call to the deconstruct method to see if it exists.
+        nlphone1.deconstruct()
+
     def test_NLBankAccountNumberFieldValidator(self):
         valid = [
             '0417164300',


### PR DESCRIPTION
I didn't add any tests for the Validators that inherit RegexValidator  because this functionality is already there, and these validators don't have to be modified explicitly. I did test one of them localy, just in case to be sure.
fixes #161