### PR TITLE
WIP: Deprecate all phonenumber validators and model fields.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 1.3   (unreleased)
 ------------------
 
+Deprecations:
+
+- Deprecated all phone number model and form fields in favor of the much more extensive
+  (django-phonenumber-field `https://github.com/stefanfoulis/django-phonenumber-field/`). Support for these classes
+  will be dropped in localflavor 1.5.
+
 New flavors:
 
 - Added local flavor for Bulgaria

--- a/localflavor/__init__.py
+++ b/localflavor/__init__.py
@@ -1,1 +1,13 @@
 __version__ = '1.2'
+
+
+class DeprecatedPhoneNumber(object):
+    def __init__(self, *args, **kwargs):
+        import warnings
+        warnings.warn(
+            "%s is deprecated and will be removed in version 1.5."
+            " Please migrate to django-phonenumber-field" % self.__class__.__name__,
+            DeprecationWarning
+        )
+
+        super(self.__class__, self).__init__(*args, **kwargs)

--- a/localflavor/au/forms.py
+++ b/localflavor/au/forms.py
@@ -12,6 +12,7 @@ from django.forms.fields import CharField, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .au_states import STATE_CHOICES
 
 PHONE_DIGITS_RE = re.compile(r'^(\d{10})$')
@@ -32,7 +33,7 @@ class AUPostCodeField(RegexField):
                                               max_length, min_length, *args, **kwargs)
 
 
-class AUPhoneNumberField(CharField):
+class AUPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A form field that validates input as an Australian phone number.
 

--- a/localflavor/au/models.py
+++ b/localflavor/au/models.py
@@ -1,6 +1,7 @@
 from django.db.models.fields import CharField
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from . import forms
 from .au_states import STATE_CHOICES
 
@@ -37,7 +38,7 @@ class AUPostCodeField(CharField):
         return super(AUPostCodeField, self).formfield(**defaults)
 
 
-class AUPhoneNumberField(CharField):
+class AUPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A model field that checks that the value is a valid Australian phone
     number (ten digits).

--- a/localflavor/be/forms.py
+++ b/localflavor/be/forms.py
@@ -5,6 +5,7 @@ Belgium-specific Form helpers
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .be_provinces import PROVINCE_CHOICES
 from .be_regions import REGION_CHOICES
 
@@ -29,7 +30,7 @@ class BEPostalCodeField(RegexField):
                                                 max_length, min_length, *args, **kwargs)
 
 
-class BEPhoneNumberField(RegexField):
+class BEPhoneNumberField(DeprecatedPhoneNumber, RegexField):
     """
     A form field that validates its input as a belgium phone number.
 

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -13,6 +13,7 @@ from django.forms.fields import Field, RegexField, CharField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .br_states import STATE_CHOICES
 
 phone_digits_re = re.compile(r'^(\d{2})[-\.]?(\d{4,5})[-\.]?(\d{4})$')
@@ -39,7 +40,7 @@ class BRZipCodeField(RegexField):
                                              max_length, min_length, *args, **kwargs)
 
 
-class BRPhoneNumberField(Field):
+class BRPhoneNumberField(DeprecatedPhoneNumber, Field):
     """
     A form field that validates input as a Brazilian phone number, that must
     be in either of the following formats: XX-XXXX-XXXX or XX-XXXXX-XXXX.

--- a/localflavor/ca/forms.py
+++ b/localflavor/ca/forms.py
@@ -11,6 +11,8 @@ from django.forms import ValidationError
 from django.forms.fields import Field, CharField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor import DeprecatedPhoneNumber
 from localflavor.generic.checksums import luhn
 
 
@@ -45,7 +47,7 @@ class CAPostalCodeField(CharField):
         return "%s %s" % (m.group(1), m.group(2))
 
 
-class CAPhoneNumberField(Field):
+class CAPhoneNumberField(DeprecatedPhoneNumber, Field):
     """Canadian phone number form field."""
     default_error_messages = {
         'invalid': _('Phone numbers must be in XXX-XXX-XXXX format.'),

--- a/localflavor/ch/forms.py
+++ b/localflavor/ch/forms.py
@@ -12,6 +12,7 @@ from django.forms.fields import CharField, Field, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .ch_states import STATE_CHOICES
 from ..generic import validators
 
@@ -39,7 +40,7 @@ class CHZipCodeField(RegexField):
         super(CHZipCodeField, self).__init__(zip_re, max_length, min_length, *args, **kwargs)
 
 
-class CHPhoneNumberField(Field):
+class CHPhoneNumberField(DeprecatedPhoneNumber, Field):
     """
     Validate local Swiss phone number (not international ones)
     The correct format is '0XX XXX XX XX'.

--- a/localflavor/cn/forms.py
+++ b/localflavor/cn/forms.py
@@ -10,6 +10,7 @@ from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .cn_provinces import CN_PROVINCE_CHOICES
 
 
@@ -180,7 +181,7 @@ class CNIDCardField(CharField):
         return '10X98765432'[checksum_index] == value[-1]
 
 
-class CNPhoneNumberField(RegexField):
+class CNPhoneNumberField(DeprecatedPhoneNumber, RegexField):
     """
     A form field that validates input as a telephone number in mainland China.
     A valid phone number could be like: 010-12345678.

--- a/localflavor/dk/forms.py
+++ b/localflavor/dk/forms.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from django.forms import widgets, fields
 
+from localflavor import DeprecatedPhoneNumber
 from .dk_postalcodes import DK_POSTALCODES
 from .dk_municipalities import DK_MUNICIPALITIES
 
@@ -38,7 +39,7 @@ class DKMunicipalitySelect(widgets.Select):
         )
 
 
-class DKPhoneNumberField(fields.RegexField):
+class DKPhoneNumberField(DeprecatedPhoneNumber, fields.RegexField):
     """
     Field with phone number validation. Requires a phone number with
     8 digits and optional country code

--- a/localflavor/es/forms.py
+++ b/localflavor/es/forms.py
@@ -12,6 +12,7 @@ from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .es_provinces import PROVINCE_CHOICES
 from .es_regions import REGION_CHOICES
 
@@ -33,7 +34,7 @@ class ESPostalCodeField(RegexField):
             max_length, min_length, *args, **kwargs)
 
 
-class ESPhoneNumberField(RegexField):
+class ESPhoneNumberField(DeprecatedPhoneNumber, RegexField):
     """
     A form field that validates its input as a Spanish phone number.
     Information numbers are ommited.

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -11,6 +11,8 @@ from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor import DeprecatedPhoneNumber
 from localflavor.generic.checksums import luhn
 
 from .fr_department import DEPARTMENT_CHOICES_PER_REGION
@@ -38,7 +40,7 @@ class FRZipCodeField(RegexField):
         super(FRZipCodeField, self).__init__(r'^\d{5}$', *args, **kwargs)
 
 
-class FRPhoneNumberField(CharField):
+class FRPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     Validate local French phone number (not international ones)
     The correct format is '0X XX XX XX XX'.

--- a/localflavor/gr/forms.py
+++ b/localflavor/gr/forms.py
@@ -8,6 +8,7 @@ from django.forms import RegexField, Field, ValidationError
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 
 NUMERIC_RE = re.compile('^\d+$')
 
@@ -64,7 +65,7 @@ class GRTaxNumberCodeField(Field):
         return val
 
 
-class GRPhoneNumberField(Field):
+class GRPhoneNumberField(DeprecatedPhoneNumber, Field):
     """
     Greek general phone field - 10 digits (can also start with +30
     which is the country-code foor greece)
@@ -89,7 +90,7 @@ class GRPhoneNumberField(Field):
         raise ValidationError(self.error_messages['invalid'])
 
 
-class GRMobilePhoneNumberField(Field):
+class GRMobilePhoneNumberField(DeprecatedPhoneNumber, Field):
     """
     Greek mobile phone field - 10 digits starting with 69
     (could also start with +30 which is the country-code foor greece)

--- a/localflavor/hk/forms.py
+++ b/localflavor/hk/forms.py
@@ -11,6 +11,7 @@ from django.forms import ValidationError
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 
 hk_phone_digits_re = re.compile(r'^(?:852-?)?(\d{4})[-\.]?(\d{4})$')
 hk_special_numbers = ('999', '992', '112')
@@ -19,7 +20,7 @@ hk_formats = ['XXXX-XXXX', '852-XXXX-XXXX', '(+852) XXXX-XXXX',
               'XXXX XXXX', 'XXXXXXXX']
 
 
-class HKPhoneNumberField(CharField):
+class HKPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A form field that validates Hong Kong phone numbers.
 

--- a/localflavor/hr/forms.py
+++ b/localflavor/hr/forms.py
@@ -13,6 +13,7 @@ from django.forms.fields import Field, Select, RegexField
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .hr_choices import (HR_LICENSE_PLATE_PREFIX_CHOICES, HR_COUNTY_CHOICES,
                          HR_PHONE_NUMBER_PREFIX_CHOICES)
 from localflavor.generic.checksums import luhn
@@ -205,7 +206,7 @@ class HRPostalCodeField(Field):
         return '%s' % value
 
 
-class HRPhoneNumberField(Field):
+class HRPhoneNumberField(DeprecatedPhoneNumber, Field):
     """
     Phone number of Croatia field.
     Format: Complete country code or leading zero, area code prefix, 6 or 7

--- a/localflavor/id_/forms.py
+++ b/localflavor/id_/forms.py
@@ -13,6 +13,7 @@ from django.forms.fields import Field, Select
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import force_text
 
+from localflavor import DeprecatedPhoneNumber
 
 postcode_re = re.compile(r'^[1-9]\d{4}$')
 phone_re = re.compile(r'^(\+62|0)[2-9]\d{7,10}$')
@@ -62,7 +63,7 @@ class IDProvinceSelect(Select):
         super(IDProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 
 
-class IDPhoneNumberField(Field):
+class IDPhoneNumberField(DeprecatedPhoneNumber, Field):
     """
     An Indonesian telephone number field.
 

--- a/localflavor/il/forms.py
+++ b/localflavor/il/forms.py
@@ -8,6 +8,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import EMPTY_VALUES
 from django.forms.fields import RegexField, Field
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor import DeprecatedPhoneNumber
 from localflavor.generic.checksums import luhn
 
 id_number_re = re.compile(r'^(?P<number>\d{1,8})-?(?P<check>\d)$')
@@ -69,7 +71,7 @@ class ILIDNumberField(Field):
         return value
 
 
-class ILMobilePhoneNumberField(RegexField):
+class ILMobilePhoneNumberField(DeprecatedPhoneNumber, RegexField):
     """
     A form field that validates its input as an Israeli Mobile phone number.
     """

--- a/localflavor/in_/forms.py
+++ b/localflavor/in_/forms.py
@@ -12,6 +12,7 @@ from django.forms.fields import Field, RegexField, CharField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .in_states import STATES_NORMALIZED, STATE_CHOICES
 
 
@@ -150,7 +151,7 @@ class INStateSelect(Select):
         super(INStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
 
-class INPhoneNumberField(CharField):
+class INPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     INPhoneNumberField validates that the data is a valid Indian phone number,
     including the STD code. It's normalised to 0XXX-XXXXXXX or 0XXX XXXXXXX

--- a/localflavor/is_/forms.py
+++ b/localflavor/is_/forms.py
@@ -11,6 +11,7 @@ from django.forms.widgets import Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .is_postalcodes import IS_POSTALCODES
 
 
@@ -62,7 +63,7 @@ class ISIdNumberField(RegexField):
         return force_text(value[:6] + '-' + value[6:])
 
 
-class ISPhoneNumberField(RegexField):
+class ISPhoneNumberField(DeprecatedPhoneNumber, RegexField):
     """
     Icelandic phone number. Seven digits with an optional hyphen or space after
     the first three digits.

--- a/localflavor/it/forms.py
+++ b/localflavor/it/forms.py
@@ -12,6 +12,7 @@ from django.forms.fields import Field, RegexField, Select, CharField
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .it_province import PROVINCE_CHOICES
 from .it_region import REGION_CHOICES, REGION_PROVINCE_CHOICES
 from .util import vat_number_validation, ssn_validation
@@ -118,7 +119,7 @@ class ITVatNumberField(Field):
             raise ValidationError(self.error_messages['invalid'])
 
 
-class ITPhoneNumberField(CharField):
+class ITPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A form field that validates input as an Italian phone number. Will strip
     any +39 country prefix from the number.

--- a/localflavor/nl/forms.py
+++ b/localflavor/nl/forms.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import six
 from django import forms
 
+from localflavor import DeprecatedPhoneNumber
 from .nl_provinces import PROVINCE_CHOICES
 from .validators import (NLPhoneNumberFieldValidator,
                          NLSoFiNumberFieldValidator, NLZipCodeFieldValidator)
@@ -38,7 +39,7 @@ class NLProvinceSelect(forms.Select):
         super(NLProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 
 
-class NLPhoneNumberField(forms.CharField):
+class NLPhoneNumberField(DeprecatedPhoneNumber, forms.CharField):
     """
     A Dutch telephone number field.
     """

--- a/localflavor/nl/models.py
+++ b/localflavor/nl/models.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from . import forms
 from .nl_provinces import PROVINCE_CHOICES
 from .validators import (NLBankAccountNumberFieldValidator,
@@ -78,7 +79,7 @@ class NLSoFiNumberField(models.CharField):
         return super(NLSoFiNumberField, self).formfield(**defaults)
 
 
-class NLPhoneNumberField(models.CharField):
+class NLPhoneNumberField(DeprecatedPhoneNumber, models.CharField):
     """
     Dutch phone number model field
 

--- a/localflavor/no/forms.py
+++ b/localflavor/no/forms.py
@@ -12,6 +12,7 @@ from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .no_municipalities import MUNICIPALITY_CHOICES
 
 
@@ -93,7 +94,7 @@ class NOSocialSecurityNumber(Field):
         return value
 
 
-class NOPhoneNumberField(RegexField):
+class NOPhoneNumberField(DeprecatedPhoneNumber, RegexField):
     """
     Field with phonenumber validation. Requires a phone number with
     8 digits and optional country code

--- a/localflavor/nz/forms.py
+++ b/localflavor/nz/forms.py
@@ -15,6 +15,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from django.forms.fields import (Field, Select, RegexField)
 
+from localflavor import DeprecatedPhoneNumber
 from .nz_councils import NORTH_ISLAND_COUNCIL_CHOICES
 from .nz_councils import SOUTH_ISLAND_COUNCIL_CHOICES
 from .nz_regions import REGION_CHOICES
@@ -78,7 +79,7 @@ class NZPostCodeField(RegexField):
             *args, **kwargs)
 
 
-class NZPhoneNumberField(Field):
+class NZPhoneNumberField(DeprecatedPhoneNumber, Field):
     """
     A form field that validates its input as New Zealand phone number.
 

--- a/localflavor/pk/forms.py
+++ b/localflavor/pk/forms.py
@@ -11,6 +11,7 @@ from django.forms.fields import CharField, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .pk_states import STATE_CHOICES
 
 POSTCODE_DIGITS_RE = re.compile(r'^(\d{5})$')
@@ -30,7 +31,7 @@ class PKPostCodeField(RegexField):
         super(PKPostCodeField, self).__init__(POSTCODE_DIGITS_RE, *args, **kwargs)
 
 
-class PKPhoneNumberField(CharField):
+class PKPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A form field that validates input as an Pakistani phone number.
 

--- a/localflavor/pk/models.py
+++ b/localflavor/pk/models.py
@@ -1,6 +1,7 @@
 from django.db.models.fields import CharField
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from . import forms
 from .pk_states import STATE_CHOICES
 
@@ -37,7 +38,7 @@ class PKPostCodeField(CharField):
         return super(PKPostCodeField, self).formfield(**defaults)
 
 
-class PKPhoneNumberField(CharField):
+class PKPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A model field that checks that the value is a valid Pakistani phone
     number (nine to eleven digits).

--- a/localflavor/pt/forms.py
+++ b/localflavor/pt/forms.py
@@ -9,6 +9,8 @@ Contains PT-specific Django form helpers.
 
 
 from __future__ import unicode_literals
+
+from localflavor import DeprecatedPhoneNumber
 from .pt_regions import REGION_CHOICES
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
@@ -72,7 +74,7 @@ class PTCitizenCardNumberField(Field):
             return value if value < 10 else value - 9
 
 
-class PTPhoneNumberField(Field):
+class PTPhoneNumberField(DeprecatedPhoneNumber, Field):
     """
     A field which validates Portuguese phone numbers.
 

--- a/localflavor/ro/forms.py
+++ b/localflavor/ro/forms.py
@@ -11,6 +11,7 @@ from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError, Field, RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from ..generic.forms import IBANFormField
 from .ro_counties import COUNTIES_CHOICES
 
@@ -191,7 +192,7 @@ class ROIBANField(IBANFormField):
         super(ROIBANField, self).__init__(use_nordea_extensions=False, include_countries=('RO',), **kwargs)
 
 
-class ROPhoneNumberField(RegexField):
+class ROPhoneNumberField(DeprecatedPhoneNumber, RegexField):
     """
     Romanian phone number field
 

--- a/localflavor/sg/forms.py
+++ b/localflavor/sg/forms.py
@@ -12,6 +12,7 @@ from django.forms.fields import CharField, RegexField
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 
 PHONE_DIGITS_RE = re.compile(r'^[689](\d{7})$')
 
@@ -35,7 +36,7 @@ class SGPostCodeField(RegexField):
         super(SGPostCodeField, self).__init__(r'^\d{6}$', *args, **kwargs)
 
 
-class SGPhoneNumberField(CharField):
+class SGPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A form field that validates input as a Singapore phone number.
 

--- a/localflavor/si/forms.py
+++ b/localflavor/si/forms.py
@@ -12,6 +12,7 @@ from django.forms import ValidationError
 from django.forms.fields import CharField, Select, ChoiceField
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .si_postalcodes import SI_POSTALCODES_CHOICES
 
 
@@ -135,7 +136,7 @@ class SIPostalCodeSelect(Select):
                                                  choices=SI_POSTALCODES_CHOICES)
 
 
-class SIPhoneNumberField(CharField):
+class SIPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     Slovenian phone number field.
 

--- a/localflavor/tr/forms.py
+++ b/localflavor/tr/forms.py
@@ -8,6 +8,7 @@ from django.forms.fields import Field, RegexField, Select, CharField
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 from .tr_provinces import PROVINCE_CHOICES
 
 
@@ -39,7 +40,7 @@ class TRPostalCodeField(RegexField):
         return value
 
 
-class TRPhoneNumberField(CharField):
+class TRPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A form field that validates input as a Turkish phone number. The correct
     format is 0xxx xxx xxxx. +90xxx xxx xxxx and inputs without spaces also

--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -12,6 +12,7 @@ from django.forms.fields import Field, RegexField, Select, CharField
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor import DeprecatedPhoneNumber
 
 phone_digits_re = re.compile(r'^(?:1-?)?(\d{3})[-\.]?(\d{3})[-\.]?(\d{4})$')
 ssn_re = re.compile(r"^(?P<area>\d{3})[-\ ]?(?P<group>\d{2})[-\ ]?(?P<serial>\d{4})$")
@@ -44,7 +45,7 @@ class USZipCodeField(RegexField):
         return value.strip()
 
 
-class USPhoneNumberField(CharField):
+class USPhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A form field that validates input as a U.S. phone number.
     """

--- a/localflavor/us/models.py
+++ b/localflavor/us/models.py
@@ -1,6 +1,7 @@
 from django.utils.translation import ugettext_lazy as _
 from django.db.models.fields import CharField
 
+from localflavor import DeprecatedPhoneNumber
 from . import forms
 from .us_states import STATE_CHOICES, USPS_CHOICES
 
@@ -63,7 +64,7 @@ class USZipCodeField(CharField):
         return super(USZipCodeField, self).formfield(**defaults)
 
 
-class PhoneNumberField(CharField):
+class PhoneNumberField(DeprecatedPhoneNumber, CharField):
     """
     A :class:`~django.db.models.CharField` that checks that the value
     is a valid U.S.A.-style phone number (in the format ``XXX-XXX-XXXX``).


### PR DESCRIPTION
This is a WIP MR that deprecates all phone-number validators, issuing a warning suggesting people switch to `django-phonenumber-field`.

Why? It seems pointless to keep maintaining the phone number validators when they are incomplete and/or inferior to the comprehensive list of validators `django-phonenumber-field` (and `libphonenumber` behind it) provide. A good way forward is to suggest that people migrate to that package, or alternatively implement our own phone number validators based on `libphonenumber`.
