### PR TITLE
+ AUTaxFileNumberField

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -27,6 +27,7 @@ Authors
 * Erik Romijn
 * Flavio Curella
 * Florian Apolloner
+* François Constant
 * Gary Wilson Jr
 * Gerardo Orozco
 * Ghassen Telmoudi

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,9 @@ New fields for existing flavors:
 - Added MXCLABEField model and form fields.
   (`gh-227 <https://github.com/django/django-localflavor/pull/227>`_).
 
+- Added AUTaxFileNumberField model and form fields.
+  (`gh-238 <https://github.com/django/django-localflavor/pull/238>`_)
+
 Modifications to existing flavors:
 
 - Fixed century bug with Kuwait Civil ID verification localflavor.kw.forms

--- a/localflavor/au/forms.py
+++ b/localflavor/au/forms.py
@@ -13,7 +13,7 @@ from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .au_states import STATE_CHOICES
-from .validators import AUBusinessNumberFieldValidator
+from .validators import AUBusinessNumberFieldValidator, AUTaxFileNumberFieldValidator
 
 
 PHONE_DIGITS_RE = re.compile(r'^(\d{10})$')
@@ -85,3 +85,23 @@ class AUBusinessNumberField(CharField):
 
         spaceless = ''.join(value.split())
         return '{} {} {} {}'.format(spaceless[:2], spaceless[2:5], spaceless[5:8], spaceless[8:])
+
+
+class AUTaxFileNumberField(CharField):
+    """
+    A form field that validates input as an Australian Tax File Number (TFN)
+
+    .. versionadded:: 1.4
+    """
+
+    default_validators = [AUTaxFileNumberFieldValidator()]
+
+    def prepare_value(self, value):
+        """
+        Format the value for display.
+        """
+        if value is None:
+            return value
+
+        spaceless = ''.join(value.split())
+        return '{} {} {}'.format(spaceless[:3], spaceless[3:6], spaceless[6:])

--- a/localflavor/au/models.py
+++ b/localflavor/au/models.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from . import forms
 from .au_states import STATE_CHOICES
-from .validators import AUBusinessNumberFieldValidator
+from .validators import AUBusinessNumberFieldValidator, AUTaxFileNumberFieldValidator
 
 
 class AUStateField(CharField):
@@ -102,6 +102,47 @@ class AUBusinessNumberField(CharField):
         Ensure the ABN is stored without spaces.
         """
         value = super(AUBusinessNumberField, self).to_python(value)
+
+        if value is not None:
+            return ''.join(value.split())
+
+        return value
+
+
+class AUTaxFileNumberField(CharField):
+    """
+    A model field that checks that the value is a valid Tax File Number (TFN).
+
+    A TFN is a number issued to a person by the Commissioner of Taxation and
+    is used to verify client identity and establish their income levels.
+    It is a eight or nine digit number without any embedded meaning.
+
+    .. versionadded:: 1.4
+    """
+
+    description = _("Australian Tax File Number")
+
+    validators = [AUTaxFileNumberFieldValidator()]
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 11
+        super(AUTaxFileNumberField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(AUTaxFileNumberField, self).deconstruct()
+        del kwargs['max_length']
+        return name, path, args, kwargs
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.AUTaxFileNumberField}
+        defaults.update(kwargs)
+        return super(AUTaxFileNumberField, self).formfield(**defaults)
+
+    def to_python(self, value):
+        """
+        Ensure the TFN is stored without spaces.
+        """
+        value = super(AUTaxFileNumberField, self).to_python(value)
 
         if value is not None:
             return ''.join(value.split())

--- a/localflavor/au/validators.py
+++ b/localflavor/au/validators.py
@@ -49,3 +49,46 @@ class AUBusinessNumberFieldValidator(RegexValidator):
         super(AUBusinessNumberFieldValidator, self).__call__(value)
         if not self._is_valid(value):
             raise ValidationError(self.error_message)
+
+
+class AUTaxFileNumberFieldValidator(RegexValidator):
+    """
+    Validation for Australian Tax File Numbers.
+
+    .. versionadded:: 1.4
+    """
+
+    error_message = _('Enter a valid TFN.')
+
+    def __init__(self):
+        """ Regex for 8 to 9 digits """
+        super(AUTaxFileNumberFieldValidator, self).__init__(
+            regex='^\d{8,9}$', message=self.error_message)
+
+    def _is_valid(self, value):
+        """
+        Return whether the given value is a valid TFN.
+
+        See http://www.mathgen.ch/codes/tfn.html for a description of the
+        validation algorithm.
+
+        """
+        # 1. Multiply each digit by its weighting factor.
+        digits = [int(i) for i in list(value)]
+        WEIGHTING_FACTORS = [1, 4, 3, 7, 5, 8, 6, 9, 10]
+        weighted = [digit * weight for digit, weight in zip(digits, WEIGHTING_FACTORS)]
+
+        # 2. Sum the resulting values.
+        total = sum(weighted)
+
+        # 3. Divide the total by 11, noting the remainder.
+        remainder = total % 11
+
+        # 4. If the remainder is zero, then it's a valid TFN.
+        return remainder == 0
+
+    def __call__(self, value):
+        value = value.replace(' ', '')
+        super(AUTaxFileNumberFieldValidator, self).__call__(value)
+        if not self._is_valid(value):
+            raise ValidationError(self.error_message)

--- a/tests/test_au/forms.py
+++ b/tests/test_au/forms.py
@@ -9,4 +9,4 @@ class AustralianPlaceForm(ModelForm):
         model = AustralianPlace
         fields = ('state', 'state_required', 'state_default', 'postcode',
                   'postcode_required', 'postcode_default',
-                  'phone', 'name', 'abn')
+                  'phone', 'name', 'abn', 'tfn')

--- a/tests/test_au/models.py
+++ b/tests/test_au/models.py
@@ -1,5 +1,6 @@
 from django.db import models
-from localflavor.au.models import AUBusinessNumberField, AUPhoneNumberField, AUPostCodeField, AUStateField
+from localflavor.au.models import (AUBusinessNumberField, AUPhoneNumberField, AUPostCodeField, AUStateField,
+                                   AUTaxFileNumberField)
 
 
 class AustralianPlace(models.Model):
@@ -12,3 +13,4 @@ class AustralianPlace(models.Model):
     phone = AUPhoneNumberField(blank=True)
     name = models.CharField(max_length=20)
     abn = AUBusinessNumberField()
+    tfn = AUTaxFileNumberField()


### PR DESCRIPTION
Hello,

I've added AUTaxFileNumberField (form and model) + AUTaxFileNumberFieldValidator.

It's based on the AUBusinessNumberField.

This is my first contribution and I hope it's all good.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`

**New Fields Only**

- [x] Prefix the country code to all fields.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [x] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [x] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [x] Add documentation for all fields.