### PR TITLE
Change 'DIF' to 'CDMX' in mx_states.py

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,8 @@ Modifications to existing flavors:
   (`gh-242` <https://github.com/django/django-localflavor/pull/242>`_).
 - Fixed French FRNationalIdentificationNumber bug with corsican people born after 2000.
   (`gh-242` <https://github.com/django/django-localflavor/pull/242>`_).
+- Renamed 'Distrito Federal' to 'Ciudad de México'
+  (`gh-251` <https://github.com/django/django-localflavor/pull/251>`_).
 
 1.3   (2016-05-06)
 ------------------

--- a/docs/localflavor/mx.rst
+++ b/docs/localflavor/mx.rst
@@ -1,6 +1,14 @@
 Mexico (``mx``)
 ===============
 
+Migrations
+----------
+
+Migrate goes here.
+
+Then set `LOCALFLAVOR_MIGRATED_MEXICO_CITY` to True in your `settings.py`
+
+
 Forms
 -----
 

--- a/localflavor/mx/models.py
+++ b/localflavor/mx/models.py
@@ -1,5 +1,6 @@
 from django.db.models import CharField
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
 from .forms import MXCLABEField as MXCLABEFormField
 from .forms import MXCURPField as MXCURPFormField
@@ -7,6 +8,8 @@ from .forms import MXRFCField as MXRFCFormField
 from .forms import MXSocialSecurityNumberField as MXSocialSecurityNumberFormField
 from .forms import MXZipCodeField as MXZipCodeFormField
 from .mx_states import STATE_CHOICES
+
+import warnings
 
 
 class MXStateField(CharField):
@@ -26,6 +29,19 @@ class MXStateField(CharField):
         del kwargs['choices']
         del kwargs['max_length']
         return name, path, args, kwargs
+
+    def clean(self, value, model_instance):
+        value = super(MXStateField, self).clean(value, model_instance)
+
+        if value == 'DIF':
+            warnings.warn(
+                "The key 'DIF' should be migrated to 'CDMX' as soon as possible. "
+                "See https://django-localflavor.readthedocs.io/en/latest/localflavor/mx/#Migrations "
+                "for more information",
+                DeprecationWarning
+            )
+
+        return value
 
 
 class MXZipCodeField(CharField):

--- a/localflavor/mx/mx_states.py
+++ b/localflavor/mx/mx_states.py
@@ -2,8 +2,13 @@
 from __future__ import unicode_literals
 
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
-#: All 31 states, plus the `Distrito Federal`.
+
+HAS_MIGRATED_MEXICO_CITY = getattr(settings, 'LOCALFLAVOR_MIGRATED_MEXICO_CITY', False)
+
+
+#: All 31 states, plus the `Ciudad de México`.
 STATE_CHOICES = (
     ('AGU', _('Aguascalientes')),
     ('BCN', _('Baja California')),
@@ -13,7 +18,7 @@ STATE_CHOICES = (
     ('CHP', _('Chiapas')),
     ('COA', _('Coahuila')),
     ('COL', _('Colima')),
-    ('DIF', _('Distrito Federal')),
+    ('CDMX' if HAS_MIGRATED_MEXICO_CITY else 'DIF', _('Ciudad de México')),
     ('DUR', _('Durango')),
     ('GRO', _('Guerrero')),
     ('GUA', _('Guanajuato')),


### PR DESCRIPTION
Not sure when this happened, but [references to Mexico City](https://en.wikipedia.org/wiki/Mexico_City) refer to it as `Ciudad de México`.