### PR TITLE
issue #214 fixed pep8, pep257 and other styling errors to pass the pr…

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,11 +24,13 @@ Modifications to existing flavors:
 - Allow passing field name as first positional argument of IBANField.
   (`gh-236 <https://github.com/django/django-localflavor/pull/236>`_).
 - Fixed French FRNationalIdentificationNumber bug with imaginary birth month values.
-  (`gh-242` <https://github.com/django/django-localflavor/pull/242>`_).
+  (`gh-242 <https://github.com/django/django-localflavor/pull/242>`_).
 - Fixed French FRNationalIdentificationNumber bug with corsican people born after 2000.
-  (`gh-242` <https://github.com/django/django-localflavor/pull/242>`_).
+  (`gh-242 <https://github.com/django/django-localflavor/pull/242>`_).
 - Fixed the translation for US state 'Georgia' from colliding with the country 'Georgia'
-  (`gh-250` <https://github.com/django/django-localflavor/pull/250>`_).
+  (`gh-250 <https://github.com/django/django-localflavor/pull/250>`_).
+- Fixed the styling errors and enabled prospector
+  (`gh-259 <https://github.com/django/django-localflavor/pull/259>`_).
 
 1.3   (2016-05-06)
 ------------------

--- a/docs/extensions/promises.py
+++ b/docs/extensions/promises.py
@@ -8,7 +8,9 @@ from django.utils.functional import Promise
 
 from sphinx.util.inspect import object_description
 
-list_or_tuple = lambda x: isinstance(x, (tuple, list))
+
+def list_or_tuple(obj):
+    return isinstance(obj, (tuple, list))
 
 
 def lazy_repr(obj):

--- a/localflavor.prospector.yaml
+++ b/localflavor.prospector.yaml
@@ -1,0 +1,13 @@
+inherits:
+  - strictness_high
+
+
+pylint:
+  options:
+    max-line-length: 120
+
+pep8:
+  options:
+    max-line-length: 120
+  disable:
+    - N802

--- a/localflavor/ar/forms.py
+++ b/localflavor/ar/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-AR-specific Form helpers.
-"""
+"""AR-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -14,10 +12,8 @@ from .ar_provinces import PROVINCE_CHOICES
 
 
 class ARProvinceSelect(Select):
-    """
-    A Select widget that uses a list of Argentinean provinces/autonomous cities
-    as its choices.
-    """
+    """A Select widget that uses a list of Argentinean provinces/autonomous cities as its choices."""
+
     def __init__(self, attrs=None):
         super(ARProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 
@@ -30,6 +26,7 @@ class ARPostalCodeField(RegexField):
         http://www.correoargentino.com.ar/cpa/que_es
         http://www.correoargentino.com.ar/cpa/como_escribirlo
     """
+
     default_error_messages = {
         'invalid': _("Enter a postal code in the format NNNN or ANNNNAAA."),
     }
@@ -51,9 +48,8 @@ class ARPostalCodeField(RegexField):
 
 
 class ARDNIField(CharField):
-    """
-    A field that validates 'Documento Nacional de Identidad' (DNI) numbers.
-    """
+    """A field that validates 'Documento Nacional de Identidad' (DNI) numbers."""
+
     default_error_messages = {
         'invalid': _("This field requires only numbers."),
         'max_digits': _("This field requires 7 or 8 digits."),
@@ -64,9 +60,7 @@ class ARDNIField(CharField):
                                          *args, **kwargs)
 
     def clean(self, value):
-        """
-        Value can be a string either in the [X]X.XXX.XXX or [X]XXXXXXX formats.
-        """
+        """Value can be a string either in the [X]X.XXX.XXX or [X]XXXXXXX formats."""
         value = super(ARDNIField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -82,8 +76,9 @@ class ARDNIField(CharField):
 
 class ARCUITField(RegexField):
     """
-    This field validates a CUIT (Código Único de Identificación Tributaria). A
-    CUIT is of the form XX-XXXXXXXX-V. The last digit is a check digit.
+    This field validates a CUIT (Código Único de Identificación Tributaria).
+
+    ACUIT is of the form XX-XXXXXXXX-V. The last digit is a check digit.
 
     More info:
     http://es.wikipedia.org/wiki/Clave_%C3%9Anica_de_Identificaci%C3%B3n_Tributaria
@@ -91,6 +86,7 @@ class ARCUITField(RegexField):
     English info:
     http://www.justlanded.com/english/Argentina/Argentina-Guide/Visas-Permits/Other-Legal-Documents
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid CUIT in XX-XXXXXXXX-X or XXXXXXXXXXXX format.'),
         'checksum': _("Invalid CUIT."),
@@ -102,10 +98,7 @@ class ARCUITField(RegexField):
                                           max_length, min_length, *args, **kwargs)
 
     def clean(self, value):
-        """
-        Value can be either a string in the format XX-XXXXXXXX-X or an
-        11-digit number.
-        """
+        """Value can be either a string in the format XX-XXXXXXXX-X or an 11-digit number."""
         value = super(ARCUITField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -141,15 +134,17 @@ class ARCUITField(RegexField):
 
 class ARCBUField(CharField):
     """
-    This field validates a CBU (Clave Bancaria Uniforme). A CBU is a 22-digits long
-    number. The first 8 digits denote bank and branch number, plus a verifying digit.
-    The remaining 14 digits denote an account number, plus a verifying digit.
+    This field validates a CBU (Clave Bancaria Uniforme).
+
+    A CBU is a 22-digits long number. The first 8 digits denote bank and branch number,
+    plus a verifying digit. The remaining 14 digits denote an account number, plus a verifying digit.
 
     More info:
     https://es.wikipedia.org/wiki/Clave_Bancaria_Uniforme
 
     .. versionadded:: 1.3
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid CBU in XXXXXXXXXXXXXXXXXXXXXX format.'),
         'max_length': _('CBU must be exactly 22 digits long.'),
@@ -179,17 +174,15 @@ class ARCBUField(CharField):
         block_1 = value[0:8]
         block_2 = value[8:22]
 
-        PONDERATOR_1 = (9, 7, 1, 3, 9, 7, 1, 3)
-        PONDERATOR_2 = (3, 9, 7, 1, 3, 9, 7, 1, 3, 9, 7, 1, 3)
+        ponderator_1 = (9, 7, 1, 3, 9, 7, 1, 3)
+        ponderator_2 = (3, 9, 7, 1, 3, 9, 7, 1, 3, 9, 7, 1, 3)
 
-        is_valid_1 = self._valid_block(block_1, PONDERATOR_1)
-        is_valid_2 = self._valid_block(block_2, PONDERATOR_2)
+        is_valid_1 = self._valid_block(block_1, ponderator_1)
+        is_valid_2 = self._valid_block(block_2, ponderator_2)
         return is_valid_1 and is_valid_2
 
     def clean(self, value):
-        """
-        Value must be a 22 digits long number.
-        """
+        """Value must be a 22 digits long number."""
         value = super(ARCBUField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''

--- a/localflavor/at/forms.py
+++ b/localflavor/at/forms.py
@@ -1,6 +1,4 @@
-"""
-AT-specific Form helpers
-"""
+"""AT-specific Form helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -21,6 +19,7 @@ class ATZipCodeField(RegexField):
 
     Accepts 4 digits (first digit must be greater than 0).
     """
+
     default_error_messages = {
         'invalid': _('Enter a zip code in the format XXXX.'),
     }
@@ -31,17 +30,17 @@ class ATZipCodeField(RegexField):
 
 
 class ATStateSelect(Select):
-    """
-    A ``Select`` widget that uses a list of AT states as its choices.
-    """
+    """A ``Select`` widget that uses a list of AT states as its choices."""
+
     def __init__(self, attrs=None):
         super(ATStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
 
 class ATSocialSecurityNumberField(Field):
     """
-    Austrian Social Security numbers are composed of a 4 digits and 6 digits
-    field. The latter represents in most cases the person's birthdate while
+    Austrian Social Security numbers are composed of a 4 digits and 6 digits field.
+
+    The latter represents in most cases the person's birthdate while
     the first 4 digits represent a 3-digits counter and a one-digit checksum.
 
     The 6-digits field can also differ from the person's birthdate if the
@@ -50,6 +49,7 @@ class ATSocialSecurityNumberField(Field):
     This code is based on information available on
     http://de.wikipedia.org/wiki/Sozialversicherungsnummer#.C3.96sterreich
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Austrian Social Security Number in XXXX XXXXXX format.'),
     }

--- a/localflavor/au/forms.py
+++ b/localflavor/au/forms.py
@@ -1,6 +1,4 @@
-"""
-Australian-specific Form helpers
-"""
+"""Australian-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -15,16 +13,17 @@ from django.utils.translation import ugettext_lazy as _
 from .au_states import STATE_CHOICES
 from .validators import AUBusinessNumberFieldValidator, AUTaxFileNumberFieldValidator
 
-
 PHONE_DIGITS_RE = re.compile(r'^(\d{10})$')
 
 
 class AUPostCodeField(RegexField):
-    """ Australian post code field.
+    """
+    Australian post code field.
 
     Assumed to be 4 digits.
     Northern Territory 3-digit postcodes should have leading zero.
     """
+
     default_error_messages = {
         'invalid': _('Enter a 4 digit postcode.'),
     }
@@ -40,14 +39,13 @@ class AUPhoneNumberField(CharField):
 
     Valid numbers have ten digits.
     """
+
     default_error_messages = {
         'invalid': 'Phone numbers must contain 10 digits.',
     }
 
     def clean(self, value):
-        """
-        Validate a phone number. Strips parentheses, whitespace and hyphens.
-        """
+        """Validate a phone number. Strips parentheses, whitespace and hyphens."""
         super(AUPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -59,17 +57,15 @@ class AUPhoneNumberField(CharField):
 
 
 class AUStateSelect(Select):
-    """
-    A Select widget that uses a list of Australian states/territories as its
-    choices.
-    """
+    """A Select widget that uses a list of Australian states/territories as its choices."""
+
     def __init__(self, attrs=None):
         super(AUStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
 
 class AUBusinessNumberField(CharField):
     """
-    A form field that validates input as an Australian Business Number (ABN)
+    A form field that validates input as an Australian Business Number (ABN).
 
     .. versionadded:: 1.3
     """
@@ -77,9 +73,7 @@ class AUBusinessNumberField(CharField):
     default_validators = [AUBusinessNumberFieldValidator()]
 
     def prepare_value(self, value):
-        """
-        Format the value for display.
-        """
+        """Format the value for display."""
         if value is None:
             return value
 
@@ -89,7 +83,7 @@ class AUBusinessNumberField(CharField):
 
 class AUTaxFileNumberField(CharField):
     """
-    A form field that validates input as an Australian Tax File Number (TFN)
+    A form field that validates input as an Australian Tax File Number (TFN).
 
     .. versionadded:: 1.4
     """
@@ -97,9 +91,7 @@ class AUTaxFileNumberField(CharField):
     default_validators = [AUTaxFileNumberFieldValidator()]
 
     def prepare_value(self, value):
-        """
-        Format the value for display.
-        """
+        """Format the value for display."""
         if value is None:
             return value
 

--- a/localflavor/au/models.py
+++ b/localflavor/au/models.py
@@ -8,10 +8,11 @@ from .validators import AUBusinessNumberFieldValidator, AUTaxFileNumberFieldVali
 
 class AUStateField(CharField):
     """
-    A model field that is represented with
-    :data:`~localflavor.au.au_states.STATE_CHOICES`` choices and
-    stores the three-letter Australian state abbreviation in the database.
+    A model field that stores the three-letter Australian state abbreviation in the database.
+
+    It is represented with :data:`~localflavor.au.au_states.STATE_CHOICES`` choices.
     """
+
     description = _("Australian State")
 
     def __init__(self, *args, **kwargs):
@@ -28,10 +29,11 @@ class AUStateField(CharField):
 
 class AUPostCodeField(CharField):
     """
-    A model field that forms represent as a
-    :class:`~localflavor.au.forms.AUPostCodeField` field and stores the
-    four-digit Australian postcode in the database.
+    A model field that stores the four-digit Australian postcode in the database.
+
+    This field is represented by forms as a :class:`~localflavor.au.forms.AUPostCodeField` field.
     """
+
     description = _("Australian Postcode")
 
     def __init__(self, *args, **kwargs):
@@ -50,10 +52,8 @@ class AUPostCodeField(CharField):
 
 
 class AUPhoneNumberField(CharField):
-    """
-    A model field that checks that the value is a valid Australian phone
-    number (ten digits).
-    """
+    """A model field that checks that the value is a valid Australian phone number (ten digits)."""
+
     description = _("Australian Phone number")
 
     def __init__(self, *args, **kwargs):
@@ -73,8 +73,7 @@ class AUPhoneNumberField(CharField):
 
 class AUBusinessNumberField(CharField):
     """
-    A model field that checks that the value is a valid Australian Business
-    Number (ABN).
+    A model field that checks that the value is a valid Australian Business Number (ABN).
 
     .. versionadded:: 1.3
     """
@@ -98,9 +97,7 @@ class AUBusinessNumberField(CharField):
         return super(AUBusinessNumberField, self).formfield(**defaults)
 
     def to_python(self, value):
-        """
-        Ensure the ABN is stored without spaces.
-        """
+        """Ensure the ABN is stored without spaces."""
         value = super(AUBusinessNumberField, self).to_python(value)
 
         if value is not None:
@@ -139,9 +136,7 @@ class AUTaxFileNumberField(CharField):
         return super(AUTaxFileNumberField, self).formfield(**defaults)
 
     def to_python(self, value):
-        """
-        Ensure the TFN is stored without spaces.
-        """
+        """Ensure the TFN is stored without spaces."""
         value = super(AUTaxFileNumberField, self).to_python(value)
 
         if value is not None:

--- a/localflavor/au/validators.py
+++ b/localflavor/au/validators.py
@@ -33,8 +33,8 @@ class AUBusinessNumberFieldValidator(RegexValidator):
         digits[0] -= 1
 
         # 2. Multiply each digit by its weighting factor.
-        WEIGHTING_FACTORS = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
-        weighted = [digit * weight for digit, weight in zip(digits, WEIGHTING_FACTORS)]
+        weighting_factors = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+        weighted = [digit * weight for digit, weight in zip(digits, weighting_factors)]
 
         # 3. Sum the resulting values.
         total = sum(weighted)
@@ -61,7 +61,7 @@ class AUTaxFileNumberFieldValidator(RegexValidator):
     error_message = _('Enter a valid TFN.')
 
     def __init__(self):
-        """ Regex for 8 to 9 digits """
+        """Regex for 8 to 9 digits."""
         super(AUTaxFileNumberFieldValidator, self).__init__(
             regex='^\d{8,9}$', message=self.error_message)
 
@@ -75,8 +75,8 @@ class AUTaxFileNumberFieldValidator(RegexValidator):
         """
         # 1. Multiply each digit by its weighting factor.
         digits = [int(i) for i in list(value)]
-        WEIGHTING_FACTORS = [1, 4, 3, 7, 5, 8, 6, 9, 10]
-        weighted = [digit * weight for digit, weight in zip(digits, WEIGHTING_FACTORS)]
+        weighting_factors = [1, 4, 3, 7, 5, 8, 6, 9, 10]
+        weighted = [digit * weight for digit, weight in zip(digits, weighting_factors)]
 
         # 2. Sum the resulting values.
         total = sum(weighted)

--- a/localflavor/be/forms.py
+++ b/localflavor/be/forms.py
@@ -1,6 +1,4 @@
-"""
-Belgium-specific Form helpers
-"""
+"""Belgium-specific Form helpers."""
 
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
@@ -19,6 +17,7 @@ class BEPostalCodeField(RegexField):
     are shared by the Brussels Capital Region, the western part of
     Flemish Brabant and Walloon Brabant)
     """
+
     default_error_messages = {
         'invalid': _(
             'Enter a valid postal code in the range and format 1XXX - 9XXX.'),
@@ -44,6 +43,7 @@ class BEPhoneNumberField(RegexField):
     04dd ddd dd dd, 04dd/ddd.dd.dd,
     04dd.ddd.dd.dd, 04ddddddddd - dialling a mobile number
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid phone number in one of the formats '
                      '0x xxx xx xx, 0xx xx xx xx, 04xx xx xx xx, '
@@ -53,22 +53,27 @@ class BEPhoneNumberField(RegexField):
     }
 
     def __init__(self, max_length=None, min_length=None, *args, **kwargs):
-        super(BEPhoneNumberField, self).__init__(r'^[0]\d{1}[/. ]?\d{3}[. ]\d{2}[. ]?\d{2}$|^[0]\d{2}[/. ]?\d{2}[. ]?\d{2}[. ]?\d{2}$|^[0][4]\d{2}[/. ]?\d{2}[. ]?\d{2}[. ]?\d{2}$',
+        super(BEPhoneNumberField, self).__init__(r'^[0]\d{1}[/. ]?'
+                                                 r'\d{3}[. ]\d{2}[. ]?'
+                                                 r'\d{2}$|^[0]\d{2}[/. ]?'
+                                                 r'\d{2}[. ]?\d{2}[. ]?'
+                                                 r'\d{2}$|^[0][4]\d{2}[/. ]?'
+                                                 r'\d{2}[. ]?'
+                                                 r'\d{2}[. ]?'
+                                                 r'\d{2}$',
                                                  max_length, min_length,
                                                  *args, **kwargs)
 
 
 class BERegionSelect(Select):
-    """
-    A Select widget that uses a list of belgium regions as its choices.
-    """
+    """A Select widget that uses a list of belgium regions as its choices."""
+
     def __init__(self, attrs=None):
         super(BERegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
 class BEProvinceSelect(Select):
-    """
-    A Select widget that uses a list of belgium provinces as its choices.
-    """
+    """A Select widget that uses a list of belgium provinces as its choices."""
+
     def __init__(self, attrs=None):
         super(BEProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)

--- a/localflavor/bg/models.py
+++ b/localflavor/bg/models.py
@@ -5,12 +5,13 @@ from .validators import egn_validator, eik_validator
 
 class BGEGNField(models.CharField):
     """
-    Field that stores Bulgarian unique citizenship number (EGN)
+    Field that stores Bulgarian unique citizenship number (EGN).
 
     This is shortcut for::
 
         models.CharField(max_length=10, validators=[localflavor.bg.validators.egn_validator])
     """
+
     default_validators = models.CharField.default_validators + [egn_validator]
 
     def __init__(self, *args, **kwargs):
@@ -25,12 +26,13 @@ class BGEGNField(models.CharField):
 
 class BGEIKField(models.CharField):
     """
-    Field that stores Bulgarian EIK/BULSTAT codes
+    Field that stores Bulgarian EIK/BULSTAT codes.
 
     This is shortcut for::
 
         models.CharField(max_length=13, validators=[localflavor.bg.validators.eik_validator])
     """
+
     default_validators = models.CharField.default_validators + [eik_validator]
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/bg/utils.py
+++ b/localflavor/bg/utils.py
@@ -3,7 +3,8 @@ import datetime
 
 def get_egn_birth_date(egn):
     """
-    Extract birth date from Bulgarian unique citizenship number (EGN)
+    Extract birth date from Bulgarian unique citizenship number (EGN).
+
     More details https://en.wikipedia.org/wiki/Unique_citizenship_number
     Information in Bulgarian for this can be found here
     http://www.grao.bg/esgraon.html#section2

--- a/localflavor/bg/validators.py
+++ b/localflavor/bg/validators.py
@@ -6,7 +6,8 @@ from .utils import get_egn_birth_date
 
 def egn_validator(egn):
     """
-    Check Bulgarian unique citizenship number (EGN) for validity
+    Check Bulgarian unique citizenship number (EGN) for validity.
+
     More details https://en.wikipedia.org/wiki/Unique_citizenship_number
     Full information in Bulgarian about algorithm is available here
     http://www.grao.bg/esgraon.html#section2
@@ -31,8 +32,9 @@ def egn_validator(egn):
 
 def eik_validator(eik):
     """
-    Check Bulgarian EIK/BULSTAT codes for validity
-    full information in Bulgarian about algorithm is available here
+    Check Bulgarian EIK/BULSTAT codes for validity.
+
+    Full information in Bulgarian about algorithm is available here
     http://bulstat.registryagency.bg/About.html
     """
     error_message = _('EIK/BULSTAT is not valid')

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-BR-specific Form helpers
-"""
+"""BR-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -26,10 +24,8 @@ process_digits_re = re.compile(
 
 
 class BRZipCodeField(RegexField):
-    """
-    A form field that validates input as a Brazilian zip code, with the format
-    XXXXX-XXX.
-    """
+    """A form field that validates input as a Brazilian zip code, with the format XXXXX-XXX."""
+
     default_error_messages = {
         'invalid': _('Enter a zip code in the format XXXXX-XXX.'),
     }
@@ -41,9 +37,11 @@ class BRZipCodeField(RegexField):
 
 class BRPhoneNumberField(Field):
     """
-    A form field that validates input as a Brazilian phone number, that must
-    be in either of the following formats: XX-XXXX-XXXX or XX-XXXXX-XXXX.
+    A form field that validates input as a Brazilian phone number.
+
+    The phone number must be in either of the following formats: XX-XXXX-XXXX or XX-XXXXX-XXXX.
     """
+
     default_error_messages = {
         'invalid': _(('Phone numbers must be in either of the following '
                       'formats: XX-XXXX-XXXX or XX-XXXXX-XXXX.')),
@@ -61,28 +59,22 @@ class BRPhoneNumberField(Field):
 
 
 class BRStateSelect(Select):
-    """
-    A Select widget that uses a list of Brazilian states/territories
-    as its choices.
-    """
+    """A Select widget that uses a list of Brazilian states/territories as its choices."""
+
     def __init__(self, attrs=None):
         super(BRStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
 
 class BRStateChoiceField(Field):
+    """A choice field that uses a list of Brazilian states as its choices."""
 
-    """
-    A choice field that uses a list of Brazilian states as its choices.
-    """
     widget = Select
     default_error_messages = {
         'invalid': _('Select a valid brazilian state. That state is not one of the available states.'),
     }
 
-    def __init__(self, required=True, widget=None, label=None,
-                 initial=None, help_text=None):
-        super(BRStateChoiceField, self).__init__(required, widget, label,
-                                                 initial, help_text)
+    def __init__(self, required=True, widget=None, label=None, initial=None, help_text=None):
+        super(BRStateChoiceField, self).__init__(required, widget, label, initial, help_text)
         self.widget.choices = STATE_CHOICES
 
     def clean(self, value):
@@ -92,26 +84,33 @@ class BRStateChoiceField(Field):
         value = force_text(value)
         if value == '':
             return value
-        valid_values = set([force_text(k) for k, v in self.widget.choices])
+        valid_values = set([force_text(entry[0]) for entry in self.widget.choices])
         if value not in valid_values:
             raise ValidationError(self.error_messages['invalid'])
         return value
 
 
-def DV_maker(v):
+def dv_maker(v):
     if v >= 2:
         return 11 - v
     return 0
 
 
+# TODO deprecate function because it's name is not PEP8 compliant, issue #258
+def DV_maker(v):  # noqa
+    return dv_maker(v)
+
+
 class BRCPFField(CharField):
     """
-    A form field that validates a CPF number or a CPF string. A CPF number is
-    compounded by XXX.XXX.XXX-VD. The two last digits are check digits.
+    A form field that validates a CPF number or a CPF string.
+
+    A CPF number is compounded by XXX.XXX.XXX-VD. The two last digits are check digits.
 
     More information:
     http://en.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas
     """
+
     default_error_messages = {
         'invalid': _("Invalid CPF number."),
         'max_digits': _("This field requires at most 11 digits or 14 characters."),
@@ -121,10 +120,7 @@ class BRCPFField(CharField):
         super(BRCPFField, self).__init__(max_length, min_length, *args, **kwargs)
 
     def clean(self, value):
-        """
-        Value can be either a string in the format XXX.XXX.XXX-XX or an
-        11-digit number.
-        """
+        """Value can be either a string in the format XXX.XXX.XXX-XX or an 11-digit number."""
         value = super(BRCPFField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -142,11 +138,11 @@ class BRCPFField(CharField):
 
         new_1dv = sum([i * int(value[idx])
                       for idx, i in enumerate(range(10, 1, -1))])
-        new_1dv = DV_maker(new_1dv % 11)
+        new_1dv = dv_maker(new_1dv % 11)
         value = value[:-2] + str(new_1dv) + value[-1]
         new_2dv = sum([i * int(value[idx])
                       for idx, i in enumerate(range(11, 1, -1))])
-        new_2dv = DV_maker(new_2dv % 11)
+        new_2dv = dv_maker(new_2dv % 11)
         value = value[:-1] + str(new_2dv)
         if value[-2:] != orig_dv:
             raise ValidationError(self.error_messages['invalid'])
@@ -165,16 +161,14 @@ class BRCNPJField(Field):
     .. _Brazilian CNPJ: http://en.wikipedia.org/wiki/National_identification_number#Brazil
 
     """
+
     default_error_messages = {
         'invalid': _("Invalid CNPJ number."),
         'max_digits': _("This field requires at least 14 digits"),
     }
 
     def clean(self, value):
-        """
-        Value can be either a string in the format XX.XXX.XXX/XXXX-XX or a
-        group of 14 characters.
-        """
+        """Value can be either a string in the format XX.XXX.XXX/XXXX-XX or a group of 14 characters."""
         value = super(BRCNPJField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -191,10 +185,10 @@ class BRCNPJField(Field):
         orig_dv = value[-2:]
 
         new_1dv = sum([i * int(value[idx]) for idx, i in enumerate(list(range(5, 1, -1)) + list(range(9, 1, -1)))])
-        new_1dv = DV_maker(new_1dv % 11)
+        new_1dv = dv_maker(new_1dv % 11)
         value = value[:-2] + str(new_1dv) + value[-1]
         new_2dv = sum([i * int(value[idx]) for idx, i in enumerate(list(range(6, 1, -1)) + list(range(9, 1, -1)))])
-        new_2dv = DV_maker(new_2dv % 11)
+        new_2dv = dv_maker(new_2dv % 11)
         value = value[:-1] + str(new_2dv)
         if value[-2:] != orig_dv:
             raise ValidationError(self.error_messages['invalid'])
@@ -209,23 +203,21 @@ def mod_97_base10(value):
 class BRProcessoField(CharField):
     """
     A form field that validates a Legal Process(Processo) number or a Legal Process string.
-    A Processo number is
-    compounded by NNNNNNN-DD.AAAA.J.TR.OOOO. The two DD digits are check digits.
+
+    A Processo number is compounded by NNNNNNN-DD.AAAA.J.TR.OOOO. The two DD digits are check digits.
     More information:
     http://www.cnj.jus.br/busca-atos-adm?documento=2748
 
     .. versionadded:: 1.2
     """
+
     default_error_messages = {'invalid': _("Invalid Process number.")}
 
     def __init__(self, max_length=25, min_length=20, *args, **kwargs):
         super(BRProcessoField, self).__init__(max_length, min_length, *args, **kwargs)
 
     def clean(self, value):
-        """
-        Value can be either a string in the format NNNNNNN-DD.AAAA.J.TR.OOOO or
-        an 20-digit number.
-        """
+        """Value can be either a string in the format NNNNNNN-DD.AAAA.J.TR.OOOO or an 20-digit number."""
         value = super(BRProcessoField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''

--- a/localflavor/br/models.py
+++ b/localflavor/br/models.py
@@ -5,9 +5,8 @@ from .br_states import STATE_CHOICES
 
 
 class BRStateField(CharField):
-    """
-    A model field for states of Brazil
-    """
+    """A model field for states of Brazil."""
+
     description = _("State of Brazil (two uppercase letters)")
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/ca/forms.py
+++ b/localflavor/ca/forms.py
@@ -1,6 +1,4 @@
-"""
-Canada-specific Form helpers
-"""
+"""Canada-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -27,6 +25,7 @@ class CAPostalCodeField(CharField):
     For more info see:
     http://www.canadapost.ca/tools/pg/manual/PGaddress-e.asp#1402170
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXX XXX.'),
     }
@@ -47,6 +46,7 @@ class CAPostalCodeField(CharField):
 
 class CAPhoneNumberField(Field):
     """Canadian phone number form field."""
+
     default_error_messages = {
         'invalid': _('Phone numbers must be in XXX-XXX-XXXX format.'),
     }
@@ -65,9 +65,11 @@ class CAPhoneNumberField(Field):
 class CAProvinceField(Field):
     """
     A form field that validates its input is a Canadian province name or abbreviation.
+
     It normalizes the input to the standard two-leter postal service
     abbreviation for the given province.
     """
+
     default_error_messages = {
         'invalid': _('Enter a Canadian province or territory.'),
     }
@@ -91,10 +93,8 @@ class CAProvinceField(Field):
 
 
 class CAProvinceSelect(Select):
-    """
-    A Select widget that uses a list of Canadian provinces and
-    territories as its choices.
-    """
+    """A Select widget that uses a list of Canadian provinces and territories as its choices."""
+
     def __init__(self, attrs=None):
         # Load data in memory only when it is required, see also #17275
         from .ca_provinces import PROVINCE_CHOICES
@@ -113,6 +113,7 @@ class CASocialInsuranceNumberField(Field):
          See: http://en.wikipedia.org/wiki/Social_Insurance_Number
 
     """
+
     default_error_messages = {
         'invalid': _(
             'Enter a valid Canadian Social Insurance number in XXX-XXX-XXX format.'),

--- a/localflavor/ch/forms.py
+++ b/localflavor/ch/forms.py
@@ -1,6 +1,4 @@
-"""
-Swiss-specific Form helpers
-"""
+"""Swiss-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -24,8 +22,9 @@ ssn_re = re.compile(r'^756.\d{4}\.\d{4}\.\d{2}$')
 
 class CHZipCodeField(RegexField):
     """
-    A form field that validates input as a Swiss zip code. Valid codes
-    consist of four digits ranging from 1XXX to 9XXX.
+    A form field that validates input as a Swiss zip code.
+
+    Valid codes consist of four digits ranging from 1XXX to 9XXX.
 
     See:
     http://en.wikipedia.org/wiki/Postal_codes_in_Switzerland_and_Liechtenstein
@@ -41,11 +40,13 @@ class CHZipCodeField(RegexField):
 
 class CHPhoneNumberField(Field):
     """
-    Validate local Swiss phone number (not international ones)
+    Validate local Swiss phone number (not international ones).
+
     The correct format is '0XX XXX XX XX'.
     '0XX.XXX.XX.XX' and '0XXXXXXXXX' validate but are corrected to
     '0XX XXX XX XX'.
     """
+
     default_error_messages = {
         'invalid': _('Phone numbers must be in 0XX XXX XX XX format.'),
     }
@@ -62,9 +63,8 @@ class CHPhoneNumberField(Field):
 
 
 class CHStateSelect(Select):
-    """
-    A Select widget that uses a list of CH states as its choices.
-    """
+    """A Select widget that uses a list of CH states as its choices."""
+
     def __init__(self, attrs=None):
         super(CHStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
@@ -79,6 +79,7 @@ class CHIdentityCardNumberField(Field):
         * Included checksums match calculated checksums
 
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Swiss identity or passport card number in X1234567<0 or 1234567890 format.'),
     }
@@ -87,7 +88,6 @@ class CHIdentityCardNumberField(Field):
         given_number, given_checksum = number[:-1], number[-1]
         new_number = given_number
         calculated_checksum = 0
-        fragment = ""
         parameter = 7
 
         first = str(number[:1])
@@ -101,8 +101,8 @@ class CHIdentityCardNumberField(Field):
         if not new_number.isdigit():
             return False
 
-        for i in range(len(new_number)):
-            fragment = int(new_number[i]) * parameter
+        for digit in new_number:
+            fragment = int(digit) * parameter
             calculated_checksum += fragment
 
             if parameter == 1:
@@ -151,6 +151,7 @@ class CHSocialSecurityNumberField(CharField):
 
     .. versionadded:: 1.2
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Swiss Social Security number in 756.XXXX.XXXX.XX format.'),
     }

--- a/localflavor/cl/forms.py
+++ b/localflavor/cl/forms.py
@@ -1,6 +1,4 @@
-"""
-Chile specific form helpers.
-"""
+"""Chile specific form helpers."""
 
 from __future__ import unicode_literals
 
@@ -14,22 +12,22 @@ from .cl_regions import REGION_CHOICES
 
 
 class CLRegionSelect(Select):
-    """
-    A Select widget that uses a list of Chilean Regions (Regiones)
-    as its choices.
-    """
+    """A Select widget that uses a list of Chilean Regions (Regiones) as its choices."""
+
     def __init__(self, attrs=None):
         super(CLRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
 class CLRutField(RegexField):
     """
-    Chilean "Rol Unico Tributario" (RUT) field. This is the Chilean national
-    identification number.
+    Chilean "Rol Unico Tributario" (RUT) field.
+
+    This is the Chilean national identification number.
 
     Samples for testing are available from
     https://palena.sii.cl/cvc/dte/ee_empresas_emisoras.html
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Chilean RUT.'),
         'strict': _('Enter a valid Chilean RUT. The format is XX.XXX.XXX-X.'),
@@ -48,9 +46,7 @@ class CLRutField(RegexField):
             super(CLRutField, self).__init__(r'^[\d\.]{1,11}-?[\dkK]$', *args, **kwargs)
 
     def clean(self, value):
-        """
-        Check and clean the Chilean RUT.
-        """
+        """Check and clean the Chilean RUT."""
         super(CLRutField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -61,9 +57,7 @@ class CLRutField(RegexField):
             raise ValidationError(self.error_messages['checksum'])
 
     def _algorithm(self, rut):
-        """
-        Takes RUT in pure canonical form, calculates the verifier digit.
-        """
+        """Takes RUT in pure canonical form, calculates the verifier digit."""
         suma = 0
         multi = 2
         for r in rut[::-1]:
@@ -74,16 +68,14 @@ class CLRutField(RegexField):
         return '0123456789K0'[11 - suma % 11]
 
     def _canonify(self, rut):
-        """
-        Turns the RUT into one normalized format. Returns a (rut, verifier)
-        tuple.
-        """
+        """Turns the RUT into one normalized format. Returns a (rut, verifier) tuple."""
         rut = force_text(rut).replace(' ', '').replace('.', '').replace('-', '')
         return rut[:-1], rut[-1].upper()
 
     def _format(self, code, verifier=None):
         """
         Formats the RUT from canonical form to the common string representation.
+
         If verifier=None, then the last digit in 'code' is the verifier.
         """
         if verifier is None:

--- a/localflavor/cn/forms.py
+++ b/localflavor/cn/forms.py
@@ -1,6 +1,4 @@
-"""
-China(mainland)-specific Form helpers
-"""
+"""China(mainland)-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -66,10 +64,8 @@ CN_LOCATION_CODES = (
 
 
 class CNProvinceSelect(Select):
-    """
-    A select widget providing the list of provinces and districts
-    in People's Republic of China as choices.
-    """
+    """A select widget providing the list of provinces and districts in People's Republic of China as choices."""
+
     def __init__(self, attrs=None):
         super(CNProvinceSelect, self).__init__(attrs, choices=CN_PROVINCE_CHOICES)
 
@@ -77,8 +73,10 @@ class CNProvinceSelect(Select):
 class CNPostCodeField(RegexField):
     """
     A form field that validates input as postal codes in mainland China.
+
     Valid codes are in the format of XXXXXX where X is a digit.
     """
+
     default_error_messages = {
         'invalid': _('Enter a post code in the format XXXXXX.'),
     }
@@ -101,6 +99,7 @@ class CNIDCardField(CharField):
     The checksum algorithm is described in GB11643-1999.
     See: http://en.wikipedia.org/wiki/Resident_Identity_Card#Identity_card_number
     """
+
     default_error_messages = {
         'invalid': _('ID Card Number consists of 15 or 18 digits.'),
         'checksum': _('Invalid ID Card Number: Wrong checksum'),
@@ -112,9 +111,7 @@ class CNIDCardField(CharField):
         super(CNIDCardField, self).__init__(max_length, min_length, *args, **kwargs)
 
     def clean(self, value):
-        """
-        Check whether the input is a valid ID Card Number.
-        """
+        """Check whether the input is a valid ID Card Number."""
         # Check the length of the ID card number.
         super(CNIDCardField, self).clean(value)
         if not value:
@@ -135,10 +132,7 @@ class CNIDCardField(CharField):
         return '%s' % value
 
     def has_valid_birthday(self, value):
-        """
-        This method would grab the date of birth from the ID card number and
-        test whether it is a valid date.
-        """
+        """This method grabs the date of birth from the ID card number and test whether it is a valid date."""
         from datetime import datetime
         if len(value) == 15:
             # 1st generation ID card
@@ -156,17 +150,11 @@ class CNIDCardField(CharField):
             return False
 
     def has_valid_location(self, value):
-        """
-        This method checks if the first two digits in the ID Card are
-        valid province code.
-        """
+        """This method checks if the first two digits in the ID Card are valid province code."""
         return int(value[:2]) in CN_LOCATION_CODES
 
     def has_valid_checksum(self, value):
-        """
-        This method checks if the last letter/digit is valid according to
-        GB11643-1999.
-        """
+        """This method checks if the last letter/digit is valid according to GB11643-1999."""
         # If the length of the number is not 18, then the number is a 1st
         # generation ID card number, and there is no checksum to be checked.
         if len(value) != 18:
@@ -182,11 +170,11 @@ class CNIDCardField(CharField):
 class CNPhoneNumberField(RegexField):
     """
     A form field that validates input as a telephone number in mainland China.
-    A valid phone number could be like: 010-12345678.
 
-    Considering there might be extension numbers,
-    this could also be: 010-12345678-35.
+    A valid phone number could be like: 010-12345678.
+    Considering there might be extension numbers, this could also be: 010-12345678-35.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid phone number.'),
     }
@@ -198,6 +186,7 @@ class CNPhoneNumberField(RegexField):
 class CNCellNumberField(RegexField):
     """
     A form field that validates input as a cellphone number in mainland China.
+
     A valid cellphone number could be like: 13012345678.
 
     A very rough rule is used here: the first digit should be 1, the second
@@ -209,6 +198,7 @@ class CNCellNumberField(RegexField):
        Added 7 as a valid second digit for Chinese virtual mobile ISPs.
 
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid cell number.'),
     }

--- a/localflavor/co/forms.py
+++ b/localflavor/co/forms.py
@@ -1,6 +1,4 @@
-"""
-Colombian-specific form helpers.
-"""
+"""Colombian-specific form helpers."""
 
 from django.forms.fields import Select
 
@@ -8,8 +6,7 @@ from .co_departments import DEPARTMENT_CHOICES
 
 
 class CODepartmentSelect(Select):
-    """
-    A Select widget that uses a list of Colombian states as its choices.
-    """
+    """A Select widget that uses a list of Colombian states as its choices."""
+
     def __init__(self, attrs=None):
         super(CODepartmentSelect, self).__init__(attrs, choices=DEPARTMENT_CHOICES)

--- a/localflavor/cz/forms.py
+++ b/localflavor/cz/forms.py
@@ -1,6 +1,4 @@
-"""
-Czech-specific form helpers
-"""
+"""Czech-specific form helpers."""
 
 from __future__ import unicode_literals
 
@@ -18,9 +16,8 @@ ic_number = re.compile(r'^(?P<number>\d{7})(?P<check>\d)$')
 
 
 class CZRegionSelect(Select):
-    """
-    A select widget widget with list of Czech regions as choices.
-    """
+    """A select widget widget with list of Czech regions as choices."""
+
     def __init__(self, attrs=None):
         super(CZRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
@@ -28,8 +25,10 @@ class CZRegionSelect(Select):
 class CZPostalCodeField(RegexField):
     """
     A form field that validates its input as Czech postal code.
+
     Valid form is XXXXX or XXX XX, where X represents integer.
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXXXX or XXX XX.'),
     }
@@ -41,6 +40,7 @@ class CZPostalCodeField(RegexField):
     def clean(self, value):
         """
         Validates the input and returns a string that contains only numbers.
+
         Returns an empty string for empty values.
         """
         v = super(CZPostalCodeField, self).clean(value)
@@ -48,9 +48,8 @@ class CZPostalCodeField(RegexField):
 
 
 class CZBirthNumberField(Field):
-    """
-    Czech birth number form field.
-    """
+    """Czech birth number form field."""
+
     default_error_messages = {
         'invalid_format': _('Enter a birth number in the format XXXXXX/XXXX or XXXXXXXXXX.'),
         'invalid': _('Enter a valid birth number.'),
@@ -99,9 +98,8 @@ class CZBirthNumberField(Field):
 
 
 class CZICNumberField(Field):
-    """
-    Czech IC number form field.
-    """
+    """Czech IC number form field."""
+
     default_error_messages = {
         'invalid': _('Enter a valid IC number.'),
     }
@@ -119,13 +117,13 @@ class CZICNumberField(Field):
         number, check = match.groupdict()[
             'number'], int(match.groupdict()['check'])
 
-        sum = 0
+        weighted_sum = 0
         weight = 8
         for digit in number:
-            sum += int(digit) * weight
+            weighted_sum += int(digit) * weight
             weight -= 1
 
-        remainder = sum % 11
+        remainder = weighted_sum % 11
 
         # remainder is equal:
         #  0 or 10: last digit is 1

--- a/localflavor/de/forms.py
+++ b/localflavor/de/forms.py
@@ -58,7 +58,6 @@ class DEIdentityCardNumberField(Field):
     def has_valid_checksum(self, number):
         given_number, given_checksum = number[:-1], number[-1]
         calculated_checksum = 0
-        fragment = ""
         parameter = 7
 
         for item in given_number:

--- a/localflavor/dk/forms.py
+++ b/localflavor/dk/forms.py
@@ -1,6 +1,4 @@
-"""
-Denmark specific Form helpers.
-"""
+"""Denmark specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -13,22 +11,19 @@ from .dk_postalcodes import DK_POSTALCODES
 
 
 def postal_code_validator(value):
-    if value not in [zip for zip, city in DK_POSTALCODES]:
+    if value not in [entry[0] for entry in DK_POSTALCODES]:
         raise ValidationError(_('Enter a postal code in the format XXXX.'))
 
 
 class DKPostalCodeField(fields.CharField):
-    """
-    An Input widget that uses a list of Danish postal codes as valid input.
-    """
+    """An Input widget that uses a list of Danish postal codes as valid input."""
+
     default_validators = [postal_code_validator]
 
 
 class DKMunicipalitySelect(widgets.Select):
-    """
-    A Select widget that uses a list of Danish municipalities (kommuner)
-    as its choices.
-    """
+    """A Select widget that uses a list of Danish municipalities (kommuner) as its choices."""
+
     def __init__(self, attrs=None, *args, **kwargs):
         super(DKMunicipalitySelect, self).__init__(
             attrs,
@@ -40,9 +35,11 @@ class DKMunicipalitySelect(widgets.Select):
 
 class DKPhoneNumberField(fields.RegexField):
     """
-    Field with phone number validation. Requires a phone number with
-    8 digits and optional country code
+    Field with phone number validation.
+
+    Requires a phone number with 8 digits and optional country code.
     """
+
     default_error_messages = {
         'invalid': _(
             'A phone number must be 8 digits and may have country code'

--- a/localflavor/ec/forms.py
+++ b/localflavor/ec/forms.py
@@ -1,14 +1,11 @@
-"""
-Ecuador-specific form helpers.
-"""
+"""Ecuador-specific form helpers."""
 from django.forms.fields import Select
 
 from .ec_provinces import PROVINCE_CHOICES
 
 
 class ECProvinceSelect(Select):
-    """
-    A Select widget that uses a list of Ecuador provinces as its choices.
-    """
+    """A Select widget that uses a list of Ecuador provinces as its choices."""
+
     def __init__(self, attrs=None):
         super(ECProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)

--- a/localflavor/ec/models.py
+++ b/localflavor/ec/models.py
@@ -6,11 +6,11 @@ from .ec_provinces import PROVINCE_CHOICES
 
 class ECProvinceField(CharField):
     """
-    A model field that represents an Ecuadorian province and stores its
-    abbreviation.
+    A model field that represents an Ecuadorian province and stores its abbreviation.
 
     .. versionadded:: 1.2
     """
+
     description = _("Ecuadorian province")
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/ee/forms.py
+++ b/localflavor/ee/forms.py
@@ -17,9 +17,11 @@ bregcode = re.compile(r'^[1-9]\d{7}$')
 
 class EEZipCodeField(RegexField):
     """
-    A form field that validates input as a Estonian zip code. Valid codes
-    consist of five digits; first digit cannot be 0.
+    A form field that validates input as a Estonian zip code.
+
+    Valid codes consist of five digits; first digit cannot be 0.
     """
+
     default_error_messages = {
         'invalid': _('Enter a zip code in the format XXXXX.'),
     }
@@ -29,9 +31,8 @@ class EEZipCodeField(RegexField):
 
 
 class EECountySelect(Select):
-    """
-    A Select widget that uses a list of Estonian counties as its choices.
-    """
+    """A Select widget that uses a list of Estonian counties as its choices."""
+
     def __init__(self, attrs=None):
         super(EECountySelect, self).__init__(attrs, choices=COUNTY_CHOICES)
 
@@ -41,6 +42,7 @@ class EEPersonalIdentificationCode(Field):
 
     See: https://www.riigiteataja.ee/akt/106032012004
     """
+
     default_error_messages = {
         'invalid_format': _('Enter an 11-digit Estonian personal identification code.'),
         'invalid': _('Enter a valid Estonian personal identification code.'),
@@ -49,7 +51,6 @@ class EEPersonalIdentificationCode(Field):
     @staticmethod
     def ee_checksum(value):
         """Takes a string of digits as input, returns check digit."""
-
         for i in (1, 3):
             check = 0
             for c in value:
@@ -91,11 +92,11 @@ class EEPersonalIdentificationCode(Field):
 
 
 class EEBusinessRegistryCode(Field):
-    """A form field that validates input as an
-    Estonian business registration code.
+    """A form field that validates input as an Estonian business registration code.
 
     .. versionadded:: 1.2
     """
+
     default_error_messages = {
         'invalid_format': _('Enter an 8-digit Estonian business registry code.'),
         'invalid': _('Enter a valid Estonian business registry code.'),

--- a/localflavor/es/forms.py
+++ b/localflavor/es/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Spanish-specific Form helpers
-"""
+"""Spanish-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -24,6 +22,7 @@ class ESPostalCodeField(RegexField):
     Spanish postal code is a five digits string, with two first digits
     between 01 and 52, assigned to provinces code.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid postal code in the range and format 01XXX - 52XXX.'),
     }
@@ -37,6 +36,7 @@ class ESPostalCodeField(RegexField):
 class ESPhoneNumberField(RegexField):
     """
     A form field that validates its input as a Spanish phone number.
+
     Information numbers are ommited.
 
     Spanish phone numbers are nine digit numbers, where first digit is 6 (for
@@ -45,6 +45,7 @@ class ESPhoneNumberField(RegexField):
 
     TODO: accept and strip characters like dot, hyphen... in phone number
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid phone number in one of the formats 6XXXXXXXX, 8XXXXXXXX or 9XXXXXXXX.'),
     }
@@ -78,6 +79,7 @@ class ESIdentityCardNumberField(RegexField):
     .. versionchanged:: 1.1
 
     """
+
     default_error_messages = {
         'invalid': _('Please enter a valid NIF, NIE, or CIF.'),
         'invalid_only_nif': _('Please enter a valid NIF or NIE.'),
@@ -146,8 +148,7 @@ class ESIdentityCardNumberField(RegexField):
 
 class ESCCCField(RegexField):
     """
-    A form field that validates its input as a Spanish bank account or CCC
-    (Codigo Cuenta Cliente).
+    A form field that validates its input as a Spanish bank account or CCC (Codigo Cuenta Cliente).
 
         Spanish CCC is in format EEEE-OOOO-CC-AAAAAAAAAA where:
 
@@ -167,6 +168,7 @@ class ESCCCField(RegexField):
 
         TODO: allow IBAN validation too
     """
+
     default_error_messages = {
         'invalid': _('Please enter a valid bank account number in format XXXX-XXXX-XX-XXXXXXXXXX.'),
         'checksum': _('Invalid checksum for bank account number.'),
@@ -195,17 +197,15 @@ def get_checksum(d):
 
 
 class ESRegionSelect(Select):
-    """
-    A Select widget that uses a list of spanish regions as its choices.
-    """
+    """A Select widget that uses a list of spanish regions as its choices."""
+
     def __init__(self, attrs=None):
         super(ESRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
 class ESProvinceSelect(Select):
-    """
-    A Select widget that uses a list of spanish provinces as its choices.
-    """
+    """A Select widget that uses a list of spanish provinces as its choices."""
+
     def __init__(self, attrs=None):
         super(ESProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 

--- a/localflavor/fi/forms.py
+++ b/localflavor/fi/forms.py
@@ -1,6 +1,4 @@
-"""
-FI-specific Form helpers
-"""
+"""FI-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -16,9 +14,11 @@ from .fi_municipalities import MUNICIPALITY_CHOICES
 
 class FIZipCodeField(RegexField):
     """
-    A form field that validates input as a Finnish zip code. Valid codes
-    consist of five digits.
+    A form field that validates input as a Finnish zip code.
+
+    Valid codes consist of five digits.
     """
+
     default_error_messages = {
         'invalid': _('Enter a zip code in the format XXXXX.'),
     }
@@ -29,15 +29,15 @@ class FIZipCodeField(RegexField):
 
 
 class FIMunicipalitySelect(Select):
-    """
-    A Select widget that uses a list of Finnish municipalities as its choices.
-    """
+    """A Select widget that uses a list of Finnish municipalities as its choices."""
+
     def __init__(self, attrs=None):
         super(FIMunicipalitySelect, self).__init__(attrs, choices=MUNICIPALITY_CHOICES)
 
 
 class FISocialSecurityNumber(Field):
     """A form field that validates input as a Finnish social security number."""
+
     default_error_messages = {
         'invalid': _('Enter a valid Finnish social security number.'),
     }

--- a/localflavor/fr/models.py
+++ b/localflavor/fr/models.py
@@ -4,11 +4,11 @@ from django.utils.translation import ugettext_lazy as _
 
 class FRSIRENField(CharField):
     """
-    A :class:`~django.db.models.CharField` that checks that the value
-    is a valid French SIREN number
+    A :class:`~django.db.models.CharField` that checks that the value is a valid French SIREN number.
 
     .. versionadded:: 1.1
     """
+
     description = _("SIREN Number")
 
     def __init__(self, *args, **kwargs):
@@ -29,11 +29,11 @@ class FRSIRENField(CharField):
 
 class FRSIRETField(CharField):
     """
-    A :class:`~django.db.models.CharField` that checks that the value
-    is a valid French SIRET number
+    A :class:`~django.db.models.CharField` that checks that the value is a valid French SIRET number.
 
     .. versionadded:: 1.1
     """
+
     description = _("SIRET Number")
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/gb/forms.py
+++ b/localflavor/gb/forms.py
@@ -1,6 +1,4 @@
-"""
-GB-specific Form helpers
-"""
+"""GB-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -22,6 +20,7 @@ class GBPostcodeField(CharField):
 
     The value is uppercased and a space added in the correct place, if required.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid postcode.'),
     }
@@ -43,16 +42,14 @@ class GBPostcodeField(CharField):
 
 
 class GBCountySelect(Select):
-    """
-    A Select widget that uses a list of UK Counties/Regions as its choices.
-    """
+    """A Select widget that uses a list of UK Counties/Regions as its choices."""
+
     def __init__(self, attrs=None):
         super(GBCountySelect, self).__init__(attrs, choices=GB_REGION_CHOICES)
 
 
 class GBNationSelect(Select):
-    """
-    A Select widget that uses a list of UK Nations as its choices.
-    """
+    """A Select widget that uses a list of UK Nations as its choices."""
+
     def __init__(self, attrs=None):
         super(GBNationSelect, self).__init__(attrs, choices=GB_NATIONS_CHOICES)

--- a/localflavor/gb/gb_regions.py
+++ b/localflavor/gb/gb_regions.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-This module contains various lists of regions and subdivisions in
-Great Britain. Since subdivisions aren't clear this is supposed to be
+This module contains various lists of regions and subdivisions in Great Britain.
+
+Since subdivisions aren't clear this is supposed to be
 the most pragmatic collection of lists as possible. Your mileage may vary.
 
 See https://github.com/django/django-localflavor/pull/43 for a long discussion
@@ -10,6 +11,7 @@ about it.
 .. versionchanged:: 1.1
 
 """
+
 from django.utils.translation import ugettext_lazy as _
 
 #: Metropolitan and non-metropolitan counties of England

--- a/localflavor/generic/checksums.py
+++ b/localflavor/generic/checksums.py
@@ -1,6 +1,4 @@
-"""
-Common checksum routines.
-"""
+"""Common checksum routines."""
 from django.utils import six
 
 __all__ = ['luhn', 'ean']
@@ -11,8 +9,9 @@ EAN_LOOKUP = (3, 1)
 
 def luhn(candidate):
     """
-    Checks a candidate number for validity according to the Luhn
-    algorithm (used in validation of, for example, credit cards).
+    Checks a candidate number for validity according to the Luhn algorithm.
+
+    Luhn algorithm is used in validation of, for example, credit cards.
     Both numeric and string candidates are accepted.
     """
     if not isinstance(candidate, six.string_types):
@@ -28,6 +27,7 @@ def luhn(candidate):
 def ean(candidate):
     """
     Checks a candidate number for validity according to the EAN checksum calculation.
+
     Note that this validator does not enforce any length checks (usually 13 or 8).
 
     http://en.wikipedia.org/wiki/International_Article_Number_(EAN)

--- a/localflavor/generic/forms.py
+++ b/localflavor/generic/forms.py
@@ -26,29 +26,24 @@ IBAN_MIN_LENGTH = min(IBAN_COUNTRY_CODE_LENGTH.values())
 
 
 class DateField(forms.DateField):
-    """
-    A date input field which uses non-US date input formats by default.
-    """
+    """A date input field which uses non-US date input formats by default."""
+
     def __init__(self, input_formats=None, *args, **kwargs):
         input_formats = input_formats or DEFAULT_DATE_INPUT_FORMATS
         super(DateField, self).__init__(input_formats=input_formats, *args, **kwargs)
 
 
 class DateTimeField(forms.DateTimeField):
-    """
-    A date and time input field which uses non-US date and time input formats
-    by default.
-    """
+    """A date and time input field which uses non-US date and time input formats by default."""
+
     def __init__(self, input_formats=None, *args, **kwargs):
         input_formats = input_formats or DEFAULT_DATETIME_INPUT_FORMATS
         super(DateTimeField, self).__init__(input_formats=input_formats, *args, **kwargs)
 
 
 class SplitDateTimeField(forms.SplitDateTimeField):
-    """
-    Split date and time input fields which use non-US date and time input
-    formats by default.
-    """
+    """Split date and time input fields which use non-US date and time input formats by default."""
+
     def __init__(self, input_date_formats=None, input_time_formats=None, *args, **kwargs):
         input_date_formats = input_date_formats or DEFAULT_DATE_INPUT_FORMATS
         super(SplitDateTimeField, self).__init__(input_date_formats=input_date_formats,
@@ -83,6 +78,7 @@ class IBANFormField(forms.CharField):
 
     .. versionadded:: 1.1
     """
+
     def __init__(self, use_nordea_extensions=False, include_countries=None, *args, **kwargs):
         kwargs.setdefault('min_length', IBAN_MIN_LENGTH)
         kwargs.setdefault('max_length', 34)
@@ -94,7 +90,7 @@ class IBANFormField(forms.CharField):
         return value.upper().replace(' ', '').replace('-', '')
 
     def prepare_value(self, value):
-        """ The display format for IBAN has a space every 4 characters. """
+        """The display format for IBAN has a space every 4 characters."""
         if value is None:
             return value
         grouping = 4
@@ -112,6 +108,7 @@ class BICFormField(forms.CharField):
 
     .. versionadded:: 1.1
     """
+
     default_validators = [BICValidator()]
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/generic/models.py
+++ b/localflavor/generic/models.py
@@ -33,6 +33,7 @@ class IBANField(models.CharField):
 
     .. versionadded:: 1.1
     """
+
     description = _('An International Bank Account Number')
 
     def __init__(self, *args, **kwargs):
@@ -75,6 +76,7 @@ class BICField(models.CharField):
 
     .. versionadded:: 1.1
     """
+
     description = _('Business Identifier Code')
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/generic/validators.py
+++ b/localflavor/generic/validators.py
@@ -129,7 +129,7 @@ NORDEA_COUNTRY_CODE_LENGTH = {'AO': 25,  # Angola
 
 @deconstructible
 class IBANValidator(object):
-    """ A validator for International Bank Account Numbers (IBAN - ISO 13616-1:2007). """
+    """A validator for International Bank Account Numbers (IBAN - ISO 13616-1:2007)."""
 
     def __init__(self, use_nordea_extensions=False, include_countries=None):
         self.use_nordea_extensions = use_nordea_extensions
@@ -142,7 +142,8 @@ class IBANValidator(object):
         if self.include_countries:
             for country_code in self.include_countries:
                 if country_code not in self.validation_countries:
-                    msg = 'Explicitly requested country code %s is not part of the configured IBAN validation set.' % country_code
+                    msg = 'Explicitly requested country code %s is not ' \
+                          'part of the configured IBAN validation set.' % country_code
                     raise ImproperlyConfigured(msg)
 
     def __eq__(self, other):
@@ -151,8 +152,11 @@ class IBANValidator(object):
 
     @staticmethod
     def iban_checksum(value):
-        """ Returns check digits for an input IBAN number. Original checksum in input value is ignored. """
+        """
+        Returns check digits for an input IBAN number.
 
+        Original checksum in input value is ignored.
+        """
         # 1. Move the two initial characters to the end of the string, replacing checksum for '00'
         value = value[4:] + value[:2] + '00'
 
@@ -201,8 +205,9 @@ class IBANValidator(object):
 @deconstructible
 class BICValidator(object):
     """
-    A validator for SWIFT Business Identifier Codes (ISO 9362:2009). Validation is based on the BIC structure found on
-    wikipedia.
+    A validator for SWIFT Business Identifier Codes (ISO 9362:2009).
+
+    Validation is based on the BIC structure found on wikipedia.
 
     https://en.wikipedia.org/wiki/ISO_9362#Structure
     """
@@ -241,6 +246,7 @@ class EANValidator(object):
 
     http://en.wikipedia.org/wiki/International_Article_Number_(EAN)
     """
+
     message = _('Not a valid EAN code.')
 
     def __init__(self, strip_nondigits=False, message=None):

--- a/localflavor/gr/forms.py
+++ b/localflavor/gr/forms.py
@@ -1,6 +1,4 @@
-"""
-Greek-specific forms helpers
-"""
+"""Greek-specific forms helpers."""
 import re
 
 from django.core.validators import EMPTY_VALUES
@@ -14,8 +12,10 @@ NUMERIC_RE = re.compile('^\d+$')
 class GRPostalCodeField(RegexField):
     """
     Greek Postal code field.
+
     Format: XXXXX, where X is any digit, and first digit is not 0 or 9.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid 5-digit greek postal code.'),
     }
@@ -28,9 +28,11 @@ class GRPostalCodeField(RegexField):
 class GRTaxNumberCodeField(Field):
     """
     Greek tax number field.
+
     The allow_test_value option can be used to enable the usage of the
     non valid 000000000 value for testing and development
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid greek tax number (9 digits).'),
     }
@@ -65,9 +67,11 @@ class GRTaxNumberCodeField(Field):
 
 class GRPhoneNumberField(Field):
     """
-    Greek general phone field - 10 digits (can also start with +30
-    which is the country-code foor greece)
+    Greek general phone field.
+
+    10 digits (can also start with +30 which is the country-code for greece)
     """
+
     default_error_messages = {
         'invalid': _('Enter a 10-digit greek phone number.'),
     }
@@ -90,9 +94,11 @@ class GRPhoneNumberField(Field):
 
 class GRMobilePhoneNumberField(Field):
     """
-    Greek mobile phone field - 10 digits starting with 69
-    (could also start with +30 which is the country-code foor greece)
+    Greek mobile phone field.
+
+    10 digits starting with 69 (could also start with +30 which is the country-code for greece)
     """
+
     default_error_messages = {
         'invalid': _('Enter a greek mobile phone number starting with 69.'),
     }
@@ -107,7 +113,8 @@ class GRMobilePhoneNumberField(Field):
         if len(phone_nr) == 10 and NUMERIC_RE.search(phone_nr) and phone_nr.startswith('69'):
             return value
 
-        if phone_nr[:3] == '+30' and len(phone_nr) == 13 and NUMERIC_RE.search(phone_nr[3:]) and phone_nr[3:].startswith('69'):
+        if phone_nr[:3] == '+30' and len(phone_nr) == 13 and \
+                NUMERIC_RE.search(phone_nr[3:]) and phone_nr[3:].startswith('69'):
             return value
 
         raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/hk/forms.py
+++ b/localflavor/hk/forms.py
@@ -1,6 +1,4 @@
-"""
-Hong Kong specific Form helpers
-"""
+"""Hong Kong specific Form helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -31,6 +29,7 @@ class HKPhoneNumberField(CharField):
 
     http://en.wikipedia.org/wiki/Telephone_numbers_in_Hong_Kong
     """
+
     default_error_messages = {
         'disguise': _('Phone number should not start with '
                       'one of the followings: %s.' %
@@ -61,8 +60,7 @@ class HKPhoneNumberField(CharField):
             if value.startswith(special):
                 raise ValidationError(self.error_messages['disguise'])
 
-        prefix_found = map(lambda prefix: value.startswith(prefix),
-                           hk_phone_prefixes)
+        prefix_found = map(value.startswith, hk_phone_prefixes)
         if not any(prefix_found):
             raise ValidationError(self.error_messages['prefix'])
 

--- a/localflavor/hr/forms.py
+++ b/localflavor/hr/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-HR-specific Form helpers
-"""
+"""HR-specific Form helpers."""
 from __future__ import unicode_literals
 
 import datetime
@@ -29,28 +27,23 @@ jmbag_re = re.compile(r'^601983(?P<copy>\d{1})1(?P<jmbag>\d{10})(?P<k>\d{1})$')
 
 
 class HRCountySelect(Select):
-    """
-    A Select widget that uses a list of counties of Croatia as its choices.
-    """
+    """A Select widget that uses a list of counties of Croatia as its choices."""
+
     def __init__(self, attrs=None):
         super(HRCountySelect, self).__init__(attrs, choices=HR_COUNTY_CHOICES)
 
 
 class HRLicensePlatePrefixSelect(Select):
-    """
-    A Select widget that uses a list of vehicle license plate prefixes of
-    Croatia as its choices.
-    """
+    """A Select widget that uses a list of vehicle license plate prefixes of Croatia as its choices."""
+
     def __init__(self, attrs=None):
         super(HRLicensePlatePrefixSelect, self).__init__(attrs,
                                                          choices=HR_LICENSE_PLATE_PREFIX_CHOICES)
 
 
 class HRPhoneNumberPrefixSelect(Select):
-    """
-    A Select widget that uses a list of phone number prefixes of Croatia as its
-    choices.
-    """
+    """A Select widget that uses a list of phone number prefixes of Croatia as its choices."""
+
     def __init__(self, attrs=None):
         super(HRPhoneNumberPrefixSelect, self).__init__(attrs,
                                                         choices=HR_PHONE_NUMBER_PREFIX_CHOICES)
@@ -59,6 +52,7 @@ class HRPhoneNumberPrefixSelect(Select):
 class HRJMBGField(Field):
     """
     Unique Master Citizen Number (JMBG) field.
+
     The number is still in use in Croatia, but it is being replaced by OIB.
 
     Source: http://en.wikipedia.org/wiki/Unique_Master_Citizen_Number
@@ -70,6 +64,7 @@ class HRJMBGField(Field):
     immigrated citizens. Therefore, this field works for any ex-Yugoslavia
     country.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid 13 digit JMBG'),
         'date': _('Error in date segment'),
@@ -117,6 +112,7 @@ class HROIBField(RegexField):
 
     http://www.oib.hr/
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid 11 digit OIB'),
     }
@@ -135,7 +131,9 @@ class HROIBField(RegexField):
 
 class HRLicensePlateField(Field):
     """
-    Vehicle license plate of Croatia field. Normalizes to the specific format
+    Vehicle license plate of Croatia field.
+
+    Normalizes to the specific format
     below. Suffix is constructed from the shared letters of the Croatian and
     English alphabets.
 
@@ -146,6 +144,7 @@ class HRLicensePlateField(Field):
 
     Used for standardized license plates only.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid vehicle license plate number'),
         'area': _('Enter a valid location code'),
@@ -179,11 +178,12 @@ class HRLicensePlateField(Field):
 class HRPostalCodeField(Field):
     """
     Postal code of Croatia field.
-    It consists of exactly five digits ranging from 10000 to possibly less than
-    60000.
+
+    It consists of exactly five digits ranging from 10000 to possibly less than 60000.
 
     http://www.posta.hr/main.aspx?id=66
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid 5 digit postal code'),
     }
@@ -207,11 +207,13 @@ class HRPostalCodeField(Field):
 class HRPhoneNumberField(Field):
     """
     Phone number of Croatia field.
+
     Format: Complete country code or leading zero, area code prefix, 6 or 7
     digit number.
     Validates fixed, mobile and FGSM numbers. Normalizes to a full number with
     country code (+385 prefix).
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid phone number'),
         'area': _('Enter a valid area or mobile network code'),
@@ -248,10 +250,12 @@ class HRPhoneNumberField(Field):
 class HRJMBAGField(Field):
     """
     Unique Master Academic Citizen Number of Croatia (JMBAG) field.
+
     This number is used by college students and professors in Croatia.
 
     http://www.cap.srce.hr/IzgledX.aspx
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid 19 digit JMBAG starting with 601983'),
         'copy': _('Card issue number cannot be zero'),

--- a/localflavor/id_/forms.py
+++ b/localflavor/id_/forms.py
@@ -1,6 +1,4 @@
-"""
-ID-specific Form helpers
-"""
+"""ID-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -26,6 +24,7 @@ class IDPostCodeField(Field):
 
     http://id.wikipedia.org/wiki/Kode_pos
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid post code'),
     }
@@ -50,10 +49,7 @@ class IDPostCodeField(Field):
 
 
 class IDProvinceSelect(Select):
-    """
-    A Select widget that uses a list of provinces of Indonesia as its
-    choices.
-    """
+    """A Select widget that uses a list of provinces of Indonesia as its choices."""
 
     def __init__(self, attrs=None):
         # Load data in memory only when it is required, see also #17275
@@ -67,6 +63,7 @@ class IDPhoneNumberField(Field):
 
     http://id.wikipedia.org/wiki/Daftar_kode_telepon_di_Indonesia
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid phone number'),
     }
@@ -86,8 +83,7 @@ class IDPhoneNumberField(Field):
 
 class IDLicensePlatePrefixSelect(Select):
     """
-    A Select widget that uses a list of vehicle license plate prefix code
-    of Indonesia as its choices.
+    A Select widget that uses a list of vehicle license plate prefix code of Indonesia as its choices.
 
     http://id.wikipedia.org/wiki/Tanda_Nomor_Kendaraan_Bermotor
     """
@@ -107,11 +103,12 @@ class IDLicensePlateField(Field):
 
     Plus: "B 12345 12"
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid vehicle license plate number'),
     }
 
-    def clean(self, value):
+    def clean(self, value):  # noqa
         # Load data in memory only when it is required, see also #17275
         from .id_choices import LICENSE_PLATE_PREFIX_CHOICES
         super(IDLicensePlateField, self).clean(value)
@@ -171,6 +168,7 @@ class IDNationalIdentityNumberField(Field):
 
     xx.xxxx.ddmmyy.xxxx - 16 digits (excl. dots)
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid NIK/KTP number'),
     }
@@ -188,29 +186,30 @@ class IDNationalIdentityNumberField(Field):
         if int(value) == 0:
             raise ValidationError(self.error_messages['invalid'])
 
-        def valid_nik_date(year, month, day):
-            try:
-                t1 = (int(year), int(month), int(day), 0, 0, 0, 0, 0, -1)
-                d = time.mktime(t1)
-                t2 = time.localtime(d)
-                if t1[:3] != t2[:3]:
-                    return False
-                else:
-                    return True
-            except (OverflowError, ValueError):
-                return False
-
         year = int(value[10:12])
         month = int(value[8:10])
         day = int(value[6:8])
         current_year = time.localtime().tm_year
         if year < int(str(current_year)[-2:]):
-            if not valid_nik_date(2000 + int(year), month, day):
+            if not IDNationalIdentityNumberField._valid_nik_date(2000 + int(year), month, day):
                 raise ValidationError(self.error_messages['invalid'])
-        elif not valid_nik_date(1900 + int(year), month, day):
+        elif not IDNationalIdentityNumberField._valid_nik_date(1900 + int(year), month, day):
             raise ValidationError(self.error_messages['invalid'])
 
         if value[:6] == '000000' or value[12:] == '0000':
             raise ValidationError(self.error_messages['invalid'])
 
         return '%s.%s.%s.%s' % (value[:2], value[2:6], value[6:12], value[12:])
+
+    @staticmethod
+    def _valid_nik_date(year, month, day):
+        try:
+            t1 = (int(year), int(month), int(day), 0, 0, 0, 0, 0, -1)
+            d = time.mktime(t1)
+            t2 = time.localtime(d)
+            if t1[:3] != t2[:3]:
+                return False
+            else:
+                return True
+        except (OverflowError, ValueError):
+            return False

--- a/localflavor/ie/forms.py
+++ b/localflavor/ie/forms.py
@@ -1,6 +1,4 @@
-"""
-UK-specific Form helpers
-"""
+"""UK-specific Form helpers."""
 
 from django.forms.fields import Select
 
@@ -8,8 +6,7 @@ from .ie_counties import IE_COUNTY_CHOICES
 
 
 class IECountySelect(Select):
-    """
-    A Select widget that uses a list of Irish Counties as its choices.
-    """
+    """A Select widget that uses a list of Irish Counties as its choices."""
+
     def __init__(self, attrs=None):
         super(IECountySelect, self).__init__(attrs, choices=IE_COUNTY_CHOICES)

--- a/localflavor/il/forms.py
+++ b/localflavor/il/forms.py
@@ -1,6 +1,4 @@
-"""
-Israeli-specific form helpers
-"""
+"""Israeli-specific form helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -19,8 +17,10 @@ mobile_phone_number_re = re.compile(r'^(\()?0?(5[02-9])(?(1)\))-?\d{7}$')  # inc
 class ILPostalCodeField(RegexField):
     """
     A form field that validates its input as an Israeli postal code.
+
     Valid form is XXXXX where X represents integer.
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXXXXXX (or XXXXX) - digits only'),
     }
@@ -37,6 +37,7 @@ class ILPostalCodeField(RegexField):
 class ILIDNumberField(Field):
     """
     A form field that validates its input as an Israeli identification number.
+
     Valid form is per the Israeli ID specification.
 
     Israeli ID numbers consist of up to 8 digits followed by a checksum digit.
@@ -72,9 +73,7 @@ class ILIDNumberField(Field):
 
 
 class ILMobilePhoneNumberField(RegexField):
-    """
-    A form field that validates its input as an Israeli Mobile phone number.
-    """
+    """A form field that validates its input as an Israeli Mobile phone number."""
 
     default_error_messages = {
         'invalid': _('Enter a valid Mobile Number.'),

--- a/localflavor/in_/forms.py
+++ b/localflavor/in_/forms.py
@@ -1,6 +1,4 @@
-"""
-India-specific Form helpers.
-"""
+"""India-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -39,10 +37,8 @@ aadhaar_re = re.compile(r"^(?P<part1>\d{4})[-\ ]?(?P<part2>\d{4})[-\ ]?(?P<part3
 
 
 class INZipCodeField(RegexField):
-    """
-    A form field that validates input as an Indian zip code, with the
-    format XXXXXXX.
-    """
+    """A form field that validates input as an Indian zip code, with the format XXXXXXX."""
+
     default_error_messages = {
         'invalid': _('Enter a zip code in the format XXXXXX or XXX XXX.'),
     }
@@ -62,8 +58,9 @@ class INZipCodeField(RegexField):
 
 class INStateField(Field):
     """
-    A form field that validates its input is a Indian state name or
-    abbreviation. It normalizes the input to the standard two-letter vehicle
+    A form field that validates its input is a Indian state name or abbreviation.
+
+    It normalizes the input to the standard two-letter vehicle
     registration abbreviation for the given state or union territory
 
     .. versionchanged:: 1.1
@@ -72,6 +69,7 @@ class INStateField(Field):
        https://en.wikipedia.org/wiki/Telangana#Bifurcation_of_Andhra_Pradesh
 
     """
+
     default_error_messages = {
         'invalid': _('Enter an Indian state or territory.'),
     }
@@ -94,8 +92,7 @@ class INStateField(Field):
 
 class INAadhaarNumberField(Field):
     """
-    A form field for Aadhaar number issued by
-    Unique Identification Authority of India (UIDAI).
+    A form field for Aadhaar number issued by Unique Identification Authority of India (UIDAI).
 
     Checks the following rules to determine whether the number is valid:
 
@@ -112,6 +109,7 @@ class INAadhaarNumberField(Field):
     More information can be found at
     http://uidai.gov.in/what-is-aadhaar-number.html
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Aadhaar number in XXXX XXXX XXXX or '
                      'XXXX-XXXX-XXXX format.'),
@@ -136,8 +134,7 @@ class INAadhaarNumberField(Field):
 
 class INStateSelect(Select):
     """
-    A Select widget that uses a list of Indian states/territories as its
-    choices.
+    A Select widget that uses a list of Indian states/territories as its choices.
 
     .. versionchanged:: 1.1
 
@@ -145,20 +142,23 @@ class INStateSelect(Select):
        https://en.wikipedia.org/wiki/Telangana#Bifurcation_of_Andhra_Pradesh
 
     """
+
     def __init__(self, attrs=None):
         super(INStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
 
 class INPhoneNumberField(CharField):
     """
-    INPhoneNumberField validates that the data is a valid Indian phone number,
-    including the STD code. It's normalised to 0XXX-XXXXXXX or 0XXX XXXXXXX
+    INPhoneNumberField validates that the data is a valid Indian phone number, including the STD code.
+
+    It's normalised to 0XXX-XXXXXXX or 0XXX XXXXXXX
     format. The first string is the STD code which is a '0' followed by 2-4
     digits. The second string is 8 digits if the STD code is 3 digits, 7
     digits if the STD code is 4 digits and 6 digits if the STD code is 5
     digits. The second string will start with numbers between 1 and 6. The
     separator is either a space or a hyphen.
     """
+
     default_error_messages = {
         'invalid': _('Phone numbers must be in 02X-8X or 03X-7X or 04X-6X format.'),
     }

--- a/localflavor/in_/models.py
+++ b/localflavor/in_/models.py
@@ -6,9 +6,11 @@ from .in_states import STATE_CHOICES
 
 class INStateField(CharField):
     """
-    A model field that forms represent as a ``forms.INStateField`` field and
-    stores the two-letter Indian state abbreviation in the database.
+    A model field that stores the two-letter Indian state abbreviation in the database.
+
+    Forms represent it as a ``forms.INStateField`` field.
     """
+
     description = _("Indian state (two uppercase letters)")
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/is_/forms.py
+++ b/localflavor/is_/forms.py
@@ -1,6 +1,4 @@
-"""
-Iceland specific form helpers.
-"""
+"""Iceland specific form helpers."""
 
 from __future__ import unicode_literals
 
@@ -16,9 +14,11 @@ from .is_postalcodes import IS_POSTALCODES
 
 class ISIdNumberField(RegexField):
     """
-    Icelandic identification number (kennitala). This is a number every citizen
-    of Iceland has.
+    Icelandic identification number (kennitala).
+
+    This is a number every citizen of Iceland has.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Icelandic identification number. The format is XXXXXX-XXXX.'),
         'checksum': _('The Icelandic identification number is not valid.'),
@@ -41,32 +41,30 @@ class ISIdNumberField(RegexField):
             raise ValidationError(self.error_messages['checksum'])
 
     def _canonify(self, value):
-        """
-        Returns the value as only digits.
-        """
+        """Returns the value as only digits."""
         return value.replace('-', '').replace(' ', '')
 
     def _validate(self, value):
         """
-        Takes in the value in canonical form and checks the verifier digit. The
-        method is modulo 11.
+        Takes in the value in canonical form and checks the verifier digit.
+
+        The method is modulo 11.
         """
         check = [3, 2, 7, 6, 5, 4, 3, 2, 1, 0]
         return sum([int(value[i]) * check[i] for i in range(10)]) % 11 == 0
 
     def _format(self, value):
-        """
-        Takes in the value in canonical form and returns it in the common
-        display format.
-        """
+        """Takes in the value in canonical form and returns it in the common display format."""
         return force_text(value[:6] + '-' + value[6:])
 
 
 class ISPhoneNumberField(RegexField):
     """
-    Icelandic phone number. Seven digits with an optional hyphen or space after
-    the first three digits.
+    Icelandic phone number.
+
+    Seven digits with an optional hyphen or space after the first three digits.
     """
+
     def __init__(self, max_length=8, min_length=7, *args, **kwargs):
         super(ISPhoneNumberField, self).__init__(r'^\d{3}(-| )?\d{4}$',
                                                  max_length, min_length, *args, **kwargs)
@@ -81,8 +79,7 @@ class ISPhoneNumberField(RegexField):
 
 
 class ISPostalCodeSelect(Select):
-    """
-    A Select widget that uses a list of Icelandic postal codes as its choices.
-    """
+    """A Select widget that uses a list of Icelandic postal codes as its choices."""
+
     def __init__(self, attrs=None):
         super(ISPostalCodeSelect, self).__init__(attrs, choices=IS_POSTALCODES)

--- a/localflavor/it/forms.py
+++ b/localflavor/it/forms.py
@@ -1,6 +1,4 @@
-"""
-IT-specific Form helpers
-"""
+"""IT-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -21,9 +19,11 @@ phone_digits_re = re.compile(r'^(?:\+?39)?((0\d{1,3})(\d{4,8})|(3\d{2})(\d{6,8})
 
 class ITZipCodeField(RegexField):
     """
-    A form field that validates input as an Italian zip code. Valid codes
-    must have five digits.
+    A form field that validates input as an Italian zip code.
+
+    Valid codes must have five digits.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid zip code.'),
     }
@@ -34,25 +34,22 @@ class ITZipCodeField(RegexField):
 
 
 class ITRegionSelect(Select):
-    """
-    A Select widget that uses a list of IT regions as its choices.
-    """
+    """A Select widget that uses a list of IT regions as its choices."""
+
     def __init__(self, attrs=None):
         super(ITRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
 class ITRegionProvinceSelect(Select):
-    """
-    A Select widget that uses a named group list of IT regions mapped to regions as its choices.
-    """
+    """A Select widget that uses a named group list of IT regions mapped to regions as its choices."""
+
     def __init__(self, attrs=None):
         super(ITRegionProvinceSelect, self).__init__(attrs, choices=REGION_PROVINCE_CHOICES)
 
 
 class ITProvinceSelect(Select):
-    """
-    A Select widget that uses a list of IT provinces as its choices.
-    """
+    """A Select widget that uses a list of IT provinces as its choices."""
+
     def __init__(self, attrs=None):
         super(ITProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 
@@ -71,6 +68,7 @@ class ITSocialSecurityNumberField(RegexField):
     The ``ITSocialSecurityNumberField`` now also accepts SSN values for
     entities (numeric-only form).
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Tax code.'),
     }
@@ -100,9 +98,8 @@ class ITSocialSecurityNumberField(RegexField):
 
 
 class ITVatNumberField(Field):
-    """
-    A form field that validates Italian VAT numbers (partita IVA).
-    """
+    """A form field that validates Italian VAT numbers (partita IVA)."""
+
     default_error_messages = {
         'invalid': _('Enter a valid VAT number.'),
     }
@@ -119,11 +116,13 @@ class ITVatNumberField(Field):
 
 class ITPhoneNumberField(CharField):
     """
-    A form field that validates input as an Italian phone number. Will strip
-    any +39 country prefix from the number.
+    A form field that validates input as an Italian phone number.
+
+    Will strip any +39 country prefix from the number.
 
     .. versionadded:: 1.1
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Italian phone number.'),
     }

--- a/localflavor/it/util.py
+++ b/localflavor/it/util.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 
 
 def ssn_check_digit(value):
-    "Calculate Italian social security number check digit."
+    """Calculate Italian social security number check digit."""
     ssn_even_chars = {
         '0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8,
         '9': 9, 'A': 0, 'B': 1, 'C': 2, 'D': 3, 'E': 4, 'F': 5, 'G': 6, 'H': 7,
@@ -61,7 +61,7 @@ def vat_number_validation(vat_number):
 
 
 def vat_number_check_digit(vat_number):
-    "Calculate Italian VAT number check digit."
+    """Calculate Italian VAT number check digit."""
     normalized_vat_number = force_text(vat_number).zfill(10)
     total = 0
     for i in range(0, 10, 2):

--- a/localflavor/jp/forms.py
+++ b/localflavor/jp/forms.py
@@ -1,6 +1,4 @@
-"""
-JP-specific Form helpers
-"""
+"""JP-specific Form helpers."""
 
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
@@ -14,6 +12,7 @@ class JPPostalCodeField(RegexField):
 
     Accepts 7 digits, with or without a hyphen.
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXXXXXX or XXX-XXXX.'),
     }
@@ -25,6 +24,7 @@ class JPPostalCodeField(RegexField):
     def clean(self, value):
         """
         Validates the input and returns a string that contains only numbers.
+
         Returns an empty string for empty values.
         """
         value = super(JPPostalCodeField, self).clean(value)
@@ -32,17 +32,18 @@ class JPPostalCodeField(RegexField):
 
 
 class JPPrefectureSelect(Select):
-    """
-    A Select widget that uses a list of Japanese prefectures as its choices.
-    """
+    """A Select widget that uses a list of Japanese prefectures as its choices."""
+
     def __init__(self, attrs=None):
         super(JPPrefectureSelect, self).__init__(attrs, choices=JP_PREFECTURES)
 
 
 class JPPrefectureCodeSelect(Select):
     """
-    A Select widget that uses a list of Japanese prefectures as its choices
-    and the prefectures code as the post value.
+    A Select widget for Japanese prefecture codes.
+
+    It uses a list of Japanese prefectures as its choices and the prefectures code as the post value.
     """
+
     def __init__(self, attrs=None):
         super(JPPrefectureCodeSelect, self).__init__(attrs, choices=JP_PREFECTURE_CODES)

--- a/localflavor/jp/jp_prefectures.py
+++ b/localflavor/jp/jp_prefectures.py
@@ -1,7 +1,7 @@
 """
-Prefectures ordered to conform with the Japanese entry
-of ISO-3166 as this ordering is widely used in Japan.
+Prefectures ordered to conform with the Japanese entry of ISO-3166.
 
+This ordering is widely used in Japan.
 See:
 http://en.wikipedia.org/wiki/ISO_3166-2:JP
 """

--- a/localflavor/kw/forms.py
+++ b/localflavor/kw/forms.py
@@ -1,6 +1,4 @@
-"""
-Kuwait-specific Form helpers
-"""
+"""Kuwait-specific Form helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -38,14 +36,14 @@ def is_valid_kw_civilid_checksum(value):
 
 class KWCivilIDNumberField(RegexField):
     """
-    Kuwaiti Civil ID numbers are 12 digits, second to seventh digits
-    represents the person's birthdate.
+    Kuwaiti Civil ID numbers are 12 digits, second to seventh digits represents the person's birthdate.
 
     Checks the following rules to determine the validty of the number:
         * The number consist of 12 digits.
         * The birthdate of the person is a valid date.
         * The calculated checksum equals to the last digit of the Civil ID.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Kuwaiti Civil ID number'),
     }

--- a/localflavor/lt/forms.py
+++ b/localflavor/lt/forms.py
@@ -38,6 +38,7 @@ class LTIDCodeField(RegexField):
         * Checksum is correct.
         * ID contains valid date.
     """
+
     default_error_messages = {
         'invalid': _('ID Code consists of exactly 11 decimal digits.'),
         'checksum': _('Wrong ID Code checksum.'),
@@ -76,7 +77,9 @@ class LTIDCodeField(RegexField):
         return True if k == int(value[-1]) else False
 
     def valid_date(self, value):
-        """Check if date in ID code is valid.
+        """
+        Check if date in ID code is valid.
+
         We won't check for dates in future as it would become too restrictive.
         """
         try:
@@ -96,6 +99,7 @@ class LTPostalCodeField(Field):
         * XXXXX
         * LT-XXXXX
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXXXX or LT-XXXXX.'),
     }
@@ -114,7 +118,7 @@ class LTPostalCodeField(Field):
 
 class LTPhoneField(Field):
     """
-    Form field that validates as Lithuanian phone number
+    Form field that validates as Lithuanian phone number.
 
     You can accept any permutation of following phone numbers:
 
@@ -137,10 +141,10 @@ class LTPhoneField(Field):
 
     # Order dependent (shorter codes cannot go before longer ones)
     _area_codes = tuple(map(text_type,
-        [425, 315, 381, 319, 450, 313, 528, 386, 349, 426, 447, 346, 427, 347,
-         445, 459, 318, 343, 443, 383, 469, 421, 460, 451, 448, 319, 422, 428,
-         458, 440, 345, 380, 449, 441, 382, 387, 446, 444, 528, 340, 389, 310,
-         342, 386, 385, 45, 46, 41, 37, 5]))
+                            [425, 315, 381, 319, 450, 313, 528, 386, 349, 426, 447, 346, 427, 347,
+                             445, 459, 318, 343, 443, 383, 469, 421, 460, 451, 448, 319, 422, 428,
+                             458, 440, 345, 380, 449, 441, 382, 387, 446, 444, 528, 340, 389, 310,
+                             342, 386, 385, 45, 46, 41, 37, 5]))
     _stripable = re.compile(r'[\+()~ ]')
     default_error_messages = {
         'non-digit': _('Phone number can only contain digits'),

--- a/localflavor/lv/forms.py
+++ b/localflavor/lv/forms.py
@@ -22,6 +22,7 @@ class LVPostalCodeField(Field):
         * XXXX
         * LV-XXXX
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXXX or LV-XXXX.'),
     }
@@ -47,6 +48,7 @@ class LVMunicipalitySelect(Select):
 
 class LVPersonalCodeField(Field):
     """A form field that validates input as a Latvian personal code."""
+
     default_error_messages = {
         'invalid_format': _('Enter a Latvian personal code in format XXXXXX-XXXXX.'),
         'invalid': _('Enter a valid Latvian personal code.'),
@@ -55,7 +57,6 @@ class LVPersonalCodeField(Field):
     @staticmethod
     def lv_checksum(value):
         """Takes a string of 10 digits as input, returns check digit."""
-
         multipliers = (1, 6, 3, 7, 9, 10, 5, 8, 4, 2)
 
         check = sum(mult * int(c) for mult, c in zip(multipliers, value))

--- a/localflavor/mk/forms.py
+++ b/localflavor/mk/forms.py
@@ -12,8 +12,11 @@ from .mk_choices import MK_MUNICIPALITIES
 
 class MKIdentityCardNumberField(RegexField):
     """
-    A Macedonian ID card number. Accepts both old and new format.
+    A Macedonian ID card number.
+
+    Accepts both old and new format.
     """
+
     default_error_messages = {
         'invalid': _('Identity card numbers must contain'
                      ' either 4 to 7 digits or an uppercase letter and 7 digits.'),
@@ -28,9 +31,9 @@ class MKIdentityCardNumberField(RegexField):
 
 class MKMunicipalitySelect(Select):
     """
-    A form ``Select`` widget that uses a list of Macedonian municipalities as
-    choices. The label is the name of the municipality and the value
-    is a 2 character code for the municipality.
+    A form ``Select`` widget that uses a list of Macedonian municipalities as choices.
+
+    The label is the name of the municipality and the value is a 2 character code for the municipality.
     """
 
     def __init__(self, attrs=None):
@@ -39,8 +42,7 @@ class MKMunicipalitySelect(Select):
 
 class UMCNField(RegexField):
     """
-    A form field that validates input as a unique master citizen
-    number.
+    A form field that validates input as a unique master citizen number.
 
     The format of the unique master citizen number has been kept the same from
     Yugoslavia. It is still in use in other countries as well, it is not applicable
@@ -53,6 +55,7 @@ class UMCNField(RegexField):
     * The first 7 digits represent a valid past date in the format DDMMYYY
     * The last digit of the UMCN passes a checksum test
     """
+
     default_error_messages = {
         'invalid': _('This field should contain exactly 13 digits.'),
         'date': _('The first 7 digits of the UMCN must represent a valid past date.'),
@@ -82,7 +85,7 @@ class UMCNField(RegexField):
             int(digit) for digit in value]
         m = 11 - ((7 * (a + g) + 6 * (b + h) + 5 * (
             c + i) + 4 * (d + j) + 3 * (e + k) + 2 * (f + l)) % 11)
-        if (m >= 1 and m <= 9) and K == m:
+        if 1 <= m <= 9 and K == m:
             return True
         elif m == 11 and K == 0:
             return True

--- a/localflavor/mk/models.py
+++ b/localflavor/mk/models.py
@@ -9,8 +9,10 @@ from .mk_choices import MK_MUNICIPALITIES
 class MKIdentityCardNumberField(CharField):
     """
     A form field that validates input as a Macedonian identity card number.
+
     Both old and new identity card numbers are supported.
     """
+
     description = _("Macedonian identity card number")
 
     def __init__(self, *args, **kwargs):
@@ -31,8 +33,10 @@ class MKIdentityCardNumberField(CharField):
 class MKMunicipalityField(CharField):
     """
     A form field that validates input as a Macedonian identity card number.
+
     Both old and new identity card numbers are supported.
     """
+
     description = _("A Macedonian municipality (2 character code)")
 
     def __init__(self, *args, **kwargs):
@@ -61,6 +65,7 @@ class UMCNField(CharField):
     * The first 7 digits represent a valid past date in the format DDMMYYY
     * The last digit of the UMCN passes a checksum test
     """
+
     description = _("Unique master citizen number (13 digits)")
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/mt/forms.py
+++ b/localflavor/mt/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Maltese-specific Form helpers.
-"""
+"""Maltese-specific Form helpers."""
 from __future__ import unicode_literals
 
 from django.forms.fields import RegexField
@@ -15,6 +13,7 @@ class MTPostalCodeField(RegexField):
     Maltese postal code is a seven digits string, with first three
     being letters and the final four numbers.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid postal code in format AAA 0000.'),
     }

--- a/localflavor/mx/forms.py
+++ b/localflavor/mx/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Mexican-specific form helpers.
-"""
+"""Mexican-specific form helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -48,9 +46,8 @@ CURP_INCONVENIENT_WORDS = [
 
 
 class MXStateSelect(Select):
-    """
-    A Select widget that uses a list of Mexican states as its choices.
-    """
+    """A Select widget that uses a list of Mexican states as its choices."""
+
     def __init__(self, attrs=None):
         super(MXStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
@@ -62,6 +59,7 @@ class MXZipCodeField(RegexField):
     More info about this:
         http://en.wikipedia.org/wiki/List_of_postal_codes_in_Mexico
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid zip code in the format XXXXX.'),
     }
@@ -73,9 +71,9 @@ class MXZipCodeField(RegexField):
 
 class MXRFCField(RegexField):
     """
-    A form field that validates a Mexican *Registro Federal de Contribuyentes*
-    for either `Persona física` or `Persona moral`.
+    A form field that validates a Mexican *Registro Federal de Contribuyentes*.
 
+    Validates either `Persona física` or `Persona moral`.
     The Persona física RFC string is integrated by a juxtaposition of
     characters following the next pattern:
 
@@ -105,6 +103,7 @@ class MXRFCField(RegexField):
     More info about this:
         http://es.wikipedia.org/wiki/Registro_Federal_de_Contribuyentes_(M%C3%A9xico)
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid RFC.'),
         'invalid_checksum': _('Invalid checksum for RFC.'),
@@ -130,8 +129,9 @@ class MXRFCField(RegexField):
 
     def _has_homoclave(self, rfc):
         """
-        This check is done due to the existance of RFCs without a *homoclave*
-        since the current algorithm to calculate it had not been created for
+        This check is done due to the existance of RFCs without a *homoclave*.
+
+        Since the current algorithm to calculate it had not been created for
         the first RFCs ever in Mexico.
         """
         rfc_without_homoclave_re = re.compile(r'^[A-Z&Ññ]{3,4}%s$' % DATE_RE,
@@ -140,6 +140,8 @@ class MXRFCField(RegexField):
 
     def _checksum(self, rfc):
         """
+        Checksum.
+
         More info about this procedure:
             www.sisi.org.mx/jspsi/documentos/2005/seguimiento/06101/0610100162005_065.doc
         """
@@ -164,7 +166,8 @@ class MXRFCField(RegexField):
 
 
 class MXCLABEField(RegexField):
-    """This field validates a CLABE (Clave Bancaria Estandarizada).
+    """
+    This field validates a CLABE (Clave Bancaria Estandarizada).
 
     A CLABE is a 18-digits long number. The first 6 digits denote bank and branch number.
     The remaining 12 digits denote an account number, plus a verifying digit.
@@ -230,13 +233,15 @@ class MXCURPField(RegexField):
     More info about this:
         http://www.condusef.gob.mx/index.php/clave-unica-de-registro-de-poblacion-curp
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid CURP.'),
         'invalid_checksum': _('Invalid checksum for CURP.'),
     }
 
     def __init__(self, min_length=18, max_length=18, *args, **kwargs):
-        states_re = r'(AS|BC|BS|CC|CL|CM|CS|CH|DF|DG|GT|GR|HG|JC|MC|MN|MS|NT|NL|OC|PL|QT|QR|SP|SL|SR|TC|TS|TL|VZ|YN|ZS|NE)'
+        states_re = r'(AS|BC|BS|CC|CL|CM|CS|CH|DF|DG|GT|GR|HG|JC|MC|MN|' \
+                    r'MS|NT|NL|OC|PL|QT|QR|SP|SL|SR|TC|TS|TL|VZ|YN|ZS|NE)'
         consonants_re = r'[B-DF-HJ-NP-TV-Z]'
         curp_re = (r'^[A-Z][AEIOU][A-Z]{2}%s[HM]%s%s{3}[0-9A-Z]\d$' %
                    (DATE_RE, states_re, consonants_re))
@@ -291,6 +296,7 @@ class MXSocialSecurityNumberField(RegexField):
     =====  ==================================================================
 
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Social Security Number.'),
         'invalid_checksum': _('Invalid checksum for Social Security Number.'),

--- a/localflavor/mx/models.py
+++ b/localflavor/mx/models.py
@@ -10,10 +10,8 @@ from .mx_states import STATE_CHOICES
 
 
 class MXStateField(CharField):
-    """
-    A model field that stores the three-letter Mexican state abbreviation in the
-    database.
-    """
+    """A model field that stores the three-letter Mexican state abbreviation in the database."""
+
     description = _("Mexico state (three uppercase letters)")
 
     def __init__(self, *args, **kwargs):
@@ -29,10 +27,8 @@ class MXStateField(CharField):
 
 
 class MXZipCodeField(CharField):
-    """
-    A model field that forms represent as a forms.MXZipCodeField field and
-    stores the five-digit Mexican zip code.
-    """
+    """A model field that forms represent as a forms.MXZipCodeField field and stores the five-digit Mexican zip code."""
+
     description = _("Mexico zip code")
 
     def __init__(self, *args, **kwargs):
@@ -51,10 +47,8 @@ class MXZipCodeField(CharField):
 
 
 class MXRFCField(CharField):
-    """
-    A model field that forms represent as a forms.MXRFCField field and
-    stores the value of a valid Mexican RFC.
-    """
+    """A model field that forms represent as a forms.MXRFCField field and stores the value of a valid Mexican RFC."""
+
     description = _("Mexican RFC")
 
     def __init__(self, *args, **kwargs):
@@ -74,11 +68,11 @@ class MXRFCField(CharField):
 
 class MXCLABEField(CharField):
     """
-    A model field that forms represent as a forms.MXCURPField field and
-    stores the value of a valid Mexican CLABE.
+    A model field that forms represent as a forms.MXCURPField field and stores the value of a valid Mexican CLABE.
 
     .. versionadded:: 1.4
     """
+
     description = _("Mexican CLABE")
 
     def __init__(self, *args, **kwargs):
@@ -97,10 +91,8 @@ class MXCLABEField(CharField):
 
 
 class MXCURPField(CharField):
-    """
-    A model field that forms represent as a forms.MXCURPField field and
-    stores the value of a valid Mexican CURP.
-    """
+    """A model field that forms represent as a forms.MXCURPField field and stores the value of a valid Mexican CURP."""
+
     description = _("Mexican CURP")
 
     def __init__(self, *args, **kwargs):
@@ -120,9 +112,11 @@ class MXCURPField(CharField):
 
 class MXSocialSecurityNumberField(CharField):
     """
-    A model field that forms represent as a forms.MXSocialSecurityNumberField
-    field and stores the value of a valid Mexican Social Security Number.
+    A model field that forms represent as a forms.MXSocialSecurityNumberField field.
+
+    It stores the value of a valid Mexican Social Security Number.
     """
+
     description = _("Mexican Social Security Number")
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/nl/forms.py
+++ b/localflavor/nl/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-NL-specific Form helpers
-"""
+"""NL-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -13,9 +11,8 @@ from .validators import NLPhoneNumberFieldValidator, NLSoFiNumberFieldValidator,
 
 
 class NLZipCodeField(forms.CharField):
-    """
-    A Dutch zip code field.
-    """
+    """A Dutch zip code field."""
+
     default_validators = [NLZipCodeFieldValidator()]
 
     def clean(self, value):
@@ -29,18 +26,15 @@ class NLZipCodeField(forms.CharField):
 
 
 class NLProvinceSelect(forms.Select):
-    """
-    A Select widget that uses a list of provinces of the Netherlands as it's
-    choices.
-    """
+    """A Select widget that uses a list of provinces of the Netherlands as it's choices."""
+
     def __init__(self, attrs=None):
         super(NLProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 
 
 class NLPhoneNumberField(forms.CharField):
-    """
-    A Dutch telephone number field.
-    """
+    """A Dutch telephone number field."""
+
     default_validators = [NLPhoneNumberFieldValidator()]
 
 
@@ -50,6 +44,7 @@ class NLSoFiNumberField(forms.CharField):
 
     http://nl.wikipedia.org/wiki/Sofinummer
     """
+
     default_validators = [NLSoFiNumberFieldValidator()]
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/nl/models.py
+++ b/localflavor/nl/models.py
@@ -50,6 +50,7 @@ class NLProvinceField(models.CharField):
 
     .. versionadded:: 1.3
     """
+
     description = _('Dutch province')
 
     def __init__(self, *args, **kwargs):
@@ -68,12 +69,13 @@ class NLProvinceField(models.CharField):
 
 class NLSoFiNumberField(models.CharField):
     """
-    A Dutch social security number (SoFi)
+    A Dutch social security number (SoFi).
 
     This model field uses :class:`validators.NLSoFiNumberFieldValidator` for validation.
 
     .. versionadded:: 1.3
     """
+
     description = _('Dutch social security number (SoFi)')
 
     validators = [NLSoFiNumberFieldValidator()]
@@ -95,12 +97,13 @@ class NLSoFiNumberField(models.CharField):
 
 class NLPhoneNumberField(models.CharField):
     """
-    Dutch phone number model field
+    Dutch phone number model field.
 
     This model field uses :class:`validators.NLPhoneNumberFieldValidator` for validation.
 
     .. versionadded:: 1.3
     """
+
     description = _('Dutch phone number')
 
     validator = [NLPhoneNumberFieldValidator()]
@@ -128,6 +131,7 @@ class NLBankAccountNumberField(models.CharField):
 
     .. versionadded:: 1.1
     """
+
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('max_length', 10)
         super(NLBankAccountNumberField, self).__init__(*args, **kwargs)

--- a/localflavor/nl/validators.py
+++ b/localflavor/nl/validators.py
@@ -16,6 +16,7 @@ class NLZipCodeFieldValidator(RegexValidator):
 
     .. versionadded:: 1.3
     """
+
     error_message = _('Enter a valid zip code.')
 
     def __init__(self):
@@ -35,6 +36,7 @@ class NLSoFiNumberFieldValidator(RegexValidator):
 
     .. versionadded:: 1.3
     """
+
     error_message = _('Enter a valid SoFi number.')
 
     def __init__(self):
@@ -94,6 +96,7 @@ class NLBankAccountNumberFieldValidator(RegexValidator):
 
     .. versionadded:: 1.1
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid bank account number.'),
         'wrong_length': _('Bank account numbers have 1 - 7, 9 or 10 digits.'),

--- a/localflavor/no/forms.py
+++ b/localflavor/no/forms.py
@@ -1,6 +1,4 @@
-"""
-Norwegian-specific Form helpers
-"""
+"""Norwegian-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -17,9 +15,11 @@ from .no_municipalities import MUNICIPALITY_CHOICES
 
 class NOZipCodeField(RegexField):
     """
-    A form field that validates input as a Norwegian zip code. Valid codes
-    have four digits.
+    A form field that validates input as a Norwegian zip code.
+
+    Valid codes have four digits.
     """
+
     default_error_messages = {
         'invalid': _('Enter a zip code in the format XXXX.'),
     }
@@ -30,23 +30,20 @@ class NOZipCodeField(RegexField):
 
 
 class NOMunicipalitySelect(Select):
-    """
-    A Select widget that uses a list of Norwegian municipalities (fylker)
-    as its choices.
-    """
+    """A Select widget that uses a list of Norwegian municipalities (fylker) as its choices."""
+
     def __init__(self, attrs=None):
         super(NOMunicipalitySelect, self).__init__(attrs, choices=MUNICIPALITY_CHOICES)
 
 
 class NOSocialSecurityNumber(Field):
-    """
-    Algorithm is documented at http://no.wikipedia.org/wiki/Personnummer
-    """
+    """Algorithm is documented at http://no.wikipedia.org/wiki/Personnummer."""
+
     default_error_messages = {
         'invalid': _('Enter a valid Norwegian social security number.'),
     }
 
-    def clean(self, value):
+    def clean(self, value):  # noqa
         super(NOSocialSecurityNumber, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -95,9 +92,11 @@ class NOSocialSecurityNumber(Field):
 
 class NOPhoneNumberField(RegexField):
     """
-    Field with phonenumber validation. Requires a phone number with
-    8 digits and optional country code
+    Field with phonenumber validation.
+
+    Requires a phone number with 8 digits and optional country code
     """
+
     default_error_messages = {
         'invalid': _('A phone number must be 8 digits and may have country code'),
     }

--- a/localflavor/nz/forms.py
+++ b/localflavor/nz/forms.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-New Zealand specific form helpers
-
-"""
+"""New Zealand specific form helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -25,60 +22,48 @@ BANK_ACCOUNT_NUMBER_RE = re.compile(r'^(\d{2})(\d{4})(\d{7})(\d{2,3})$')
 
 
 class NZRegionSelect(Select):
-    """
-    A select widget with list of New Zealand regions as its choices.
+    """A select widget with list of New Zealand regions as its choices."""
 
-    """
     def __init__(self, attrs=None):
         super(NZRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
 class NZProvinceSelect(Select):
-    """
-    A select widget with list of New Zealand provinces as its choices.
+    """A select widget with list of New Zealand provinces as its choices."""
 
-    """
     def __init__(self, attrs=None):
         super(NZProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 
 
 class NZNorthIslandCouncilSelect(Select):
-    """
-    A select widget with list of New Zealand North Island city and district councils as its choices.
+    """A select widget with list of New Zealand North Island city and district councils as its choices."""
 
-    """
     def __init__(self, attrs=None):
         super(NZNorthIslandCouncilSelect, self).__init__(attrs, choices=NORTH_ISLAND_COUNCIL_CHOICES)
 
 
 class NZSouthIslandCouncilSelect(Select):
-    """
-    A select widget with list of New Zealand South Island city and district councils as its choices.
+    """A select widget with list of New Zealand South Island city and district councils as its choices."""
 
-    """
     def __init__(self, attrs=None):
         super(NZSouthIslandCouncilSelect, self).__init__(attrs, choices=SOUTH_ISLAND_COUNCIL_CHOICES)
 
 
 class NZPostCodeField(RegexField):
-    """
-    A form field that validates its input as New Zealand postal code.
+    """A form field that validates its input as New Zealand postal code."""
 
-    """
     default_error_messages = {
         'invalid': _('Invalid post code.'),
     }
 
     def __init__(self, *args, **kwargs):
         super(NZPostCodeField, self).__init__(r'^\d{4}$',
-            *args, **kwargs)
+                                              *args, **kwargs)
 
 
 class NZPhoneNumberField(Field):
-    """
-    A form field that validates its input as New Zealand phone number.
+    """A form field that validates its input as New Zealand phone number."""
 
-    """
     default_error_messages = {'invalid': _('Invalid phone number.')}
 
     def clean(self, value):
@@ -122,6 +107,7 @@ class NZBankAccountNumberField(Field):
     * the last two or three digits define type of the account.
 
     """
+
     default_error_messages = {
         'invalid': _('Invalid bank account number.'),
     }
@@ -136,5 +122,5 @@ class NZBankAccountNumberField(Field):
             # normalize the last part
             last = '0%s' % match.group(4) if len(match.group(4)) == 2 else match.group(4)
             return '%s-%s-%s-%s' % (match.group(1),
-                match.group(2), match.group(3), last)
+                                    match.group(2), match.group(3), last)
         raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/nz/nz_provinces.py
+++ b/localflavor/nz/nz_provinces.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-""" New Zealand Provinces.
+"""
+New Zealand Provinces.
 
 See "The Anniversary Day of the Province" at the source URL.
 
@@ -8,7 +9,6 @@ Source: http://www.dol.govt.nz/er/holidaysandleave/publicholidays/publicholidayd
 Note that provinces were abolished in 1876 and the names have very limited modern uses.
 
 Source: http://en.wikipedia.org/wiki/Provinces_of_New_Zealand
-
 """
 
 from __future__ import unicode_literals

--- a/localflavor/pe/forms.py
+++ b/localflavor/pe/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-PE-specific Form helpers.
-"""
+"""PE-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -14,17 +12,15 @@ from .pe_region import REGION_CHOICES
 
 
 class PERegionSelect(Select):
-    """
-    A Select widget that uses a list of Peruvian Regions as its choices.
-    """
+    """A Select widget that uses a list of Peruvian Regions as its choices."""
+
     def __init__(self, attrs=None):
         super(PERegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
 class PEDNIField(CharField):
-    """
-    A field that validates Documento Nacional de Identidad (DNI) numbers.
-    """
+    """A field that validates Documento Nacional de Identidad (DNI) numbers."""
+
     default_error_messages = {
         'invalid': _("This field requires only numbers."),
         'max_digits': _("This field requires 8 digits."),
@@ -35,9 +31,7 @@ class PEDNIField(CharField):
                                          **kwargs)
 
     def clean(self, value):
-        """
-        Value must be a string in the XXXXXXXX formats.
-        """
+        """Value must be a string in the XXXXXXXX formats."""
         value = super(PEDNIField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -51,9 +45,11 @@ class PEDNIField(CharField):
 
 class PERUCField(CharField):
     """
-    This field validates a RUC (Registro Unico de Contribuyentes). A RUC is of
-    the form XXXXXXXXXXX.
+    This field validates a RUC (Registro Unico de Contribuyentes).
+
+    A RUC is of the form XXXXXXXXXXX.
     """
+
     default_error_messages = {
         'invalid': _("This field requires only numbers."),
         'max_digits': _("This field requires 11 digits."),
@@ -64,9 +60,7 @@ class PERUCField(CharField):
                                          **kwargs)
 
     def clean(self, value):
-        """
-        Value must be an 11-digit number.
-        """
+        """Value must be an 11-digit number."""
         value = super(PERUCField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''

--- a/localflavor/pk/forms.py
+++ b/localflavor/pk/forms.py
@@ -1,6 +1,4 @@
-"""
-Pakistani-specific Form helpers
-"""
+"""Pakistani-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -19,10 +17,12 @@ PHONE_DIGITS_RE = re.compile(r'^(\d{9,11})$')
 
 
 class PKPostCodeField(RegexField):
-    """ Pakistani post code field.
+    """
+    Pakistani post code field.
 
     Assumed to be 5 digits.
     """
+
     default_error_messages = {
         'invalid': _('Enter a 5 digit postcode.'),
     }
@@ -37,13 +37,16 @@ class PKPhoneNumberField(CharField):
 
     Valid numbers have nine to eleven digits.
     """
+
     default_error_messages = {
         'invalid': _('Phone numbers must contain 9, 10 or 11 digits.'),
     }
 
     def clean(self, value):
         """
-        Validate a phone number. Strips parentheses, whitespace and hyphens.
+        Validate a phone number.
+
+        Strips parentheses, whitespace and hyphens.
         """
         super(PKPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
@@ -56,9 +59,7 @@ class PKPhoneNumberField(CharField):
 
 
 class PKStateSelect(Select):
-    """
-    A Select widget that uses a list of Pakistani states/territories as its
-    choices.
-    """
+    """A Select widget that uses a list of Pakistani states/territories as its choices."""
+
     def __init__(self, attrs=None):
         super(PKStateSelect, self).__init__(attrs, choices=STATE_CHOICES)

--- a/localflavor/pk/models.py
+++ b/localflavor/pk/models.py
@@ -7,10 +7,11 @@ from .pk_states import STATE_CHOICES
 
 class PKStateField(CharField):
     """
-    A model field that is represented with
-    :data:`~localflavor.pk.pk_states.STATE_CHOICES`` choices and
-    stores the five-letter Pakistani state abbreviation in the database.
+    A model field that stores the five-letter Pakistani state abbreviation in the database.
+
+    It is represented with :data:`~localflavor.pk.pk_states.STATE_CHOICES`` choices.
     """
+
     description = _("Pakistani State")
 
     def __init__(self, *args, **kwargs):
@@ -27,10 +28,11 @@ class PKStateField(CharField):
 
 class PKPostCodeField(CharField):
     """
-    A model field that forms represent as a
-    :class:`~localflavor.pk.forms.PKPostCodeField` field and stores the
-    five-digit Pakistani postcode in the database.
+    A model field that stores the five-digit Pakistani postcode in the database
+
+    Forms represent it as a :class:`~localflavor.pk.forms.PKPostCodeField` field.
     """
+
     description = _("Pakistani Postcode")
 
     def __init__(self, *args, **kwargs):
@@ -49,10 +51,8 @@ class PKPostCodeField(CharField):
 
 
 class PKPhoneNumberField(CharField):
-    """
-    A model field that checks that the value is a valid Pakistani phone
-    number (nine to eleven digits).
-    """
+    """A model field that checks that the value is a valid Pakistani phone number (nine to eleven digits)."""
+
     description = _("Pakistani Phone number")
 
     def __init__(self, *args, **kwargs):

--- a/localflavor/pl/forms.py
+++ b/localflavor/pl/forms.py
@@ -1,6 +1,4 @@
-"""
-Polish-specific form helpers
-"""
+"""Polish-specific form helpers."""
 
 from __future__ import unicode_literals
 
@@ -17,17 +15,15 @@ from .pl_voivodeships import VOIVODESHIP_CHOICES
 
 
 class PLProvinceSelect(Select):
-    """
-    A select widget with list of Polish administrative provinces as choices.
-    """
+    """A select widget with list of Polish administrative provinces as choices."""
+
     def __init__(self, attrs=None):
         super(PLProvinceSelect, self).__init__(attrs, choices=VOIVODESHIP_CHOICES)
 
 
 class PLCountySelect(Select):
-    """
-    A select widget with list of Polish administrative units as choices.
-    """
+    """A select widget with list of Polish administrative units as choices."""
+
     def __init__(self, attrs=None):
         super(PLCountySelect, self).__init__(attrs, choices=ADMINISTRATIVE_UNIT_CHOICES)
 
@@ -45,6 +41,7 @@ class PLPESELField(RegexField):
 
     .. versionchanged:: 1.4
     """
+
     default_error_messages = {
         'invalid': _('National Identification Number consists of 11 digits.'),
         'checksum': _('Wrong checksum for the National Identification Number.'),
@@ -66,13 +63,11 @@ class PLPESELField(RegexField):
         return '%s' % value
 
     def has_valid_checksum(self, number):
-        """
-        Calculates a checksum with the provided algorithm.
-        """
+        """Calculates a checksum with the provided algorithm."""
         multiple_table = (1, 3, 7, 9, 1, 3, 7, 9, 1, 3, 1)
         result = 0
-        for i in range(len(number)):
-            result += int(number[i]) * multiple_table[i]
+        for i, digit in enumerate(number):
+            result += int(digit) * multiple_table[i]
         return result % 10 == 0
 
     def has_valid_birth_date(self, number):
@@ -105,6 +100,7 @@ class PLNationalIDCardNumberField(RegexField):
 
     The algorithm is documented at http://en.wikipedia.org/wiki/Polish_identity_card.
     """
+
     default_error_messages = {
         'invalid': _('National ID Card Number consists of 3 letters and 6 digits.'),
         'checksum': _('Wrong checksum for the National ID Card Number.'),
@@ -127,9 +123,7 @@ class PLNationalIDCardNumberField(RegexField):
         return '%s' % value
 
     def has_valid_checksum(self, number):
-        """
-        Calculates a checksum with the provided algorithm.
-        """
+        """Calculates a checksum with the provided algorithm."""
         letter_dict = {'A': 10, 'B': 11, 'C': 12, 'D': 13,
                        'E': 14, 'F': 15, 'G': 16, 'H': 17,
                        'I': 18, 'J': 19, 'K': 20, 'L': 21,
@@ -144,8 +138,8 @@ class PLNationalIDCardNumberField(RegexField):
 
         multiple_table = (7, 3, 1, -1, 7, 3, 1, 7, 3)
         result = 0
-        for i in range(len(int_table)):
-            result += int_table[i] * multiple_table[i]
+        for i, digit in enumerate(int_table):
+            result += int(digit) * multiple_table[i]
 
         return result % 10 == 0
 
@@ -153,11 +147,12 @@ class PLNationalIDCardNumberField(RegexField):
 class PLNIPField(RegexField):
     """
     A form field that validates as Polish Tax Number (NIP).
-    Valid forms are: XXX-YYY-YY-YY, XXX-YY-YY-YYY or XXXYYYYYYY.
 
+    Valid forms are: XXX-YYY-YY-YY, XXX-YY-YY-YYY or XXXYYYYYYY.
     Checksum algorithm based on documentation at
     http://wipos.p.lodz.pl/zylla/ut/nip-rego.html
     """
+
     default_error_messages = {
         'invalid': _('Enter a tax number field (NIP) in the format XXX-XXX-XX-XX, XXX-XX-XX-XXX or XXXXXXXXXX.'),
         'checksum': _('Wrong checksum for the Tax Number (NIP).'),
@@ -178,19 +173,14 @@ class PLNIPField(RegexField):
         return '%s' % value
 
     def has_valid_checksum(self, number):
-        """
-        Calculates a checksum with the provided algorithm.
-        """
+        """Calculates a checksum with the provided algorithm."""
         multiple_table = (6, 5, 7, 2, 3, 4, 5, 6, 7)
         result = 0
-        for i in range(len(number) - 1):
-            result += int(number[i]) * multiple_table[i]
+        for i, digit in enumerate(number[:-1]):
+            result += int(digit) * multiple_table[i]
 
         result %= 11
-        if result == int(number[-1]):
-            return True
-        else:
-            return False
+        return result == int(number[-1])
 
 
 class PLREGONField(RegexField):
@@ -200,6 +190,7 @@ class PLREGONField(RegexField):
     Valid regon number consists of 9 or 14 digits.
     See http://www.stat.gov.pl/bip/regon_ENG_HTML.htm for more information.
     """
+
     default_error_messages = {
         'invalid': _('National Business Register Number (REGON) consists of 9 or 14 digits.'),
         'checksum': _('Wrong checksum for the National Business Register Number (REGON).'),
@@ -218,9 +209,7 @@ class PLREGONField(RegexField):
         return '%s' % value
 
     def has_valid_checksum(self, number):
-        """
-        Calculates a checksum with the provided algorithm.
-        """
+        """Calculates a checksum with the provided algorithm."""
         weights = (
             (8, 9, 2, 3, 4, 5, 6, 7, -1),
             (2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8, -1),
@@ -246,8 +235,10 @@ class PLREGONField(RegexField):
 class PLPostalCodeField(RegexField):
     """
     A form field that validates as Polish postal code.
+
     Valid code is XX-XXX where X is digit.
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XX-XXX.'),
     }

--- a/localflavor/pt/forms.py
+++ b/localflavor/pt/forms.py
@@ -32,14 +32,17 @@ class PTCitizenCardNumberField(Field):
     """
     A field which validates Portuguese Citizen Card numbers (locally CC - 'Cartão do Cidadão').
 
-    - Citizen Card numbers have the format XXXXXXXXXYYX or XXXXXXXX-XYYX (where X is a digit and Y is an alphanumeric character).
+    - Citizen Card numbers have the format XXXXXXXXXYYX or XXXXXXXX-XYYX
+        (where X is a digit and Y is an alphanumeric character).
     - Citizen Card numbers validate as per http://bit.ly/RP0BzW.
     - The input string may or may not have an hyphen separating the identity number from the document's check-digits.
     - This field does NOT validate old ID card numbers (locally BI - 'Bilhete de Identidade').
     """
+
     default_error_messages = {
         'badchecksum': _('The specified value is not a valid Citizen Card number.'),
-        'invalid': _('Citizen Card numbers have the format XXXXXXXXXYYX or XXXXXXXX-XYYX (where X is a digit and Y is an alphanumeric character).'),
+        'invalid': _('Citizen Card numbers have the format XXXXXXXXXYYX or XXXXXXXX-XYYX '
+                     '(where X is a digit and Y is an alphanumeric character).'),
     }
 
     def clean(self, value):
@@ -82,8 +85,10 @@ class PTPhoneNumberField(Field):
     - Phone numbers have at least 3 and at most 9 digits and may optionally be prefixed with '00351' or '+351'.
     - The input string is allowed to contain spaces (though they will be stripped).
     """
+
     default_error_messages = {
-        'invalid': _('Phone numbers have at least 3 and at most 9 digits and may optionally be prefixed with \'00351\' or \'+351\'.'),
+        'invalid': _('Phone numbers have at least 3 and at most 9 digits '
+                     'and may optionally be prefixed with \'00351\' or \'+351\'.'),
     }
 
     def clean(self, value):
@@ -107,19 +112,23 @@ class PTRegionSelect(Select):
 
     - Regions correspond to the Portuguese 'distritos' and 'regiões autónomas' as per ISO3166:2-PT.
     """
+
     def __init__(self, attrs=None):
         super(PTRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
 class PTSocialSecurityNumberField(Field):
     """
-    A field which validates Portuguese Social Security numbers (locally NISS - 'Número de Identificação na Segurança Social').
+    A field which validates Portuguese Social Security numbers.
 
+    (locally NISS - 'Número de Identificação na Segurança Social').
     - Social Security numbers must be in the format XYYYYYYYYYY (where X is either 1 or 2 and Y is any other digit).
     """
+
     default_error_messages = {
         'badchecksum': _('The specified number is not a valid Social Security number.'),
-        'invalid': _('Social Security numbers must be in the format XYYYYYYYYYY (where X is either 1 or 2 and Y is any other digit).'),
+        'invalid': _('Social Security numbers must be in the format XYYYYYYYYYY '
+                     '(where X is either 1 or 2 and Y is any other digit).'),
     }
 
     def clean(self, value):
@@ -154,8 +163,10 @@ class PTZipCodeField(RegexField):
     NOTE
     - Zip codes have the format XYYY-YYY (where X is a digit between 1 and 9 and Y is any other digit).
     """
+
     default_error_messages = {
-        'invalid': _('Zip codes must be in the format XYYY-YYY (where X is a digit between 1 and 9 and Y is any other digit).'),
+        'invalid': _('Zip codes must be in the format XYYY-YYY'
+                     ' (where X is a digit between 1 and 9 and Y is any other digit).'),
     }
 
     def __init__(self, max_length=None, min_length=None, *args, **kwargs):

--- a/localflavor/py_/forms.py
+++ b/localflavor/py_/forms.py
@@ -1,6 +1,4 @@
-"""
-PY-specific Form helpers.
-"""
+"""PY-specific Form helpers."""
 
 from django.forms.fields import Select
 
@@ -8,16 +6,14 @@ from .py_department import DEPARTMENT_CHOICES, DEPARTMENT_ROMAN_CHOICES
 
 
 class PyDepartmentSelect(Select):
-    """
-    A Select widget with a list of Paraguayan departments as choices.
-    """
+    """A Select widget with a list of Paraguayan departments as choices."""
+
     def __init__(self, attrs=None):
         super(PyDepartmentSelect, self).__init__(attrs, choices=DEPARTMENT_CHOICES)
 
 
 class PyNumberedDepartmentSelect(Select):
-    """
-    A Select widget with a roman numbered list of Paraguayan departments as choices.
-    """
+    """A Select widget with a roman numbered list of Paraguayan departments as choices."""
+
     def __init__(self, attrs=None):
         super(PyNumberedDepartmentSelect, self).__init__(attrs, choices=DEPARTMENT_ROMAN_CHOICES)

--- a/localflavor/ro/forms.py
+++ b/localflavor/ro/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Romanian specific form helpers.
-"""
+"""Romanian specific form helpers."""
 from __future__ import unicode_literals
 
 import datetime
@@ -19,10 +17,11 @@ phone_digits_re = re.compile(r'^[0-9\-\.\(\)\s]{3,20}$')
 
 class ROCIFField(RegexField):
     """
-    A Romanian fiscal identity code (CIF) field
+    A Romanian fiscal identity code (CIF) field.
 
     For CIF validation algorithm see: https://ro.wikipedia.org/wiki/Cod_de_Identificare_Fiscal%C4%83
     """
+
     default_error_messages = {
         'invalid': _("Enter a valid CIF."),
     }
@@ -33,7 +32,7 @@ class ROCIFField(RegexField):
 
     def clean(self, value):
         """
-        CIF validation
+        CIF validation.
 
         Args:
             value: the CIF code
@@ -67,10 +66,11 @@ class ROCIFField(RegexField):
 
 class ROCNPField(RegexField):
     """
-    A Romanian personal identity code (CNP) field
+    A Romanian personal identity code (CNP) field.
 
     For CNP validation algorithm see: https://ro.wikipedia.org/wiki/Cod_numeric_personal
     """
+
     default_error_messages = {
         'invalid': _("Enter a valid CNP."),
     }
@@ -81,7 +81,7 @@ class ROCNPField(RegexField):
 
     def clean(self, value):
         """
-        CNP validations
+        CNP validations.
 
         Args:
             value: the CNP code
@@ -117,9 +117,9 @@ class ROCNPField(RegexField):
 
 class ROCountyField(Field):
     """
-    A form field that validates its input is a Romanian county name or
-    abbreviation. It normalizes the input to the standard vehicle registration
-    abbreviation for the given county.
+    A form field that validates its input is a Romanian county name or abbreviation.
+
+    It normalizes the input to the standard vehicle registration abbreviation for the given county.
 
     WARNING: This field will only accept names written with diacritics (using comma bellow for ș and ț); consider
     using ROCountySelect if this behavior is unacceptable for you
@@ -133,6 +133,7 @@ class ROCountyField(Field):
         | Arges => invalid (no diacritic)
 
     """
+
     default_error_messages = {
         'invalid': 'Enter a Romanian county code or name.',
     }
@@ -166,10 +167,7 @@ class ROCountyField(Field):
 
 
 class ROCountySelect(Select):
-    """
-    A Select widget that uses a list of Romanian counties (județe) as its
-    choices.
-    """
+    """A Select widget that uses a list of Romanian counties (județe) as its choices."""
 
     def __init__(self, attrs=None):
         super(ROCountySelect, self).__init__(attrs, choices=COUNTIES_CHOICES)
@@ -177,7 +175,7 @@ class ROCountySelect(Select):
 
 class ROIBANField(IBANFormField):
     """
-    Romanian International Bank Account Number (IBAN) field
+    Romanian International Bank Account Number (IBAN) field.
 
     .. versionchanged:: 1.1
         Validation error messages changed to the messages used in :class:`.IBANFormField`
@@ -187,12 +185,14 @@ class ROIBANField(IBANFormField):
     """
 
     def __init__(self, *args, **kwargs):
-        super(ROIBANField, self).__init__(use_nordea_extensions=False, include_countries=('RO',), **kwargs)
+        kwargs['use_nordea_extensions'] = False
+        kwargs['include_countries'] = ('RO',)
+        super(ROIBANField, self).__init__(*args, **kwargs)
 
 
 class ROPhoneNumberField(RegexField):
     """
-    Romanian phone number field
+    Romanian phone number field.
 
     .. versionchanged:: 1.1
 
@@ -202,6 +202,7 @@ class ROPhoneNumberField(RegexField):
         | Official documentation (in Romanian): http://www.ancom.org.ro/pnn_1300
 
     """
+
     default_error_messages = {
         'invalid_length':
             _('Phone numbers may only have 7 or 10 digits, except the ' +
@@ -245,6 +246,7 @@ class ROPhoneNumberField(RegexField):
 
 class ROPostalCodeField(RegexField):
     """Romanian postal code field."""
+
     default_error_messages = {
         'invalid': _('Enter a valid postal code in the format XXXXXX'),
     }

--- a/localflavor/ru/forms.py
+++ b/localflavor/ru/forms.py
@@ -1,6 +1,4 @@
-"""
-Russian-specific forms helpers
-"""
+"""Russian-specific forms helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -14,17 +12,15 @@ phone_digits_re = re.compile(r'^(?:[78]-?)?(\d{3})[-\.]?(\d{3})[-\.]?(\d{4})$')
 
 
 class RUCountySelect(Select):
-    """
-    A Select widget that uses a list of Russian Counties as its choices.
-    """
+    """A Select widget that uses a list of Russian Counties as its choices."""
+
     def __init__(self, attrs=None):
         super(RUCountySelect, self).__init__(attrs, choices=RU_COUNTY_CHOICES)
 
 
 class RURegionSelect(Select):
-    """
-    A Select widget that uses a list of Russian Regions as its choices.
-    """
+    """A Select widget that uses a list of Russian Regions as its choices."""
+
     def __init__(self, attrs=None):
         super(RURegionSelect, self).__init__(attrs, choices=RU_REGIONS_CHOICES)
 
@@ -32,8 +28,10 @@ class RURegionSelect(Select):
 class RUPostalCodeField(RegexField):
     """
     Russian Postal code field.
+
     Format: XXXXXX, where X is any digit, and first digit is not zero.
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXXXXX.'),
     }
@@ -45,9 +43,11 @@ class RUPostalCodeField(RegexField):
 
 class RUPassportNumberField(RegexField):
     """
-    Russian internal passport number format:
+    Russian internal passport number format.
+
     XXXX XXXXXX where X - any digit.
     """
+
     default_error_messages = {
         'invalid': _('Enter a passport number in the format XXXX XXXXXX.'),
     }
@@ -59,9 +59,11 @@ class RUPassportNumberField(RegexField):
 
 class RUAlienPassportNumberField(RegexField):
     """
-    Russian alien's passport number format:
+    Russian alien's passport number format.
+
     XX XXXXXXX where X - any digit.
     """
+
     default_error_messages = {
         'invalid': _('Enter a passport number in the format XX XXXXXXX.'),
     }

--- a/localflavor/se/forms.py
+++ b/localflavor/se/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Swedish specific Form helpers
-"""
+"""Swedish specific Form helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -17,14 +15,14 @@ from .utils import (format_organisation_number, format_personal_id_number, id_nu
 __all__ = ('SECountySelect', 'SEOrganisationNumberField',
            'SEPersonalIdentityNumberField', 'SEPostalCodeField')
 
-SWEDISH_ID_NUMBER = re.compile(r'^(?P<century>\d{2})?(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})(?P<sign>[\-+])?(?P<serial>\d{3})(?P<checksum>\d)$')
+SWEDISH_ID_NUMBER = re.compile(r'^(?P<century>\d{2})?(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})'
+                               r'(?P<sign>[\-+])?(?P<serial>\d{3})(?P<checksum>\d)$')
 SE_POSTAL_CODE = re.compile(r'^[1-9]\d{2} ?\d{2}$')
 
 
 class SECountySelect(forms.Select):
     """
-    A Select form widget that uses a list of the Swedish counties (län) as its
-    choices.
+    A Select form widget that uses a list of the Swedish counties (län) as its choices.
 
     The cleaned value is the official county code -- see
     http://en.wikipedia.org/wiki/Counties_of_Sweden for a list.
@@ -37,8 +35,7 @@ class SECountySelect(forms.Select):
 
 class SEOrganisationNumberField(forms.CharField):
     """
-    A form field that validates input as a Swedish organisation number
-    (organisationsnummer).
+    A form field that validates input as a Swedish organisation number (organisationsnummer).
 
     It accepts the same input as SEPersonalIdentityField (for sole
     proprietorships (enskild firma). However, co-ordination numbers are not
@@ -85,8 +82,7 @@ class SEOrganisationNumberField(forms.CharField):
 
 class SEPersonalIdentityNumberField(forms.CharField):
     """
-    A form field that validates input as a Swedish personal identity number
-    (personnummer).
+    A form field that validates input as a Swedish personal identity number (personnummer).
 
     The correct formats are YYYYMMDD-XXXX, YYYYMMDDXXXX, YYMMDD-XXXX,
     YYMMDDXXXX and YYMMDD+XXXX.
@@ -145,6 +141,7 @@ class SEPersonalIdentityNumberField(forms.CharField):
 class SEPostalCodeField(forms.RegexField):
     """
     A form field that validates input as a Swedish postal code (postnummer).
+
     Valid codes consist of five digits (XXXXX). The number can optionally be
     formatted with a space after the third digit (XXX XX).
 

--- a/localflavor/se/utils.py
+++ b/localflavor/se/utils.py
@@ -4,10 +4,7 @@ from django.utils import six
 
 
 def id_number_checksum(gd):
-    """
-    Calculates a Swedish ID number checksum, using the
-    "Luhn"-algoritm
-    """
+    """Calculates a Swedish ID number checksum, using the "Luhn"-algoritm."""
     n = s = 0
     for c in (gd['year'] + gd['month'] + gd['day'] + gd['serial']):
         tmp = ((n % 2) and 1 or 2) * int(c)
@@ -26,12 +23,10 @@ def id_number_checksum(gd):
 
 def validate_id_birthday(gd, fix_coordination_number_day=True):
     """
-    Validates the birth_day and returns the datetime.date object for
-    the birth_day.
+    Validates the birth_day and returns the datetime.date object for the birth_day.
 
     If the date is an invalid birth day, a ValueError will be raised.
     """
-
     today = datetime.date.today()
 
     day = int(gd['day'])

--- a/localflavor/sg/forms.py
+++ b/localflavor/sg/forms.py
@@ -1,6 +1,4 @@
-"""
-Singapore-specific Form helpers
-"""
+"""Singapore-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -26,6 +24,7 @@ class SGPostCodeField(RegexField):
 
     Assumed to be 6 digits.
     """
+
     default_error_messages = {
         'invalid': _('Enter a 6-digit postal code.'),
     }
@@ -40,6 +39,7 @@ class SGPhoneNumberField(CharField):
 
     Valid numbers have 8 digits and start with either 6, 8, or 9
     """
+
     default_error_messages = {
         'invalid': _('Phone numbers must contain 8 digits and start with '
                      'either 6, or 8, or 9.')
@@ -47,9 +47,7 @@ class SGPhoneNumberField(CharField):
     }
 
     def clean(self, value):
-        """
-        Validate a phone number. Strips parentheses, whitespace and hyphens.
-        """
+        """Validate a phone number. Strips parentheses, whitespace and hyphens."""
         super(SGPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -60,9 +58,11 @@ class SGPhoneNumberField(CharField):
         raise ValidationError(self.error_messages['invalid'])
 
 
-class SGNRIC_FINField(CharField):
+# TODO change to a pep8 compatible class name
+class SGNRIC_FINField(CharField):  # noqa
     """
-    A form field that validates input as a Singapore National Registration
+    A form field that validates input as a Singapore National Registration.
+
     Identity Card (NRIC) or Foreign Identification Number (FIN)
 
     Based on http://en.wikipedia.org/wiki/National_Registration_Identity_Card
@@ -77,13 +77,16 @@ class SGNRIC_FINField(CharField):
         S or T: 0=J, 1=Z, 2=I, 3=H, 4=G, 5=F, 6=E, 7=D, 8=C, 9=B, 10=A
         F or G: 0=X, 1=W, 2=U, 3=T, 4=R, 5=Q, 6=P, 7=N, 8=M, 9=L, 10=K
     """
+
     default_error_messages = {
         'invalid': _('Invalid NRIC/FIN.')
     }
 
     def clean(self, value):
         """
-        Validate NRIC/FIN. Strips whitespace.
+        Validate NRIC/FIN.
+
+        Strips whitespace.
         """
         super(SGNRIC_FINField, self).clean(value)
         if value in EMPTY_VALUES:

--- a/localflavor/si/forms.py
+++ b/localflavor/si/forms.py
@@ -1,6 +1,4 @@
-"""
-Slovenian specific form helpers.
-"""
+"""Slovenian specific form helpers."""
 
 from __future__ import unicode_literals
 
@@ -40,6 +38,9 @@ class SIEMSOField(CharField):
         if m is None:
             raise ValidationError(self.error_messages['invalid'])
 
+        # Extract information in the identification number.
+        day, month, year, nationality, gender, checksum = [int(i) for i in m.groups()]
+
         # Validate EMSO
         s = 0
         int_values = [int(i) for i in value]
@@ -47,22 +48,19 @@ class SIEMSOField(CharField):
             s += a * b
         chk = s % 11
         if chk == 0:
-            K = 0
+            k = 0
         else:
-            K = 11 - chk
+            k = 11 - chk
 
-        if K == 10 or int_values[-1] != K:
+        if k == 10 or checksum != k:
             raise ValidationError(self.error_messages['checksum'])
 
-        # Extract extra info in the identification number
-        day, month, year, nationality, gender, chksum = [int(i) for i in m.groups()]
-
+        # Validate birth date.
         if year < 890:
             year += 2000
         else:
             year += 1000
 
-        # validate birthday
         try:
             birthday = datetime.date(year, month, day)
         except ValueError:
@@ -120,18 +118,16 @@ class SITaxNumberField(CharField):
 
 
 class SIPostalCodeField(ChoiceField):
-    """
-    Slovenian post codes field.
-    """
+    """Slovenian post codes field."""
+
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('choices', SI_POSTALCODES_CHOICES)
         super(SIPostalCodeField, self).__init__(*args, **kwargs)
 
 
 class SIPostalCodeSelect(Select):
-    """
-    A Select widget that uses Slovenian postal codes as its choices.
-    """
+    """A Select widget that uses Slovenian postal codes as its choices."""
+
     def __init__(self, attrs=None):
         super(SIPostalCodeSelect, self).__init__(attrs,
                                                  choices=SI_POSTALCODES_CHOICES)

--- a/localflavor/sk/forms.py
+++ b/localflavor/sk/forms.py
@@ -1,6 +1,4 @@
-"""
-Slovak-specific form helpers
-"""
+"""Slovak-specific form helpers."""
 
 from __future__ import unicode_literals
 
@@ -12,17 +10,15 @@ from .sk_regions import REGION_CHOICES
 
 
 class SKRegionSelect(Select):
-    """
-    A select widget widget with list of Slovak regions as choices.
-    """
+    """A select widget widget with list of Slovak regions as choices."""
+
     def __init__(self, attrs=None):
         super(SKRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
 class SKDistrictSelect(Select):
-    """
-    A select widget with list of Slovak districts as choices.
-    """
+    """A select widget with list of Slovak districts as choices."""
+
     def __init__(self, attrs=None):
         super(SKDistrictSelect, self).__init__(attrs, choices=DISTRICT_CHOICES)
 
@@ -30,8 +26,10 @@ class SKDistrictSelect(Select):
 class SKPostalCodeField(RegexField):
     """
     A form field that validates its input as Slovak postal code.
+
     Valid form is XXXXX or XXX XX, where X represents integer.
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXXXX or XXX XX.'),
     }
@@ -43,6 +41,7 @@ class SKPostalCodeField(RegexField):
     def clean(self, value):
         """
         Validates the input and returns a string that contains only numbers.
+
         Returns an empty string for empty values.
         """
         v = super(SKPostalCodeField, self).clean(value)

--- a/localflavor/tn/forms.py
+++ b/localflavor/tn/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Tunisia-specific Form helpers.
-"""
+"""Tunisia-specific Form helpers."""
 from __future__ import unicode_literals
 
 from django.forms.fields import Select
@@ -10,10 +8,8 @@ from .tn_governorates import GOVERNORATE_CHOICES
 
 
 class TNGovernorateSelect(Select):
-    """
-    A Select widget that uses a list of the Tunisian governorates as its
-    choices.
-    """
+    """A Select widget that uses a list of the Tunisian governorates as its choices."""
+
     def __init__(self, attrs=None):
         super(TNGovernorateSelect, self).__init__(
             attrs, choices=GOVERNORATE_CHOICES

--- a/localflavor/tr/forms.py
+++ b/localflavor/tr/forms.py
@@ -15,9 +15,11 @@ phone_digits_re = re.compile(r'^(\+90|0)? ?(([1-9]\d{2})|\([1-9]\d{2}\)) ?([2-9]
 
 class TRPostalCodeField(RegexField):
     """
-    A form field that validates input as a Turkish zip code. Valid codes
-    consist of five digits.
+    A form field that validates input as a Turkish zip code.
+
+    Valid codes consist of five digits.
     """
+
     default_error_messages = {
         'invalid': _('Enter a postal code in the format XXXXX.'),
     }
@@ -40,10 +42,12 @@ class TRPostalCodeField(RegexField):
 
 class TRPhoneNumberField(CharField):
     """
-    A form field that validates input as a Turkish phone number. The correct
-    format is 0xxx xxx xxxx. +90xxx xxx xxxx and inputs without spaces also
+    A form field that validates input as a Turkish phone number.
+
+    The correct format is 0xxx xxx xxxx. +90xxx xxx xxxx and inputs without spaces also
     validates. The result is normalized to xxx xxx xxxx format.
     """
+
     default_error_messages = {
         'invalid': _('Phone numbers must be in 0XXX XXX XXXX format.'),
     }
@@ -62,6 +66,7 @@ class TRPhoneNumberField(CharField):
 class TRIdentificationNumberField(Field):
     """
     A Turkey Identification Number number.
+
     See: http://tr.wikipedia.org/wiki/T%C3%BCrkiye_Cumhuriyeti_Kimlik_Numaras%C4%B1
 
     Checks the following rules to determine whether the number is valid:
@@ -72,6 +77,7 @@ class TRIdentificationNumberField(Field):
           (sum(1st, 3rd, 5th, 7th, 9th)*7 - sum(2nd,4th,6th,8th)) % 10 = 10th digit
           sum(1st to 10th) % 10 = 11th digit
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid Turkish Identification number.'),
         'not_11': _('Turkish Identification number must be 11 digits.'),
@@ -104,8 +110,7 @@ class TRIdentificationNumberField(Field):
 
 
 class TRProvinceSelect(Select):
-    """
-    A Select widget that uses a list of provinces in Turkey as its choices.
-    """
+    """A Select widget that uses a list of provinces in Turkey as its choices."""
+
     def __init__(self, attrs=None):
         super(TRProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)

--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -1,6 +1,4 @@
-"""
-USA-specific Form helpers
-"""
+"""USA-specific Form helpers."""
 
 from __future__ import unicode_literals
 
@@ -17,9 +15,10 @@ ssn_re = re.compile(r"^(?P<area>\d{3})[-\ ]?(?P<group>\d{2})[-\ ]?(?P<serial>\d{
 
 
 class USZipCodeField(RegexField):
-    """"
-    A form field that validates input as a U.S. ZIP code. Valid formats are
-    XXXXX or XXXXX-XXXX.
+    """
+    A form field that validates input as a U.S. ZIP code.
+
+    Valid formats are XXXXX or XXXXX-XXXX.
 
     .. note::
 
@@ -30,6 +29,7 @@ class USZipCodeField(RegexField):
 
     Whitespace around the ZIP code is accepted and automatically trimmed.
     """
+
     default_error_messages = {
         'invalid': _('Enter a zip code in the format XXXXX or XXXXX-XXXX.'),
     }
@@ -44,9 +44,8 @@ class USZipCodeField(RegexField):
 
 
 class USPhoneNumberField(CharField):
-    """
-    A form field that validates input as a U.S. phone number.
-    """
+    """A form field that validates input as a U.S. phone number."""
+
     default_error_messages = {
         'invalid': _('Phone numbers must be in XXX-XXX-XXXX format.'),
     }
@@ -79,6 +78,7 @@ class USSocialSecurityNumberField(CharField):
 
     .. versionadded:: 1.1
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid U.S. Social Security number in XXX-XX-XXXX format.'),
     }
@@ -108,9 +108,11 @@ class USSocialSecurityNumberField(CharField):
 class USStateField(Field):
     """
     A form field that validates its input is a U.S. state name or abbreviation.
+
     It normalizes the input to the standard two-leter postal service
     abbreviation for the given state.
     """
+
     default_error_messages = {
         'invalid': _('Enter a U.S. state or territory.'),
     }
@@ -133,9 +135,8 @@ class USStateField(Field):
 
 
 class USStateSelect(Select):
-    """
-    A Select widget that uses a list of U.S. states/territories as its choices.
-    """
+    """A Select widget that uses a list of U.S. states/territories as its choices."""
+
     def __init__(self, attrs=None):
         from .us_states import STATE_CHOICES
         super(USStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
@@ -143,8 +144,7 @@ class USStateSelect(Select):
 
 class USPSSelect(Select):
     """
-    A Select widget that uses a list of US Postal Service codes as its
-    choices.
+    A Select widget that uses a list of US Postal Service codes as its choices.
 
     .. note::
 
@@ -152,6 +152,7 @@ class USPSSelect(Select):
         please use :class:`~localflavor.us.forms.USZipCodeField`.
 
     """
+
     def __init__(self, attrs=None):
         from .us_states import USPS_CHOICES
         super(USPSSelect, self).__init__(attrs, choices=USPS_CHOICES)

--- a/localflavor/us/models.py
+++ b/localflavor/us/models.py
@@ -1,15 +1,19 @@
 from django.db.models import CharField
 from django.utils.translation import ugettext_lazy as _
 
-from . import forms
+from .forms import USPhoneNumberField as USPhoneNumberFormField
+from .forms import USSocialSecurityNumberField as USSocialSecurityNumberFieldFormField
+from .forms import USZipCodeField as USZipCodeFormField
 from .us_states import STATE_CHOICES, USPS_CHOICES
 
 
 class USStateField(CharField):
     """
-    A model field that forms represent as a ``forms.USStateField`` field and
-    stores the two-letter U.S. state abbreviation in the database.
+    A model field that stores the two-letter U.S. state abbreviation in the database.
+
+    Forms represent it as a ``forms.USStateField`` field.
     """
+
     description = _("U.S. state (two uppercase letters)")
 
     def __init__(self, *args, **kwargs):
@@ -25,16 +29,17 @@ class USStateField(CharField):
 
 
 class USPostalCodeField(CharField):
-    """"
-    A model field that forms represent as a
-    :class:`~localflavor.us.forms.USPSSelect`` field and stores the two-letter
-    U.S. Postal Service abbreviation in the database.
+    """
+    A model field that stores the two-letter U.S. Postal Service abbreviation in the database.
+
+    Forms represent it as a :class:`~localflavor.us.forms.USPSSelect`` field.
 
     .. note::
 
         If you are looking for a model field that validates U.S. ZIP codes
         please use :class:`~localflavor.us.models.USZipCodeField`.
     """
+
     description = _("U.S. postal code (two uppercase letters)")
 
     def __init__(self, *args, **kwargs):
@@ -51,9 +56,9 @@ class USPostalCodeField(CharField):
 
 class USZipCodeField(CharField):
     """
-    A model field that forms represent as a
-    :class:`~localflavor.us.forms.USZipCodeField` field and stores the
-    U.S. ZIP code in the database.
+    A model field that stores the U.S. ZIP code in the database.
+
+    Forms represent it as a :class:`~localflavor.us.forms.USZipCodeField` field.
 
     .. note::
 
@@ -63,6 +68,7 @@ class USZipCodeField(CharField):
     .. versionadded:: 1.1
 
     """
+
     description = _("U.S. ZIP code")
 
     def __init__(self, *args, **kwargs):
@@ -75,16 +81,18 @@ class USZipCodeField(CharField):
         return name, path, args, kwargs
 
     def formfield(self, **kwargs):
-        defaults = {'form_class': forms.USZipCodeField}
+        defaults = {'form_class': USZipCodeFormField}
         defaults.update(kwargs)
         return super(USZipCodeField, self).formfield(**defaults)
 
 
 class PhoneNumberField(CharField):
     """
-    A :class:`~django.db.models.CharField` that checks that the value
-    is a valid U.S.A.-style phone number (in the format ``XXX-XXX-XXXX``).
+    A :class:`~django.db.models.CharField` that checks that the value is a valid U.S.A.-style phone number.
+
+    (in the format ``XXX-XXX-XXXX``).
     """
+
     description = _("Phone number")
 
     def __init__(self, *args, **kwargs):
@@ -97,19 +105,20 @@ class PhoneNumberField(CharField):
         return name, path, args, kwargs
 
     def formfield(self, **kwargs):
-        from localflavor.us.forms import USPhoneNumberField
-        defaults = {'form_class': USPhoneNumberField}
+        defaults = {'form_class': USPhoneNumberFormField}
         defaults.update(kwargs)
         return super(PhoneNumberField, self).formfield(**defaults)
 
 
 class USSocialSecurityNumberField(CharField):
     """
-    A model field that forms represent as ``forms.USSocialSecurityNumberField``
-    and stores in the format ``XXX-XX-XXXX``.
+    A model field that stores  the security number in the format ``XXX-XX-XXXX``.
+
+    Forms represent it as ``forms.USSocialSecurityNumberField`` field.
 
     .. versionadded:: 1.1
     """
+
     description = _("Social security number")
 
     def __init__(self, *args, **kwargs):
@@ -122,8 +131,6 @@ class USSocialSecurityNumberField(CharField):
         return name, path, args, kwargs
 
     def formfield(self, **kwargs):
-        from localflavor.us.forms import (USSocialSecurityNumberField as
-            USSocialSecurityNumberFieldFormField)
         defaults = {'form_class': USSocialSecurityNumberFieldFormField}
         defaults.update(kwargs)
         return super(USSocialSecurityNumberField, self).formfield(**defaults)

--- a/localflavor/us/us_states.py
+++ b/localflavor/us/us_states.py
@@ -1,4 +1,6 @@
 """
+Misspellings/abbreviations mapping.
+
 A mapping of state misspellings/abbreviations to normalized
 abbreviations, and alphabetical lists of US states, territories,
 military mail regions and non-US states to which the US provides

--- a/localflavor/uy/forms.py
+++ b/localflavor/uy/forms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-UY-specific form helpers.
-"""
+"""UY-specific form helpers."""
 
 from __future__ import unicode_literals
 
@@ -14,18 +12,16 @@ from .util import get_validation_digit
 
 
 class UYDepartmentSelect(Select):
-    """
-    A Select widget that uses a list of Uruguayan departments as its choices.
-    """
+    """A Select widget that uses a list of Uruguayan departments as its choices."""
+
     def __init__(self, attrs=None):
         from .uy_departments import DEPARTMENT_CHOICES
         super(UYDepartmentSelect, self).__init__(attrs, choices=DEPARTMENT_CHOICES)
 
 
 class UYCIField(RegexField):
-    """
-    A field that validates Uruguayan 'Cedula de identidad' (CI) numbers.
-    """
+    """A field that validates Uruguayan 'Cedula de identidad' (CI) numbers."""
+
     default_error_messages = {
         'invalid': _("Enter a valid CI number in X.XXX.XXX-X,"
                      "XXXXXXX-X or XXXXXXXX format."),
@@ -45,7 +41,6 @@ class UYCIField(RegexField):
         the correct place. The three typically used formats are supported:
         [X]XXXXXXX, [X]XXXXXX-X and [X.]XXX.XXX-X.
         """
-
         value = super(UYCIField, self).clean(value)
         if value in EMPTY_VALUES:
             return ''
@@ -56,7 +51,7 @@ class UYCIField(RegexField):
         number = int(match.group('num').replace('.', ''))
         validation_digit = int(match.group('val'))
 
-        if not validation_digit == get_validation_digit(number):
+        if validation_digit != get_validation_digit(number):
             raise ValidationError(self.error_messages['invalid_validation_digit'])
 
         return value

--- a/localflavor/uy/util.py
+++ b/localflavor/uy/util.py
@@ -2,12 +2,12 @@
 
 
 def get_validation_digit(number):
-    """ Calculates the validation digit for the given number. """
-    sum = 0
+    """Calculates the validation digit for the given number."""
+    weighted_sum = 0
     dvs = [4, 3, 6, 7, 8, 9, 2]
     number = str(number)
 
     for i in range(0, len(number)):
-        sum = (int(number[-1 - i]) * dvs[i] + sum) % 10
+        weighted_sum = (int(number[-1 - i]) * dvs[i] + weighted_sum) % 10
 
-    return (10 - sum) % 10
+    return (10 - weighted_sum) % 10

--- a/localflavor/za/forms.py
+++ b/localflavor/za/forms.py
@@ -1,6 +1,4 @@
-"""
-South Africa-specific Form helpers
-"""
+"""South Africa-specific Form helpers."""
 from __future__ import unicode_literals
 
 import re
@@ -18,10 +16,12 @@ id_re = re.compile(r'^(?P<yy>\d\d)(?P<mm>\d\d)(?P<dd>\d\d)(?P<mid>\d{4})(?P<end>
 
 class ZAIDField(CharField):
     """
-    A form field for South African ID numbers -- the checksum is validated
-    using the Luhn checksum, and uses a simlistic (read: not entirely accurate)
+    A form field for South African ID numbers.
+
+    The checksum is validated using the Luhn checksum, and uses a simlistic (read: not entirely accurate)
     check for the birthdate
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid South African ID number'),
     }
@@ -58,9 +58,11 @@ class ZAIDField(CharField):
 
 class ZAPostCodeField(RegexField):
     """
-    A form field that validates input as a South African postcode. Valid
-    postcodes must have four digits.
+    A form field that validates input as a South African postcode.
+
+    Valid postcodes must have four digits.
     """
+
     default_error_messages = {
         'invalid': _('Enter a valid South African postal code'),
     }
@@ -71,9 +73,8 @@ class ZAPostCodeField(RegexField):
 
 
 class ZAProvinceSelect(Select):
-    """
-    A Select widget that uses a list of South African Provinces as its choices.
-    """
+    """A Select widget that uses a list of South African Provinces as its choices."""
+
     def __init__(self, attrs=None):
         from .za_provinces import PROVINCE_CHOICES
         super(ZAProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)

--- a/tests/test_au/forms.py
+++ b/tests/test_au/forms.py
@@ -4,7 +4,8 @@ from .models import AustralianPlace
 
 
 class AustralianPlaceForm(ModelForm):
-    """ Form for storing an Australian place. """
+    """Form for storing an Australian place."""
+
     class Meta:
         model = AustralianPlace
         fields = ('state', 'state_required', 'state_default', 'postcode',

--- a/tests/test_au/models.py
+++ b/tests/test_au/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+
 from localflavor.au.models import (AUBusinessNumberField, AUPhoneNumberField, AUPostCodeField, AUStateField,
                                    AUTaxFileNumberField)
 

--- a/tests/test_au/tests.py
+++ b/tests/test_au/tests.py
@@ -31,13 +31,13 @@ class AULocalflavorTests(TestCase):
              })
 
     def test_get_display_methods(self):
-        """ Ensure get_*_display() methods are added to model instances. """
+        """Ensure get_*_display() methods are added to model instances."""
         place = self.form.save()
         self.assertEqual(place.get_state_display(), 'Western Australia')
         self.assertEqual(place.get_state_required_display(), 'Queensland')
 
     def test_default_values(self):
-        """ Ensure that default values are selected in forms. """
+        """Ensure that default values are selected in forms."""
         form = AustralianPlaceForm()
         self.assertTrue(re.search(SELECTED_OPTION_PATTERN % 'NSW',
                                   str(form['state_default'])))
@@ -45,7 +45,7 @@ class AULocalflavorTests(TestCase):
                                   str(form['postcode_default'])))
 
     def test_required(self):
-        """ Test that required AUStateFields throw appropriate errors. """
+        """Test that required AUStateFields throw appropriate errors."""
         form = AustralianPlaceForm({'state': 'NSW', 'name': 'Wollongong'})
         self.assertFalse(form.is_valid())
         self.assertEqual(set(form.errors.keys()),
@@ -62,12 +62,12 @@ class AULocalflavorTests(TestCase):
             form.errors['tfn'], ['This field is required.'])
 
     def test_field_blank_option(self):
-        """ Test that the empty option is there. """
+        """Test that the empty option is there."""
         self.assertTrue(re.search(BLANK_OPTION_PATTERN,
                                   str(self.form['state'])))
 
     def test_selected_values(self):
-        """ Ensure selected states match the initial values provided. """
+        """Ensure selected states match the initial values provided."""
         self.assertTrue(re.search(SELECTED_OPTION_PATTERN % 'WA',
                                   str(self.form['state'])))
         self.assertTrue(re.search(SELECTED_OPTION_PATTERN % 'QLD',
@@ -255,14 +255,12 @@ class AULocalFlavourAUBusinessNumberFormFieldTests(TestCase):
 
     def test_abn_with_spaces_remains_unchanged(self):
         """Test that an ABN with the formatting we expect is unchanged."""
-
         field = forms.AUBusinessNumberField()
 
         self.assertEqual('53 004 085 616', field.prepare_value('53 004 085 616'))
 
     def test_spaces_are_reconfigured(self):
         """Test that an ABN with formatting we don't expect is transformed."""
-
         field = forms.AUBusinessNumberField()
 
         self.assertEqual('53 004 085 616', field.prepare_value('53004085616'))
@@ -273,14 +271,12 @@ class AULocalFlavourAUTaxFileNumberFormFieldTests(TestCase):
 
     def test_tfn_with_spaces_remains_unchanged(self):
         """Test that a TFN with the formatting we expect is unchanged."""
-
         field = forms.AUTaxFileNumberField()
 
         self.assertEqual('123 456 782', field.prepare_value('123 456 782'))
 
     def test_spaces_are_reconfigured(self):
         """Test that a TFN with formatting we don't expect is transformed."""
-
         field = forms.AUTaxFileNumberField()
 
         self.assertEqual('123 456 782', field.prepare_value('123456782'))
@@ -291,7 +287,6 @@ class AULocalFlavourAUBusinessNumberModelFieldTests(TestCase):
 
     def test_to_python_strips_whitespace(self):
         """Test the value is stored without whitespace."""
-
         field = models.AUBusinessNumberField()
 
         self.assertEqual('53004085616', field.to_python('53 004 085 616'))
@@ -301,7 +296,6 @@ class AULocalFlavourAUTaxFileNumberModelFieldTests(TestCase):
 
     def test_to_python_strips_whitespace(self):
         """Test the value is stored without whitespace."""
-
         field = models.AUTaxFileNumberField()
 
         self.assertEqual('123456782', field.to_python('123 456 782'))

--- a/tests/test_generic/test_checksums.py
+++ b/tests/test_generic/test_checksums.py
@@ -11,9 +11,7 @@ class TestUtilsChecksums(unittest.TestCase):
                 checksum.__name__, repr(value), output, not output))
 
     def test_luhn(self):
-        """
-        Check that function(value) equals output.
-        """
+        """Check that function(value) equals output."""
         result_pairs = (
             (4111111111111111, True),
             ('4111111111111111', True),

--- a/tests/test_generic/tests.py
+++ b/tests/test_generic/tests.py
@@ -151,7 +151,7 @@ class IBANTests(TestCase):
             self.assertEqual(iban1, iban2, msg="IBAN validators with equal parameters are not equal.")
 
     def test_iban_fields(self):
-        """ Test the IBAN model and form field. """
+        """Test the IBAN model and form field."""
         valid = {
             'NL02ABNA0123456789': 'NL02ABNA0123456789',
             'Nl02aBNa0123456789': 'NL02ABNA0123456789',
@@ -208,7 +208,7 @@ class IBANTests(TestCase):
             self.assertEqual(context_manager.exception.messages, errors)
 
     def test_nordea_extensions(self):
-        """ Test a valid IBAN in the Nordea extensions. """
+        """Test a valid IBAN in the Nordea extensions."""
         iban_validator = IBANValidator(use_nordea_extensions=True)
         # Run the validator to ensure there are no ValidationErrors raised.
         iban_validator('Eg1100006001880800100014553')
@@ -230,7 +230,7 @@ class IBANTests(TestCase):
         self.assertEqual(iban_form_field.to_python(None), '')
 
     def test_include_countries(self):
-        """ Test the IBAN model and form include_countries feature. """
+        """Test the IBAN model and form include_countries feature."""
         include_countries = ('NL', 'BE', 'LU')
 
         valid = {
@@ -261,7 +261,7 @@ class IBANTests(TestCase):
             self.assertEqual(context_manager.exception.messages, errors)
 
     def test_misconfigured_include_countries(self):
-        """ Test that an IBAN field or model raises an error when asked to validate a country not part of IBAN. """
+        """Test that an IBAN field or model raises an error when asked to validate a country not part of IBAN."""
         # Test an unassigned ISO 3166-1 country code.
         self.assertRaises(ImproperlyConfigured, IBANValidator, include_countries=('JJ',))
         self.assertRaises(ImproperlyConfigured, IBANValidator, use_nordea_extensions=True, include_countries=('JJ',))
@@ -270,7 +270,7 @@ class IBANTests(TestCase):
         self.assertRaises(ImproperlyConfigured, IBANValidator, include_countries=('AO',))
 
     def test_sepa_countries(self):
-        """ Test include_countries using the SEPA counties. """
+        """Test include_countries using the SEPA counties."""
         # A few SEPA valid IBANs.
         valid = {
             'GI75 NWBK 0000 0000 7099 453': 'GI75NWBK000000007099453',

--- a/tests/test_gr.py
+++ b/tests/test_gr.py
@@ -6,8 +6,7 @@ from localflavor.gr.forms import GRMobilePhoneNumberField, GRPhoneNumberField, G
 class GRLocalFlavorTests(SimpleTestCase):
 
     def test_GRTaxNumberField(self):
-        """ The valid tests are from greek tax numbers (AFMs) found on the internet
-        with a google search. """
+        """The valid tests are from greek tax numbers (AFMs) found on the internet with a google search."""
         error = ['Enter a valid greek tax number (9 digits).']
         valid = {
             '090051291': '090051291',

--- a/tests/test_in.py
+++ b/tests/test_in.py
@@ -84,7 +84,7 @@ class INLocalFlavorTests(SimpleTestCase):
 
     def test_INAadhaarNumberField(self):
         error_format = ['Enter a valid Aadhaar number in XXXX XXXX XXXX or '
-                                                    'XXXX-XXXX-XXXX format.']
+                        'XXXX-XXXX-XXXX format.']
         valid = {
             '3603-1178-8988': '3603 1178 8988',
             '1892 3114 7727': '1892 3114 7727',

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -6,8 +6,6 @@ from django.test import SimpleTestCase
 
 from localflavor.it.forms import (ITPhoneNumberField, ITRegionProvinceSelect, ITRegionSelect,
                                   ITSocialSecurityNumberField, ITVatNumberField, ITZipCodeField)
-from localflavor.it.it_province import *
-from localflavor.it.it_region import *
 
 
 class ITLocalFlavorTests(SimpleTestCase):

--- a/tests/test_lt.py
+++ b/tests/test_lt.py
@@ -141,7 +141,6 @@ class LTLocalFlavorTests(SimpleTestCase):
                    'o 600 00 000': [errors['non-digit']]}
         self.assertFieldOutput(LTPhoneField, {}, invalid)
 
-
     def test_LTPhoneField_emergency(self):
         errors = LTPhoneField().error_messages
 

--- a/tests/test_mk/tests.py
+++ b/tests/test_mk/tests.py
@@ -21,18 +21,13 @@ class MKLocalFlavorTests(TestCase):
         })
 
     def test_get_display_methods(self):
-        """
-        Test that the get_*_display() methods are added to the model instances.
-        """
+        """Test that the get_*_display() methods are added to the model instances."""
         person = self.form.save()
         self.assertEqual(person.get_municipality_display(), 'Ohrid')
         self.assertEqual(person.get_municipality_req_display(), 'Veles')
 
     def test_municipality_required(self):
-        """
-        Test that required MKMunicipalityFields throw appropriate errors.
-        """
-
+        """Test that required MKMunicipalityFields throw appropriate errors."""
         form = MKPersonForm({
             'first_name': 'Someone',
             'last_name': 'Something',
@@ -45,9 +40,7 @@ class MKLocalFlavorTests(TestCase):
             form.errors['municipality_req'], ['This field is required.'])
 
     def test_umcn_invalid(self):
-        """
-        Test that UMCNFields throw appropriate errors for invalid UMCNs.
-        """
+        """Test that UMCNFields throw appropriate errors for invalid UMCNs."""
         form = MKPersonForm({
             'first_name': 'Someone',
             'last_name': 'Something',
@@ -71,11 +64,7 @@ class MKLocalFlavorTests(TestCase):
                          ['The first 7 digits of the UMCN must represent a valid past date.'])
 
     def test_idnumber_invalid(self):
-        """
-        Test that MKIdentityCardNumberFields throw
-        appropriate errors for invalid values
-        """
-
+        """Test that MKIdentityCardNumberFields throw appropriate errors for invalid values"""
         form = MKPersonForm({
             'first_name': 'Someone',
             'last_name': 'Something',
@@ -90,9 +79,7 @@ class MKLocalFlavorTests(TestCase):
                           'digits or an uppercase letter and 7 digits.'])
 
     def test_field_blank_option(self):
-        """
-        Test that the empty option is there.
-        """
+        """Test that the empty option is there."""
         municipality_select_html = """\
 <select name="municipality" id="id_municipality">
 <option value="">---------</option>

--- a/tests/test_mx/models.py
+++ b/tests/test_mx/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+
 from localflavor.mx.models import (MXCLABEField, MXCURPField, MXRFCField, MXSocialSecurityNumberField, MXStateField,
                                    MXZipCodeField)
 

--- a/tests/test_mx/tests.py
+++ b/tests/test_mx/tests.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
+
 from localflavor.mx.forms import (MXCLABEField, MXCURPField, MXRFCField, MXSocialSecurityNumberField, MXStateSelect,
                                   MXZipCodeField)
 

--- a/tests/test_nl/tests.py
+++ b/tests/test_nl/tests.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django import db
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 
@@ -96,7 +95,6 @@ class NLLocalFlavorModelTests(SimpleTestCase):
         self.assertEqual(field.to_python(None), None)
 
         self.assertIsInstance(field.formfield(), forms.NLZipCodeField)
-
 
     def test_NL_model(self):
         m = NLPlace(**{

--- a/tests/test_pk/forms.py
+++ b/tests/test_pk/forms.py
@@ -4,7 +4,8 @@ from .models import PakistaniPlace
 
 
 class PakistaniPlaceForm(ModelForm):
-    """ Form for storing a Pakistani place. """
+    """Form for storing a Pakistani place."""
+
     class Meta:
         model = PakistaniPlace
         fields = ('state', 'state_required', 'state_default', 'postcode', 'postcode_required', 'postcode_default',

--- a/tests/test_pk/tests.py
+++ b/tests/test_pk/tests.py
@@ -26,13 +26,13 @@ class PKLocalflavorTests(TestCase):
              })
 
     def test_get_display_methods(self):
-        """ Ensure get_*_display() methods are added to model instances. """
+        """Ensure get_*_display() methods are added to model instances."""
         place = self.form.save()
         self.assertEqual(place.get_state_display(), 'Islamabad')
         self.assertEqual(place.get_state_required_display(), 'Punjab')
 
     def test_default_values(self):
-        """ Ensure that default values are selected in forms. """
+        """Ensure that default values are selected in forms."""
         form = PakistaniPlaceForm()
         self.assertTrue(re.search(SELECTED_OPTION_PATTERN % 'PK-IS',
                                   str(form['state_default'])))
@@ -40,7 +40,7 @@ class PKLocalflavorTests(TestCase):
                                   str(form['postcode_default'])))
 
     def test_required(self):
-        """ Test that required PKStateFields throw appropriate errors. """
+        """Test that required PKStateFields throw appropriate errors."""
         form = PakistaniPlaceForm({'state': 'PK-PB', 'name': 'Lahore'})
         self.assertFalse(form.is_valid())
         self.assertEqual(
@@ -49,12 +49,12 @@ class PKLocalflavorTests(TestCase):
             form.errors['postcode_required'], ['This field is required.'])
 
     def test_field_blank_option(self):
-        """ Test that the empty option is there. """
+        """Test that the empty option is there."""
         self.assertTrue(re.search(BLANK_OPTION_PATTERN,
                                   str(self.form['state'])))
 
     def test_selected_values(self):
-        """ Ensure selected states match the initial values provided. """
+        """Ensure selected states match the initial values provided."""
         self.assertTrue(re.search(SELECTED_OPTION_PATTERN % 'PK-IS',
                                   str(self.form['state'])))
         self.assertTrue(re.search(SELECTED_OPTION_PATTERN % 'PK-PB',

--- a/tests/test_pt.py
+++ b/tests/test_pt.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Contains a set of tests which can be used to validate the current implementation.
-"""
+"""Contains a set of tests which can be used to validate the current implementation."""
 from __future__ import unicode_literals
 
 from django.test import SimpleTestCase
@@ -13,7 +11,8 @@ from localflavor.pt.forms import (PTCitizenCardNumberField, PTPhoneNumberField, 
 class PTLocalFlavorTests(SimpleTestCase):
     def test_PTCitizenCardNumberField(self):
         error_badchecksum = ['The specified value is not a valid Citizen Card number.']
-        error_invalid = ['Citizen Card numbers have the format XXXXXXXXXYYX or XXXXXXXX-XYYX (where X is a digit and Y is an alphanumeric character).']
+        error_invalid = ['Citizen Card numbers have the format XXXXXXXXXYYX or XXXXXXXX-XYYX '
+                         '(where X is a digit and Y is an alphanumeric character).']
         valid = {
             '132011441ZZ8': '13201144-1ZZ8',
             '129463833ZY7': '12946383-3ZY7',
@@ -44,7 +43,8 @@ class PTLocalFlavorTests(SimpleTestCase):
         self.assertFieldOutput(PTCitizenCardNumberField, valid, invalid)
 
     def test_PTPhoneNumberField(self):
-        error_invalid = ['Phone numbers have at least 3 and at most 9 digits and may optionally be prefixed with \'00351\' or \'+351\'.']
+        error_invalid = ['Phone numbers have at least 3 and at most 9 digits '
+                         'and may optionally be prefixed with \'00351\' or \'+351\'.']
         valid = {
             '117': '117',
             '4800': '4800',
@@ -92,7 +92,8 @@ class PTLocalFlavorTests(SimpleTestCase):
 
     def test_PTSocialSecurityNumberField(self):
         error_badchecksum = ['The specified number is not a valid Social Security number.']
-        error_invalid = ['Social Security numbers must be in the format XYYYYYYYYYY (where X is either 1 or 2 and Y is any other digit).']
+        error_invalid = ['Social Security numbers must be in the format XYYYYYYYYYY '
+                         '(where X is either 1 or 2 and Y is any other digit).']
         valid = {
             '12347312896': 12347312896,
             '21865241240': 21865241240,
@@ -115,7 +116,8 @@ class PTLocalFlavorTests(SimpleTestCase):
         self.assertFieldOutput(PTSocialSecurityNumberField, valid, invalid)
 
     def test_PTZipCodeField(self):
-        error_invalid = ['Zip codes must be in the format XYYY-YYY (where X is a digit between 1 and 9 and Y is any other digit).']
+        error_invalid = ['Zip codes must be in the format XYYY-YYY '
+                         '(where X is a digit between 1 and 9 and Y is any other digit).']
         valid = {
             '3030-034': '3030-034',
             '3800-011': '3800-011',

--- a/tests/test_ro.py
+++ b/tests/test_ro.py
@@ -116,11 +116,11 @@ class ROLocalFlavorTests(SimpleTestCase):
 
     def test_ROPhoneNumberField(self):
         error_invalid_length = ['Phone numbers may only have 7 or 10 digits,' +
-            ' except the national short numbers which have 3 to 6 digits']
+                                ' except the national short numbers which have 3 to 6 digits']
         error_invalid_long_format = ['Normal phone numbers (7 or 10 digits)' +
-            ' must begin with "0"']
+                                     ' must begin with "0"']
         error_invalid_short_format = ['National short numbers (3 to 6 digits)' +
-            ' must begin with "1"']
+                                      ' must begin with "1"']
         valid = {
             '112': '112',
             '12 345': '12345',

--- a/tests/test_tn.py
+++ b/tests/test_tn.py
@@ -7,13 +7,10 @@ from localflavor.tn.forms import TNGovernorateSelect
 
 
 class TNLocalFlavorTests(SimpleTestCase):
-    """
-    Tunisia Local Flavor Tests class.
-    """
+    """Tunisia Local Flavor Tests class."""
+
     def test_tn_governorate_select(self):
-        """
-        Tests Select Governorate.
-        """
+        """Tests Select Governorate."""
         form = TNGovernorateSelect()
 
         select_governorate_html = '''<select name="governorate">

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 [testenv:prospector]
 deps = prospector
 basepython = python2.7
-commands = prospector --zero-exit {toxinidir}
+commands = prospector --profile localflavor.prospector.yaml {toxinidir}
 
 [testenv:isort]
 deps = isort>=4.2,<4.3


### PR DESCRIPTION
I have fixed most pep8, pep257 and other styling errors that didn't let prospector validate
Added a custom config for prospector, that inherits hygh_strictness, but has a line length setting changed to 120, and has pep8 N802 disabled because it is conflicting with test naming.


**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`
