### PR TITLE
Added new french regions (2016 reform).

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -9,6 +9,7 @@ Authors
 * Alex Gaynor
 * Alex Hill
 * Alex Zhang
+* Alix Martineau
 * Alonisser
 * Andreas Pelme
 * Andres Torres Marroquin

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ New fields for existing flavors:
   (`gh-238 <https://github.com/django/django-localflavor/pull/238>`_)
 - Added KWGovernorateSelect field to easily select Kuwait governorates.
   (`gh-231 <https://github.com/django/django-localflavor/pull/231>`_).
+- Added FRNewRegionSelect field to stick to current legislation.
 
 Modifications to existing flavors:
 

--- a/docs/localflavor/fr.rst
+++ b/docs/localflavor/fr.rst
@@ -18,3 +18,4 @@ Data
 
 .. autodata:: localflavor.fr.fr_region.REGION_CHOICES
 
+.. autodata:: localflavor.fr.fr_region.NEW_REGION_CHOICES

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -16,7 +16,7 @@ from django.utils.translation import ugettext_lazy as _
 from localflavor.generic.checksums import luhn
 
 from .fr_department import DEPARTMENT_CHOICES_PER_REGION
-from .fr_region import REGION_CHOICES
+from .fr_region import NEW_REGION_CHOICES, REGION_CHOICES
 
 nin_re = re.compile(
     r'^(?P<gender>[1278])(?P<year_of_birth>\d{2})(?P<month_of_birth>0[1-9]|1[0-2]|20|3[0-9]|4[0-2]|[5-9][0-9])'
@@ -104,6 +104,18 @@ class FRRegionSelect(Select):
             attrs,
             choices=choices
         )
+
+
+class FRNewRegionSelect(Select):
+    """
+    A Select widget that uses a list of France's New Regions as its choices.
+    """
+    def __init__(self, attrs=None):
+        choices = [
+            (reg[0], '%s - %s' % (reg[0], reg[1]))
+            for reg in NEW_REGION_CHOICES
+        ]
+        super(FRNewRegionSelect, self).__init__(attrs, choices=choices)
 
 
 class FRDepartmentField(CharField):

--- a/localflavor/fr/fr_region.py
+++ b/localflavor/fr/fr_region.py
@@ -33,3 +33,27 @@ REGION_CHOICES = (
     ('93', 'Provence-Alpes-Côte d\'Azur'),
     ('94', 'Corse')
 )
+
+#: France changed its regions in 2016 (see http://www.insee.fr/fr/methodes/nomenclatures/cog/)
+NEW_REGION_CHOICES = (
+    # Overseas regions
+    ('01', "Guadeloupe"),
+    ('02', "Martinique"),
+    ('03', "Guyane"),
+    ('04', "La Réunion"),
+    ('06', "Mayotte"),
+    # Metropolitan regions
+    ('11', "Île-de-France"),
+    ('24', "Centre-Val de Loire"),
+    ('27', "Bourgogne-Franche-Comté"),
+    ('28', "Normandie"),
+    ('32', "Nord-Pas-de-Calais-Picardie"),
+    ('44', "Alsace-Champagne-Ardenne-Lorraine"),
+    ('52', "Pays de la Loire"),
+    ('53', "Bretagne"),
+    ('75', "Aquitaine-Limousin-Poitou-Charentes"),
+    ('76', "Languedoc-Roussillon-Midi-Pyrénées"),
+    ('84', "Auvergne-Rhône-Alpes"),
+    ('93', "Provence-Alpes-Côte d'Azur"),
+    ('94', "Corse"),
+)

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from django.test import SimpleTestCase
 
 from localflavor.fr.forms import (FRDepartmentField, FRDepartmentSelect, FRNationalIdentificationNumber,
-                                  FRPhoneNumberField, FRRegionField, FRRegionSelect, FRSIRENField, FRSIRETField,
-                                  FRZipCodeField)
+                                  FRNewRegionSelect, FRPhoneNumberField, FRRegionField, FRRegionSelect, FRSIRENField,
+                                  FRSIRETField, FRZipCodeField)
 
 
 DEP_SELECT_OUTPUT = '''
@@ -156,6 +156,29 @@ REG_SELECT_OUTPUT = '''
     </select>
 '''
 
+NEW_REG_SELECT_OUTPUT = '''
+    <select name="reg">
+        <option value="01">01 - Guadeloupe</option>
+        <option value="02">02 - Martinique</option>
+        <option value="03">03 - Guyane</option>
+        <option value="04">04 - La Réunion</option>
+        <option value="06">06 - Mayotte</option>
+        <option value="11">11 - Île-de-France</option>
+        <option value="24">24 - Centre-Val de Loire</option>
+        <option value="27">27 - Bourgogne-Franche-Comté</option>
+        <option value="28">28 - Normandie</option>
+        <option value="32">32 - Nord-Pas-de-Calais-Picardie</option>
+        <option value="44">44 - Alsace-Champagne-Ardenne-Lorraine</option>
+        <option value="52" selected="selected">52 - Pays de la Loire</option>
+        <option value="53">53 - Bretagne</option>
+        <option value="75">75 - Aquitaine-Limousin-Poitou-Charentes</option>
+        <option value="76">76 - Languedoc-Roussillon-Midi-Pyrénées</option>
+        <option value="84">84 - Auvergne-Rhône-Alpes</option>
+        <option value="93">93 - Provence-Alpes-Côte d&#39;Azur</option>
+        <option value="94">94 - Corse</option>
+    </select>
+'''
+
 
 class FRLocalFlavorTests(SimpleTestCase):
     def test_FRZipCodeField(self):
@@ -201,6 +224,11 @@ class FRLocalFlavorTests(SimpleTestCase):
     def test_FRRegionSelect(self):
         f = FRRegionSelect()
         self.assertHTMLEqual(f.render('reg', '25'), REG_SELECT_OUTPUT)
+
+    def test_FRNewRegionSelect(self):
+        self.maxDiff = None
+        f = FRNewRegionSelect()
+        self.assertHTMLEqual(f.render('reg', '52'), NEW_REG_SELECT_OUTPUT)
 
     def test_FRNationalIdentificationNumber(self):
         error_format = ['Enter a valid French National Identification number.']


### PR DESCRIPTION
Added new french regions dataset (http://www.insee.fr/fr/methodes/nomenclatures/cog/).

We should keep the old regions and refer to these ones as "new regions", as the government's decision to change french regions is quite controversial.
Therefore, it's a good idea to leave the option to django-localflavour users to keep using the old regions system, at least for a little while.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`

**New Fields Only**

- [x] Prefix the country code to all fields.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [x] Add documentation for all fields.
