### PR TITLE
Adding local flavor for Venezuela

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -52,6 +52,7 @@ Authors
 * Justin Bronn
 * Karen Tracey
 * László Ratskó
+* Luis Alberto Santana
 * Łukasz Langa
 * Luke Benstead
 * luyikei

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,8 @@ Changelog
 
 New flavors:
 
-- None
+- Added local flavor for Venezuela
+  (`gh-245 <https://github.com/django/django-localflavor/pull/245>`_)
 
 New fields for existing flavors:
 

--- a/localflavor/ve/forms.py
+++ b/localflavor/ve/forms.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Ve-specific Form helpers.
+"""
+
+from django.forms.fields import Select
+
+from .ve_region import REGION_CHOICES
+from .ve_states import STATE_CHOICES
+
+
+class VERegionSelect(Select):
+    """
+    A Select widget that uses a list of Venezuelan regions as its choices.
+    """
+    def __init__(self, attrs=None):
+        super(VERegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
+
+
+class VEStateSelect(Select):
+    """
+    A Select widget that uses a list of Venezuelan states as its choices.
+    """
+    def __init__(self, attrs=None):
+        super(VEStateSelect, self).__init__(attrs, choices=STATE_CHOICES)

--- a/localflavor/ve/ve_region.py
+++ b/localflavor/ve/ve_region.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+
+#: A list of Venezuelan regions for use as `choices` in a formfield.
+#: Data based from http://en.wikipedia.org/wiki/Regions_of_Venezuela
+REGION_CHOICES = (
+    ('501', _('Región Capital')),
+    ('502', _('Región Central')),
+    ('503', _('Región de los Llanos')),
+    ('504', _('Región Centro Occidental')),
+    ('505', _('Región Zuliana')),
+    ('506', _('Región de los Andes')),
+    ('507', _('Región Nor-Oriental')),
+    ('508', _('Región Insular')),
+    ('509', _('Región Guayana')),
+    ('510', _('Región Sur Occidental')),
+)

--- a/localflavor/ve/ve_states.py
+++ b/localflavor/ve/ve_states.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+
+#: A list of Venezuelan states for use as `choices` in a formfield.
+#: Data based from ISO_3166-2:VE http://en.wikipedia.org/wiki/ISO_3166-2:VE
+STATE_CHOICES = (
+    ('VE-Z', _('Amazonas')),
+    ('VE-B', _('Anzoátegui')),
+    ('VE-C', _('Apure')),
+    ('VE-D', _('Aragua')),
+    ('VE-E', _('Barinas')),
+    ('VE-F', _('Bolívar')),
+    ('VE-G', _('Carabobo')),
+    ('VE-H', _('Cojedes')),
+    ('VE-Y', _('Delta Amacuro')),
+    ('VE-W', _('Dependencias Federales')),
+    ('VE-A', _('Distrito Capital')),
+    ('VE-I', _('Falcón')),
+    ('VE-J', _('Guárico')),
+    ('VE-K', _('Lara')),
+    ('VE-L', _('Mérida')),
+    ('VE-M', _('Miranda')),
+    ('VE-N', _('Monagas')),
+    ('VE-O', _('Nueva Esparta')),
+    ('VE-P', _('Portuguesa')),
+    ('VE-R', _('Sucre')),
+    ('VE-S', _('Táchira')),
+    ('VE-T', _('Trujillo')),
+    ('VE-X', _('Vargas')),
+    ('VE-U', _('Yaracuy')),
+    ('VE-V', _('Zulia')),
+)

--- a/tests/test_ve.py
+++ b/tests/test_ve.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.test import SimpleTestCase
+
+from localflavor.ve.forms import VERegionSelect, VEStateSelect
+
+class VELocalFlavorTests(SimpleTestCase):
+
+    def test_VERegionSelect(self):
+        f = VERegionSelect()
+
+        out = '''<select name="regiones">
+<option value="501">Regi\xf3n Capital</option>
+<option value="502">Regi\xf3n Central</option>
+<option value="503">Regi\xf3n de los Llanos</option>
+<option value="504">Regi\xf3n Centro Occidental</option>
+<option value="505">Regi\xf3n Zuliana</option>
+<option value="506">Regi\xf3n de los Andes</option>
+<option value="507">Regi\xf3n Nor-Oriental</option>
+<option value="508" selected="selected">Regi\xf3n Insular</option>
+<option value="509">Regi\xf3n Guayana</option>
+<option value="510">Regi\xf3n Sur Occidental</option>
+</select>'''
+
+        self.assertHTMLEqual(f.render('regiones', '508'), out)
+
+
+    def test_VEStateSelect(self):
+        f = VEStateSelect()
+
+        out = '''<select name="estados">
+<option value="VE-Z">Amazonas</option>
+<option value="VE-B">Anzo\xe1tegui</option>
+<option value="VE-C">Apure</option>
+<option value="VE-D">Aragua</option>
+<option value="VE-E">Barinas</option>
+<option value="VE-F">Bolívar</option>
+<option value="VE-G">Carabobo</option>
+<option value="VE-H" selected="selected">Cojedes</option>
+<option value="VE-Y">Delta Amacuro</option>
+<option value="VE-W">Dependencias Federales</option>
+<option value="VE-A">Distrito Capital</option>
+<option value="VE-I">Falc\xf3n</option>
+<option value="VE-J">Gu\xe1rico</option>
+<option value="VE-K">Lara</option>
+<option value="VE-L">M\xe9rida</option>
+<option value="VE-M">Miranda</option>
+<option value="VE-N">Monagas</option>
+<option value="VE-O">Nueva Esparta</option>
+<option value="VE-P">Portuguesa</option>
+<option value="VE-R">Sucre</option>
+<option value="VE-S">T\xe1chira</option>
+<option value="VE-T">Trujillo</option>
+<option value="VE-X">Vargas</option>
+<option value="VE-U">Yaracuy</option>
+<option value="VE-V">Zulia</option>
+</select>'''
+
+        self.assertHTMLEqual(f.render('estados', 'VE-H'), out)


### PR DESCRIPTION
**Changes**
- Added states and regions datada
- Added forms helpers for select widgets.

**All Changes**
- [x] Add an entry to the docs/changelog.rst describing the change.
- [x] Add an entry for your name in the docs/authors.rst file if it's not
    already there.
- [x] Adjust your imports to a standard form by running this command:
  
    `isort --recursive --line-width 120 localflavor tests`

**New Fields Only**
- [x] Prefix the country code to all fields.
- [x] Field names should be easily understood by developers from the target
    localflavor country. This means that English translations are usually
    not the best name unless it's for something standard like postal code,
    tax / VAT ID etc.
