### PR TITLE
Fix rare inconsistencies with FRNationalIdentificationNumber 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,10 @@ Modifications to existing flavors:
   (`gh-195 <https://github.com/django/django-localflavor/pull/195>`_).
 - Allow passing field name as first positional argument of IBANField.
   (`gh-236 <https://github.com/django/django-localflavor/pull/236>`_).
-
+- Fixed French FRNationalIdentificationNumber bug with imaginary birth month values.
+  (`gh-242` <https://github.com/django/django-localflavor/pull/242>`_).
+- Fixed French FRNationalIdentificationNumber bug with corsican people born after 2000.
+  (`gh-242` <https://github.com/django/django-localflavor/pull/242>`_).
 
 1.3   (2016-05-06)
 ------------------

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -17,9 +17,10 @@ from localflavor.generic.checksums import luhn
 from .fr_department import DEPARTMENT_CHOICES_PER_REGION
 from .fr_region import REGION_CHOICES
 
-nin_re = re.compile(r'^(?P<gender>[1278])(?P<year_of_birth>\d{2})(?P<month_of_birth>0[1-9]|1[0-2]|20)' +
-                    '(?P<department_of_origin>\d{2}|2[AB])(?P<commune_of_origin>\d{3})(?P<person_unique_number>\d{3})' +
-                    '(?P<control_key>\d{2})$')
+nin_re = re.compile(
+    r'^(?P<gender>[1278])(?P<year_of_birth>\d{2})(?P<month_of_birth>0[1-9]|1[0-2]|20|3[0-9]|4[0-2]|[5-9][0-9])'
+    r'(?P<department_of_origin>\d{2}|2[AB])(?P<commune_of_origin>\d{3})(?P<person_unique_number>\d{3})'
+    r'(?P<control_key>\d{2})$')
 
 
 class FRZipCodeField(RegexField):

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -5,6 +5,7 @@ FR-specific Form helpers
 from __future__ import unicode_literals
 
 import re
+from datetime import date
 
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
@@ -158,6 +159,9 @@ class FRNationalIdentificationNumber(CharField):
         person_unique_number = match.group('person_unique_number')
         control_key = int(match.group('control_key'))
 
+        # Get current year
+        current_year = int(str(date.today().year)[2:])
+
         # Department number 98 is for Monaco
         if department_of_origin == '98':
             raise ValidationError(self.error_messages['invalid'])
@@ -165,7 +169,7 @@ class FRNationalIdentificationNumber(CharField):
         # Departments number 20, 2A and 2B represent Corsica
         if department_of_origin in ['20', '2A', '2B']:
             # For people born before 1976, Corsica number was 20
-            if int(year_of_birth) < 76 and department_of_origin != '20':
+            if current_year < int(year_of_birth) < 76 and department_of_origin != '20':
                 raise ValidationError(self.error_messages['invalid'])
             # For people born from 1976, Corsica dep number is either 2A or 2B
             if (int(year_of_birth) > 75 and

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -214,6 +214,10 @@ class FRLocalFlavorTests(SimpleTestCase):
             '882062A09002279': '882062A09002279',
             # Good, new Corsica department number (2B) with birthdate >= 1976
             '882062B09002279': '882062B09002279',
+            # Good, new Corsica department number (2B) with birthdate >= 1976 (2005)
+            '105062B09002231': '105062B09002231',
+            # Good, new Corsica department number (20) with birthdate < 1976 (1905)
+            '105062009002231': '105062009002231',
             # Good, birth month not known (then, can be 20, [30-42] or [50-99])
             '140200109002223': '140200109002223',
             '141330109002285': '141330109002285',

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -214,6 +214,11 @@ class FRLocalFlavorTests(SimpleTestCase):
             '882062A09002279': '882062A09002279',
             # Good, new Corsica department number (2B) with birthdate >= 1976
             '882062B09002279': '882062B09002279',
+            # Good, birth month not known (then, can be 20, [30-42] or [50-99])
+            '140200109002223': '140200109002223',
+            '141330109002285': '141330109002285',
+            '142580109002248': '142580109002248',
+            '143990109002273': '143990109002273',
         }
         invalid = {
             # Gender mismatch


### PR DESCRIPTION
This PR fixes some french identification numbers errors occurring with these cases:
- People with imaginary birth month (when not known or unverifiable)
- People born in Corsica after 2000

--

Based on these (reliable) sources:
- https://www.e-ventail.fr/ss/Satellite/e-ventail/documentation/fiches-techniques/numero-securite-sociale.html

```
La signification des chiffres est la suivante : 
    1 sexe : 1 pour les hommes, 2 pour les femmes;
    2 et 3 deux derniers chiffres de l'année de naissance (*);
    3 et 4 mois de naissance (01 à 12) (**);
    6 et 7 département de naissance (2A ou 2B pour les personnes nées en Corse à partir de 1976, 98 pour les DOM, 99 pour les personnes nées à l'étranger ; 91, 92 ou 93 pour certaines personnes nées en Algérie sous administration française);
    8, 9 et 10 numéro d'ordre de la commune de naissance dans le département;
    11, 12 et 13 numéro d'ordre de l'acte de naissance.

(*) L’année du NIR doit être égale à l’année renseignée dans la date de naissance. 
L’année du NIR doit être inférieure à l’année en cours et supérieure à l’année en cours moins 120. 
Exemple : Pour une déclaration déposée en 2006 concernant les salaires de 2005. L’année de naissance pourra prendre une valeur de 1885 à 2005.

(**) Le mois de naissance peut aussi être compris entre 30 et 42, entre 50 et 99 ou égal à 20 ou 99 ; pour les personnes dont on ne connaît pas le mois de naissance du fait d’absence de registre d’état civil dans certains pays étrangers.
```

- http://www.dsn-info.fr/documentation/dsn_cahier_technique_phase1.pdf (p. 72-73)
