### PR TITLE
Add deconstruct to model fields

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -50,6 +50,7 @@ Authors
 * Marti Raudsepp
 * Martin Ogden
 * Matias Dinota
+* Mike Lissner
 * Olivier Sels
 * Rael Max
 * Ramiro Morales

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,9 @@ Modifications to existing flavors:
 - Fix bug in ESIdentityCardNumberField where some valid values for NIE numbers were not
   validating.
   (`gh-217 <https://github.com/django/django-localflavor/pull/217>`_)
+- Add deconstruct method to all model fields.
+  (`gh-162 <https://github.com/django/django-localflavor/pull/162>`_)
+  (`gh-224 <https://github.com/django/django-localflavor/pull/224>`_)
 
 Other changes:
 

--- a/localflavor/au/models.py
+++ b/localflavor/au/models.py
@@ -1,4 +1,4 @@
-from django.db.models.fields import CharField
+from django.db.models import CharField
 from django.utils.translation import ugettext_lazy as _
 
 from . import forms
@@ -18,6 +18,12 @@ class AUStateField(CharField):
         kwargs['max_length'] = 3
         super(AUStateField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(AUStateField, self).deconstruct()
+        del kwargs['choices']
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
 
 class AUPostCodeField(CharField):
     """
@@ -30,6 +36,11 @@ class AUPostCodeField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 4
         super(AUPostCodeField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(AUPostCodeField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.AUPostCodeField}
@@ -47,6 +58,11 @@ class AUPhoneNumberField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 20
         super(AUPhoneNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(AUPhoneNumberField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.AUPhoneNumberField}

--- a/localflavor/bg/models.py
+++ b/localflavor/bg/models.py
@@ -17,6 +17,11 @@ class BGEGNField(models.CharField):
         kwargs['max_length'] = 10
         super(BGEGNField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(BGEGNField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
 
 class BGEIKField(models.CharField):
     """
@@ -31,3 +36,8 @@ class BGEIKField(models.CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 13
         super(BGEIKField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(BGEIKField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs

--- a/localflavor/br/models.py
+++ b/localflavor/br/models.py
@@ -14,3 +14,9 @@ class BRStateField(CharField):
         kwargs['choices'] = STATE_CHOICES
         kwargs['max_length'] = 2
         super(BRStateField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(BRStateField, self).deconstruct()
+        del kwargs['choices']
+        del kwargs['max_length']
+        return name, path, args, kwargs

--- a/localflavor/ec/models.py
+++ b/localflavor/ec/models.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext_lazy as _
-from django.db.models.fields import CharField
+from django.db.models import CharField
 
 from .ec_provinces import PROVINCE_CHOICES
 
@@ -17,3 +17,9 @@ class ECProvinceField(CharField):
         kwargs['choices'] = PROVINCE_CHOICES
         kwargs['max_length'] = 2
         super(ECProvinceField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(ECProvinceField, self).deconstruct()
+        del kwargs['choices']
+        del kwargs['max_length']
+        return name, path, args, kwargs

--- a/localflavor/fr/models.py
+++ b/localflavor/fr/models.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext_lazy as _
-from django.db.models.fields import CharField
+from django.db.models import CharField
 
 
 class FRSIRENField(CharField):
@@ -14,6 +14,11 @@ class FRSIRENField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 9
         super(FRSIRENField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(FRSIRENField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         from . import forms
@@ -34,6 +39,11 @@ class FRSIRETField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 14
         super(FRSIRETField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(FRSIRETField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         from . import forms

--- a/localflavor/generic/models.py
+++ b/localflavor/generic/models.py
@@ -42,6 +42,13 @@ class IBANField(models.CharField):
         self.include_countries = include_countries
         self.validators.append(IBANValidator(use_nordea_extensions, include_countries))
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(IBANField, self).deconstruct()
+        del kwargs['max_length']
+        args.append(self.use_nordea_extensions)
+        args.append(self.include_countries)
+        return name, path, args, kwargs
+
     def to_python(self, value):
         value = super(IBANField, self).to_python(value)
         if value is not None:
@@ -74,6 +81,11 @@ class BICField(models.CharField):
         kwargs.setdefault('max_length', 11)
         super(BICField, self).__init__(*args, **kwargs)
         self.validators.append(BICValidator())
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(BICField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def to_python(self, value):
         # BIC is always written in upper case.

--- a/localflavor/in_/models.py
+++ b/localflavor/in_/models.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext_lazy as _
-from django.db.models.fields import CharField
+from django.db.models import CharField
 
 from .in_states import STATE_CHOICES
 
@@ -15,3 +15,9 @@ class INStateField(CharField):
         kwargs['choices'] = STATE_CHOICES
         kwargs['max_length'] = 2
         super(INStateField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(INStateField, self).deconstruct()
+        del kwargs['choices']
+        del kwargs['max_length']
+        return name, path, args, kwargs

--- a/localflavor/mk/models.py
+++ b/localflavor/mk/models.py
@@ -1,4 +1,4 @@
-from django.db.models.fields import CharField
+from django.db.models import CharField
 from django.utils.translation import ugettext_lazy as _
 
 from .mk_choices import MK_MUNICIPALITIES
@@ -17,6 +17,11 @@ class MKIdentityCardNumberField(CharField):
         kwargs['max_length'] = 8
         super(MKIdentityCardNumberField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(MKIdentityCardNumberField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
     def formfield(self, **kwargs):
         defaults = {'form_class': MKIdentityCardNumberFormField}
         defaults.update(kwargs)
@@ -34,6 +39,12 @@ class MKMunicipalityField(CharField):
         kwargs['choices'] = MK_MUNICIPALITIES
         kwargs['max_length'] = 2
         super(MKMunicipalityField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(MKMunicipalityField, self).deconstruct()
+        del kwargs['choices']
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
 
 class UMCNField(CharField):
@@ -55,6 +66,11 @@ class UMCNField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 13
         super(UMCNField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(UMCNField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         defaults = {'form_class': UMCNFormField}

--- a/localflavor/models.py
+++ b/localflavor/models.py
@@ -1,7 +1,0 @@
-# Add South introspection rules
-try:
-    from south.modelsinspector import add_introspection_rules
-except ImportError:
-    pass
-else:
-    add_introspection_rules([], ["^localflavor"])

--- a/localflavor/mx/models.py
+++ b/localflavor/mx/models.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext_lazy as _
-from django.db.models.fields import CharField
+from django.db.models import CharField
 
 from .mx_states import STATE_CHOICES
 from .forms import (MXRFCField as MXRFCFormField,
@@ -19,6 +19,12 @@ class MXStateField(CharField):
         kwargs['max_length'] = 3
         super(MXStateField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(MXStateField, self).deconstruct()
+        del kwargs['choices']
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
 
 class MXZipCodeField(CharField):
     """
@@ -30,6 +36,11 @@ class MXZipCodeField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 5
         super(MXZipCodeField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(MXZipCodeField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         defaults = {'form_class': MXZipCodeFormField}
@@ -48,6 +59,11 @@ class MXRFCField(CharField):
         kwargs['max_length'] = 13
         super(MXRFCField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(MXRFCField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
     def formfield(self, **kwargs):
         defaults = {'form_class': MXRFCFormField}
         defaults.update(kwargs)
@@ -65,6 +81,11 @@ class MXCURPField(CharField):
         kwargs['max_length'] = 18
         super(MXCURPField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(MXCURPField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
     def formfield(self, **kwargs):
         defaults = {'form_class': MXCURPFormField}
         defaults.update(kwargs)
@@ -81,6 +102,11 @@ class MXSocialSecurityNumberField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 11
         super(MXSocialSecurityNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(MXSocialSecurityNumberField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         defaults = {'form_class': MXSocialSecurityNumberFormField}

--- a/localflavor/nl/models.py
+++ b/localflavor/nl/models.py
@@ -27,6 +27,11 @@ class NLZipCodeField(models.CharField):
         kwargs['max_length'] = 7
         super(NLZipCodeField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(NLZipCodeField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
     def to_python(self, value):
         value = super(NLZipCodeField, self).to_python(value)
         if value is not None:
@@ -42,7 +47,7 @@ class NLZipCodeField(models.CharField):
 
 class NLProvinceField(models.CharField):
     """
-    A Dutch Provice field.
+    A Dutch Province field.
 
     .. versionadded:: 1.3
     """
@@ -54,6 +59,12 @@ class NLProvinceField(models.CharField):
             'max_length': 3
         })
         super(NLProvinceField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(NLProvinceField, self).deconstruct()
+        del kwargs['choices']
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
 
 class NLSoFiNumberField(models.CharField):
@@ -71,6 +82,11 @@ class NLSoFiNumberField(models.CharField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('max_length', 12)
         super(NLSoFiNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(NLSoFiNumberField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.NLSoFiNumberField}
@@ -94,6 +110,11 @@ class NLPhoneNumberField(models.CharField):
         kwargs.setdefault('max_length', 12)
         super(NLPhoneNumberField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(NLPhoneNumberField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.NLPhoneNumberField}
         defaults.update(kwargs)
@@ -113,3 +134,8 @@ class NLBankAccountNumberField(models.CharField):
         super(NLBankAccountNumberField, self).__init__(*args, **kwargs)
         # Ensure that only the NLBankAccountNumberFieldValidator is set.
         self.validators = [NLBankAccountNumberFieldValidator()]
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(NLBankAccountNumberField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs

--- a/localflavor/pk/models.py
+++ b/localflavor/pk/models.py
@@ -1,4 +1,4 @@
-from django.db.models.fields import CharField
+from django.db.models import CharField
 from django.utils.translation import ugettext_lazy as _
 
 from . import forms
@@ -18,6 +18,12 @@ class PKStateField(CharField):
         kwargs['max_length'] = 5
         super(PKStateField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(PKStateField, self).deconstruct()
+        del kwargs['choices']
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
 
 class PKPostCodeField(CharField):
     """
@@ -30,6 +36,11 @@ class PKPostCodeField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 5
         super(PKPostCodeField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(PKPostCodeField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.PKPostCodeField}
@@ -47,6 +58,11 @@ class PKPhoneNumberField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 20
         super(PKPhoneNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(PKPhoneNumberField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.PKPhoneNumberField}

--- a/localflavor/us/models.py
+++ b/localflavor/us/models.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext_lazy as _
-from django.db.models.fields import CharField
+from django.db.models import CharField
 
 from . import forms
 from .us_states import STATE_CHOICES, USPS_CHOICES
@@ -19,8 +19,8 @@ class USStateField(CharField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(USStateField, self).deconstruct()
-        del kwargs["choices"]
-        del kwargs["max_length"]
+        del kwargs['choices']
+        del kwargs['max_length']
         return name, path, args, kwargs
 
 
@@ -44,8 +44,8 @@ class USPostalCodeField(CharField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(USPostalCodeField, self).deconstruct()
-        del kwargs["choices"]
-        del kwargs["max_length"]
+        del kwargs['choices']
+        del kwargs['max_length']
         return name, path, args, kwargs
 
 
@@ -71,7 +71,7 @@ class USZipCodeField(CharField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(USZipCodeField, self).deconstruct()
-        del kwargs["max_length"]
+        del kwargs['max_length']
         return name, path, args, kwargs
 
     def formfield(self, **kwargs):
@@ -93,7 +93,7 @@ class PhoneNumberField(CharField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(PhoneNumberField, self).deconstruct()
-        del kwargs["max_length"]
+        del kwargs['max_length']
         return name, path, args, kwargs
 
     def formfield(self, **kwargs):
@@ -118,7 +118,7 @@ class USSocialSecurityNumberField(CharField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(USSocialSecurityNumberField, self).deconstruct()
-        del kwargs["max_length"]
+        del kwargs['max_length']
         return name, path, args, kwargs
 
     def formfield(self, **kwargs):

--- a/localflavor/us/models.py
+++ b/localflavor/us/models.py
@@ -17,6 +17,12 @@ class USStateField(CharField):
         kwargs['max_length'] = 2
         super(USStateField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(USStateField, self).deconstruct()
+        del kwargs["choices"]
+        del kwargs["max_length"]
+        return name, path, args, kwargs
+
 
 class USPostalCodeField(CharField):
     """"
@@ -35,6 +41,12 @@ class USPostalCodeField(CharField):
         kwargs['choices'] = USPS_CHOICES
         kwargs['max_length'] = 2
         super(USPostalCodeField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(USPostalCodeField, self).deconstruct()
+        del kwargs["choices"]
+        del kwargs["max_length"]
+        return name, path, args, kwargs
 
 
 class USZipCodeField(CharField):
@@ -57,6 +69,11 @@ class USZipCodeField(CharField):
         kwargs['max_length'] = 10
         super(USZipCodeField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(USZipCodeField, self).deconstruct()
+        del kwargs["max_length"]
+        return name, path, args, kwargs
+
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.USZipCodeField}
         defaults.update(kwargs)
@@ -73,6 +90,11 @@ class PhoneNumberField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 20
         super(PhoneNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(PhoneNumberField, self).deconstruct()
+        del kwargs["max_length"]
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         from localflavor.us.forms import USPhoneNumberField
@@ -93,6 +115,11 @@ class USSocialSecurityNumberField(CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 11
         super(USSocialSecurityNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(USSocialSecurityNumberField, self).deconstruct()
+        del kwargs["max_length"]
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         from localflavor.us.forms import (USSocialSecurityNumberField as

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import importlib
+import pkgutil
+import sys
+
+from django.db.models import Field
+from django.test.testcases import TestCase
+from django.utils import six
+
+import localflavor
+
+
+class GeneralTests(TestCase):
+
+    def _find_package_model_fields(self, package):
+        model_fields = []
+        for importer, modname, ispkg in pkgutil.walk_packages(path=package.__path__, prefix=package.__name__ + '.',
+                                                              onerror=lambda x: None):
+            if ispkg:
+                continue
+
+            module = importlib.import_module(modname)
+            for f in dir(module):
+                if f.startswith('_'):
+                    continue
+
+                item = getattr(module, f)
+                if package.__name__ in six.text_type(item) and type(item) == type and issubclass(item, Field):
+                    model_fields.append(item)
+
+        return model_fields
+
+    def test_model_field_deconstruct_methods_with_default_options(self):
+        # This test can only check the choices and max_length options. Specific tests are required for model fields with
+        # options that users can set. See to the IBAN tests for an example.
+        options = ('choices', 'max_length')
+
+        # Finding the localflavor model fields directly with walk_packages doesn't work with Python 3.2. The workaround
+        # is to find the model fields in all of the submodules.
+        if sys.version_info[:2] == (3, 2):
+            model_fields = []
+            for attr in dir(localflavor):
+                if attr.startswith('_'):
+                    continue
+                sub_module = importlib.import_module(localflavor.__name__ + '.' + attr)
+                sub_module_fields = self._find_package_model_fields(sub_module)
+                if len(sub_module_fields) > 0:
+                    model_fields.extend(sub_module_fields)
+        else:
+            model_fields = self._find_package_model_fields(localflavor)
+        self.assertTrue(len(model_fields) > 0, 'No localflavor model fields were found.')
+
+        for cls in model_fields:
+            test_instance = cls()
+            name, path, args, kwargs = test_instance.deconstruct()
+
+            # The model fields always set max_length and sometimes set choices. In all cases, max_length and choices
+            # should not be in the kwargs output of deconstruct.
+            for attr in options:
+                self.assertNotIn(attr, kwargs)
+
+            # The attribute values should match an instance created with the args and kwargs output of deconstruct.
+            new_instance = cls(*args, **kwargs)
+            for attr in options:
+                self.assertEqual(getattr(test_instance, attr), getattr(new_instance, attr))

--- a/tests/test_generic/tests.py
+++ b/tests/test_generic/tests.py
@@ -450,3 +450,11 @@ class EANTests(TestCase):
 
         for value in invalid:
             self.assertRaisesMessage(ValidationError,  error_message, validator, value)
+
+    def test_deconstruct_methods(self):
+        # test_instance must be created with the non-default options.
+        test_instance = IBANField(include_countries=('NL', 'BE'), use_nordea_extensions=True)
+        name, path, args, kwargs = test_instance.deconstruct()
+        new_instance = IBANField(*args, **kwargs)
+        for attr in ('include_countries', 'use_nordea_extensions'):
+            self.assertEqual(getattr(test_instance, attr), getattr(new_instance, attr))

--- a/tests/test_us/tests.py
+++ b/tests/test_us/tests.py
@@ -2,9 +2,8 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
-from localflavor.us.forms import (USZipCodeField, USPhoneNumberField,
-                                  USStateField, USStateSelect,
-                                  USSocialSecurityNumberField)
+from localflavor.us import forms
+from localflavor.us import models
 
 from .forms import USPlaceForm
 
@@ -187,7 +186,7 @@ class USLocalFlavorTests(TestCase):
         self.assertHTMLEqual(str(self.form['postal_code']), usps_select_html)
 
     def test_USStateSelect(self):
-        f = USStateSelect()
+        f = forms.USStateSelect()
         out = '''<select name="state">
 <option value="AL">Alabama</option>
 <option value="AK">Alaska</option>
@@ -265,7 +264,7 @@ class USLocalFlavorTests(TestCase):
             '6060-1234': error_format,
             '60606-': error_format,
         }
-        self.assertFieldOutput(USZipCodeField, valid, invalid)
+        self.assertFieldOutput(forms.USZipCodeField, valid, invalid)
 
     def test_USZipCodeField_formfield(self):
         """Test that the full US ZIP code field is really the full list."""
@@ -288,7 +287,7 @@ class USLocalFlavorTests(TestCase):
             '555-1212': error_format,
             '312-55-1212': error_format,
         }
-        self.assertFieldOutput(USPhoneNumberField, valid, invalid)
+        self.assertFieldOutput(forms.USPhoneNumberField, valid, invalid)
 
     def test_USStateField(self):
         error_invalid = ['Enter a U.S. state or territory.']
@@ -301,7 +300,7 @@ class USLocalFlavorTests(TestCase):
         invalid = {
             60606: error_invalid,
         }
-        self.assertFieldOutput(USStateField, valid, invalid)
+        self.assertFieldOutput(forms.USStateField, valid, invalid)
 
     def test_USSocialSecurityNumberField(self):
         error_invalid = ['Enter a valid U.S. Social Security number in XXX-XX-XXXX format.']
@@ -318,4 +317,18 @@ class USLocalFlavorTests(TestCase):
             '999-98-7652': error_invalid,
             '999987652': error_invalid,
         }
-        self.assertFieldOutput(USSocialSecurityNumberField, valid, invalid)
+        self.assertFieldOutput(forms.USSocialSecurityNumberField, valid, invalid)
+
+    def test_deconstruct_methods(self):
+        classes = (models.USStateField, models.USPostalCodeField,
+                   models.USZipCodeField, models.PhoneNumberField,
+                   models.USSocialSecurityNumberField)
+        for cls in classes:
+            test_instance = cls()
+            name, path, args, kwargs = test_instance.deconstruct()
+            new_instance = cls(*args, **kwargs)
+            for attr in ('choices', 'max_length'):
+                self.assertEqual(
+                    getattr(test_instance, attr),
+                    getattr(new_instance, attr),
+                )

--- a/tests/test_us/tests.py
+++ b/tests/test_us/tests.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from django.test import TestCase
 
 from localflavor.us import forms
-from localflavor.us import models
 
 from .forms import USPlaceForm
 
@@ -318,17 +317,3 @@ class USLocalFlavorTests(TestCase):
             '999987652': error_invalid,
         }
         self.assertFieldOutput(forms.USSocialSecurityNumberField, valid, invalid)
-
-    def test_deconstruct_methods(self):
-        classes = (models.USStateField, models.USPostalCodeField,
-                   models.USZipCodeField, models.PhoneNumberField,
-                   models.USSocialSecurityNumberField)
-        for cls in classes:
-            test_instance = cls()
-            name, path, args, kwargs = test_instance.deconstruct()
-            new_instance = cls(*args, **kwargs)
-            for attr in ('choices', 'max_length'):
-                self.assertEqual(
-                    getattr(test_instance, attr),
-                    getattr(new_instance, attr),
-                )


### PR DESCRIPTION
This builds on the @mlissner's commit in PR #162. I've added a deconstruct method to all model fields. I've also added a generic test for the deconstruct as well as a test for the options in the IBAN Field. It would be great if somebody could review this and provide feedback. Thanks.

Closes #162 