### PR TITLE
Adding support for Kuwait governorates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,9 +12,10 @@ New fields for existing flavors:
 
 - Added MXCLABEField model and form fields.
   (`gh-227 <https://github.com/django/django-localflavor/pull/227>`_).
-
 - Added AUTaxFileNumberField model and form fields.
   (`gh-238 <https://github.com/django/django-localflavor/pull/238>`_)
+- Added KWGovernorateSelect field to easily select Kuwait governorates.
+  (`gh-231 <https://github.com/django/django-localflavor/pull/231>`_).
 
 Modifications to existing flavors:
 

--- a/localflavor/kw/forms.py
+++ b/localflavor/kw/forms.py
@@ -8,8 +8,10 @@ from datetime import date
 
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
-from django.forms.fields import Field
+from django.forms.fields import Field, Select
 from django.utils.translation import gettext_lazy as _
+
+from .kw_governorates import GOVERNORATE_CHOICES
 
 id_re = re.compile(r'''^(?P<initial>\d{1})
                        (?P<yy>\d\d)
@@ -73,3 +75,13 @@ class KWCivilIDNumberField(Field):
             raise ValidationError(self.error_messages['invalid'])
 
         return value
+
+
+class KWGovernorateSelect(Select):
+    """
+    A Select widget that uses a list of Kuwait governorates
+    as its choices.
+    """
+    def __init__(self, attrs=None):
+        super(KWGovernorateSelect, self).__init__(attrs,
+                                                  choices=GOVERNORATE_CHOICES)

--- a/localflavor/kw/kw_governorates.py
+++ b/localflavor/kw/kw_governorates.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+
+# List of governorates as defined by ISO_3166-2
+# For reference; see https://en.wikipedia.org/wiki/ISO_3166-2:KW
+# Note that these are governorates and not subdivisons
+
+# These are the English names
+GOVERNORATE_CHOICES = (
+    ('AH', _('Ahmadi')),
+    ('FA', _('Farwaniyah')),
+    ('JA', _('Jahra')),
+    ('KU', _('Capital')),
+    ('HA', _('Hawalli')),
+    ('MU', _('Mubarak Al Kabir')),
+)

--- a/localflavor/kw/kw_governorates.py
+++ b/localflavor/kw/kw_governorates.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 # List of governorates as defined by ISO_3166-2
 # For reference; see https://en.wikipedia.org/wiki/ISO_3166-2:KW
-# Note that these are governorates and not subdivisons
+# Note that these are governorates and not subdivisions
 
 # These are the English names
 GOVERNORATE_CHOICES = (

--- a/tests/test_kw.py
+++ b/tests/test_kw.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.test import SimpleTestCase
 
-from localflavor.kw.forms import KWCivilIDNumberField
+from localflavor.kw.forms import KWCivilIDNumberField, KWGovernorateSelect
 
 
 class KWLocalFlavorTests(SimpleTestCase):
@@ -20,3 +20,15 @@ class KWLocalFlavorTests(SimpleTestCase):
             '2*9332013455': error_invalid,
         }
         self.assertFieldOutput(KWCivilIDNumberField, valid, invalid)
+
+    def test_KWGovernorateSelect(self):
+        f = KWGovernorateSelect()
+        result = '''<select name="governorates">
+<option value="AH">Ahmadi</option>
+<option value="FA">Farwaniyah</option>
+<option value="JA">Jahra</option>
+<option value="KU" selected="selected">Capital</option>
+<option value="HA">Hawalli</option>
+<option value="MU">Mubarak Al Kabir</option>
+</select>'''
+        self.assertHTMLEqual(f.render('governorates', 'KU'), result)


### PR DESCRIPTION
This PR adds a select field that enumerates the 6 governorates of Kuwait; as per [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2:KW)

Note that in the wikipedia entry they are listed as _subdivision_ but they are actually governorates.
