### PR TITLE
Add MXCLABEField for Mexico

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,13 +10,14 @@ New flavors:
 
 New fields for existing flavors:
 
-- None
+- Added MXCLABEField model and form fields.
+  (`gh-227 <https://github.com/django/django-localflavor/pull/227>`_).
 
 Modifications to existing flavors:
 
 - None
 
-1.3   (2016-04-06)
+1.3   (2016-05-06)
 ------------------
 
 New flavors:

--- a/localflavor/mx/models.py
+++ b/localflavor/mx/models.py
@@ -1,6 +1,7 @@
 from django.db.models import CharField
 from django.utils.translation import ugettext_lazy as _
 
+from .forms import MXCLABEField as MXCLABEFormField
 from .forms import MXCURPField as MXCURPFormField
 from .forms import MXRFCField as MXRFCFormField
 from .forms import MXSocialSecurityNumberField as MXSocialSecurityNumberFormField
@@ -69,6 +70,30 @@ class MXRFCField(CharField):
         defaults = {'form_class': MXRFCFormField}
         defaults.update(kwargs)
         return super(MXRFCField, self).formfield(**defaults)
+
+
+class MXCLABEField(CharField):
+    """
+    A model field that forms represent as a forms.MXCURPField field and
+    stores the value of a valid Mexican CLABE.
+
+    .. versionadded:: 1.4
+    """
+    description = _("Mexican CLABE")
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 18
+        super(MXCLABEField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(MXCLABEField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': MXCLABEFormField}
+        defaults.update(kwargs)
+        return super(MXCLABEField, self).formfield(**defaults)
 
 
 class MXCURPField(CharField):

--- a/tests/test_mx/forms.py
+++ b/tests/test_mx/forms.py
@@ -7,4 +7,4 @@ class MXPersonProfileForm(ModelForm):
 
     class Meta:
         model = MXPersonProfile
-        fields = ('state', 'rfc', 'curp', 'zip_code', 'ssn')
+        fields = ('state', 'rfc', 'curp', 'zip_code', 'ssn', 'clabe')

--- a/tests/test_mx/models.py
+++ b/tests/test_mx/models.py
@@ -1,6 +1,6 @@
 from django.db import models
-
-from localflavor.mx.models import MXCURPField, MXRFCField, MXSocialSecurityNumberField, MXStateField, MXZipCodeField
+from localflavor.mx.models import (MXCLABEField, MXCURPField, MXRFCField, MXSocialSecurityNumberField, MXStateField,
+                                   MXZipCodeField)
 
 
 class MXPersonProfile(models.Model):
@@ -9,3 +9,4 @@ class MXPersonProfile(models.Model):
     curp = MXCURPField()
     zip_code = MXZipCodeField()
     ssn = MXSocialSecurityNumberField()
+    clabe = MXCLABEField()

--- a/tests/test_mx/tests.py
+++ b/tests/test_mx/tests.py
@@ -2,8 +2,8 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
-
-from localflavor.mx.forms import MXCURPField, MXRFCField, MXSocialSecurityNumberField, MXStateSelect, MXZipCodeField
+from localflavor.mx.forms import (MXCLABEField, MXCURPField, MXRFCField, MXSocialSecurityNumberField, MXStateSelect,
+                                  MXZipCodeField)
 
 from .forms import MXPersonProfileForm
 
@@ -17,6 +17,7 @@ class MXLocalFlavorTests(TestCase):
             'curp': 'toma880125hmnrrn02',
             'zip_code': '58120',
             'ssn': '53987417457',
+            'clabe': '032180000118359719'
         })
 
     def test_get_display_methods(self):
@@ -32,13 +33,21 @@ class MXLocalFlavorTests(TestCase):
             'curp': 'invalid curp',
             'zip_code': 'xxx',
             'ssn': 'invalid ssn',
+            'clabe': 'invalid clabexxxxx'
         })
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors['state'], ['Select a valid choice. Invalid state is not one of the available choices.'])
-        self.assertEqual(form.errors['rfc'], ['Ensure this value has at least 12 characters (it has 11).', 'Enter a valid RFC.'])
-        self.assertEqual(form.errors['curp'], ['Ensure this value has at least 18 characters (it has 12).', 'Enter a valid CURP.'])
+        self.assertEqual(
+            form.errors['state'], ['Select a valid choice. Invalid state is not one of the available choices.']
+        )
+        self.assertEqual(
+            form.errors['rfc'], ['Ensure this value has at least 12 characters (it has 11).', 'Enter a valid RFC.']
+        )
+        self.assertEqual(
+            form.errors['curp'], ['Ensure this value has at least 18 characters (it has 12).', 'Enter a valid CURP.']
+        )
         self.assertEqual(form.errors['zip_code'], ['Enter a valid zip code in the format XXXXX.'])
         self.assertEqual(form.errors['ssn'], ['Enter a valid Social Security Number.'])
+        self.assertEqual(form.errors['clabe'], ['Enter a valid CLABE.'])
 
     def test_field_blank_option(self):
         """Test that the empty option is there."""
@@ -247,3 +256,28 @@ class MXLocalFlavorTests(TestCase):
             '53563800130': error_checksum,
         }
         self.assertFieldOutput(MXSocialSecurityNumberField, valid, invalid)
+
+    def test_MXCLABEField(self):
+        error_format = ['Enter a valid CLABE.']
+        error_checksum = ['Invalid checksum for CLABE.']
+        valid = {
+            '032180000118359719': '032180000118359719',
+            '002115016003269411': '002115016003269411',
+            '435816798316429530': '435816798316429530',
+            '102211657483920119': '102211657483920119',
+            '002846375894578321': '002846375894578321',
+            '012276385238571288': '012276385238571288',
+            '633790823578925966': '633790823578925966',
+            '613137129494921910': '613137129494921910',
+            '108180637932589295': '108180637932589295',
+        }
+
+        invalid = {
+            'abc123def456-902-4': error_format,
+            '123456789123456789': error_checksum,
+            '123456237454589458': error_checksum,
+            '098765375925788389': error_checksum,
+            '042560735684818257': error_checksum,
+            '037027587179835981': error_checksum,
+        }
+        self.assertFieldOutput(MXCLABEField, valid, invalid)


### PR DESCRIPTION
This pull request adds a custom field for Clave Bancaria Estandarizada, used in all financial transactions in Mexico.

More info (in spanish):
https://es.wikipedia.org/wiki/CLABE