### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,4 +60,4 @@ And combine both options::
     $ COUNTRY=us tox -e py27-1.7
 
 __ https://github.com/django/django-localflavor/issues
-__ http://tox.readthedocs.org/en/latest/install.html
+__ https://tox.readthedocs.io/en/latest/install.html

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ django-localflavor
    :target: http://codecov.io/github/django/django-localflavor?branch=master
 
 .. image:: https://readthedocs.org/projects/django-localflavor/badge/?version=latest&style=plastic
-   :target: http://django-localflavor.readthedocs.org/en/latest/
+   :target: https://django-localflavor.readthedocs.io/en/latest/
 
 Django's "localflavor" packages offer additional functionality for particular
 countries or cultures. For example, these might include form fields for your
@@ -23,7 +23,7 @@ This code used to live in Django proper -- in ``django.contrib.localflavor``
 framework's core clean.
 
 For a full list of available localflavors, see
-http://django-localflavor.readthedocs.org/
+https://django-localflavor.readthedocs.io/
 
 django-localflavor can also be found on and installed from the Python
 Package Index: https://pypi.python.org/pypi/django-localflavor

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ def find_package_data(where='.', package='',
 setup(
     name="django-localflavor",
     version=find_version("localflavor", "__init__.py"),
-    url='http://django-localflavor.readthedocs.org/en/latest/',
+    url='https://django-localflavor.readthedocs.io/en/latest/',
     license='BSD',
     description="Country-specific Django helpers",
     long_description=read('README.rst'),


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.