### PR TITLE
BRCNPJField is now a CharField

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -62,6 +62,7 @@ Authors
 * Michał Sałaban
 * Mike Lissner
 * Olivier Sels
+* Paulo Poiati
 * Rael Max
 * Ramiro Morales
 * Rolf Erik Lekang

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ New fields for existing flavors:
 
 Modifications to existing flavors:
 
+- Enhancements of localflavor.br.forms.BRCNPJField
+  (`gh-240 <https://github.com/django/django-localflavor/pull/240>`_).
 - Fixed century bug with Kuwait Civil ID verification localflavor.kw.forms
   (`gh-195 <https://github.com/django/django-localflavor/pull/195>`_).
 - Allow passing field name as first positional argument of IBANField.

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -155,7 +155,7 @@ class BRCPFField(CharField):
         return orig_value
 
 
-class BRCNPJField(Field):
+class BRCNPJField(CharField):
     """
     A form field that validates input as `Brazilian CNPJ`_.
 
@@ -169,6 +169,9 @@ class BRCNPJField(Field):
         'invalid': _("Invalid CNPJ number."),
         'max_digits': _("This field requires at least 14 digits"),
     }
+
+    def __init__(self, min_length=14, max_length=18, *args, **kwargs):
+        super(BRCNPJField, self).__init__(max_length, min_length, *args, **kwargs)
 
     def clean(self, value):
         """


### PR DESCRIPTION
Make the `localflavor.br.forms.BRCNPJField` a subclass of `django.forms.CharField` (instead of `django.forms.Field`). 

With this change the user can select with formats the field can accept. E.g:

Both formats bellow are valid:
- 56.352.556/0001-00
- 56352556000100

But with the current implementation the user can't select just one of them. With this he can using the `min_length` and `max_length` from `django.forms.CharField`.
