### PR TITLE
Lazily generate US_STATES, STATE_CHOICES, and USPS_CHOICES

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -67,6 +67,7 @@ Authors
 * Michał Sałaban
 * Mike Lissner
 * Olivier Sels
+* Paul Donohue
 * Paulo Poiati
 * Rael Max
 * Ramiro Morales

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,9 @@ Other changes:
 - Ensure the migration framework generates schema migrations for model fields that change the max_length
   (`gh-257 <https://github.com/django/django-localflavor/pull/257>`_). Users will need to generate migrations for any
   model fields they use with 'makemigrations'.
+- Lazily generate US_STATES, STATE_CHOICES, and USPS_CHOICES
+  (`gh-203 <https://github.com/django/django-localflavor/issues/203>`_
+  `gh-272 <https://github.com/django/django-localflavor/pull/272>`_).
 - Deprecated Phone Number fields
   (`gh-262 <https://github.com/django/django-localflavor/pull/262>`_).
 - Bumped versions of requirements for testing

--- a/docs/localflavor/us.rst
+++ b/docs/localflavor/us.rst
@@ -18,7 +18,7 @@ Data
 
 .. autodata:: localflavor.us.us_states.CONTIGUOUS_STATES
 
-.. autodata:: localflavor.us.us_states.US_STATES
+.. autodata:: localflavor.us.us_states.NON_CONTIGUOUS_STATES
 
 .. autodata:: localflavor.us.us_states.US_TERRITORIES
 
@@ -28,8 +28,82 @@ Data
 
 .. autodata:: localflavor.us.us_states.OBSOLETE_STATES
 
-.. autodata:: localflavor.us.us_states.STATE_CHOICES
+.. data:: localflavor.us.us_states.US_STATES
+    :annotation: = CONTIGUOUS_STATES + NON_CONTIGUOUS_STATES
 
-.. autodata:: localflavor.us.us_states.USPS_CHOICES
+    All US states.
+
+    This tuple is lazily generated and may not work as expected in all cases due
+    to tuple optimizations in the Python interpreter which do not account for
+    lazily generated tuples.  For example::
+
+      US_STATES + ('XX', _('Select a State'))
+
+    should work as expected, but::
+
+      ('XX', _('Select a State')) + US_STATES
+
+    may throw:
+
+    ``TypeError: can only concatenate tuple (not "proxy") to tuple``
+
+    due to a Python optimization that causes the concatenation to occur before
+    US_STATES has been lazily generated.  To work around these issues, you
+    can use a slice index (``[:]``) to force the generation of US_STATES
+    before any other operations are processed by the Python interpreter::
+
+      ('XX', _('Select a State')) + US_STATES[:]
+
+.. data:: localflavor.us.us_states.STATE_CHOICES
+    :annotation: = CONTIGUOUS_STATES + NON_CONTIGUOUS_STATES + US_TERRITORIES + ARMED_FORCES_STATES
+
+    All US states and territories plus DC and military mail.
+
+    This tuple is lazily generated and may not work as expected in all cases due
+    to tuple optimizations in the Python interpreter which do not account for
+    lazily generated tuples.  For example::
+
+      STATE_CHOICES + ('XX', _('Select a State'))
+
+    should work as expected, but::
+
+      ('XX', _('Select a State')) + STATE_CHOICES
+
+    may throw:
+
+    ``TypeError: can only concatenate tuple (not "proxy") to tuple``
+
+    due to a Python optimization that causes the concatenation to occur before
+    STATE_CHOICES has been lazily generated.  To work around these issues, you
+    can use a slice index (``[:]``) to force the generation of STATE_CHOICES
+    before any other operations are processed by the Python interpreter::
+
+      ('XX', _('Select a State')) + STATE_CHOICES[:]
+
+.. data:: localflavor.us.us_states.USPS_CHOICES
+    :annotation: = CONTIGUOUS_STATES + NON_CONTIGUOUS_STATES + US_TERRITORIES + ARMED_FORCES_STATES + COFA_STATES
+
+    All US Postal Service locations.
+
+    This tuple is lazily generated and may not work as expected in all cases due
+    to tuple optimizations in the Python interpreter which do not account for
+    lazily generated tuples.  For example::
+
+      USPS_CHOICES + ('XX', _('Select a State'))
+
+    should work as expected, but::
+
+      ('XX', _('Select a State')) + USPS_CHOICES
+
+    may throw:
+
+      ``TypeError: can only concatenate tuple (not "proxy") to tuple``
+
+    due to a Python optimization that causes the concatenation to occur before
+    USPS_CHOICES has been lazily generated.  To work around these issues, you
+    can use a slice index (``[:]``) to force the generation of USPS_CHOICES
+    before any other operations are processed by the Python interpreter::
+
+      ('XX', _('Select a State')) + USPS_CHOICES[:]
 
 .. autodata:: localflavor.us.us_states.STATES_NORMALIZED

--- a/localflavor/us/us_states.py
+++ b/localflavor/us/us_states.py
@@ -12,6 +12,7 @@ when explicitly needed.
 
 import operator
 
+from django.utils.functional import lazy
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import pgettext_lazy
 
@@ -109,13 +110,98 @@ OBSOLETE_STATES = (
     ('TT', _('Trust Territory of the Pacific Islands')),
 )
 
-US_STATES = tuple(sorted(CONTIGUOUS_STATES + NON_CONTIGUOUS_STATES, key=operator.itemgetter(0)))
+US_STATES = lazy(lambda: tuple(sorted(
+    CONTIGUOUS_STATES + NON_CONTIGUOUS_STATES,
+    key=operator.itemgetter(0))), tuple)()
+"""
+This docstring is not read by Sphinx, so it has been copied to
+docs/localflavor/us.rst.
 
-#: All US states and territories plus DC and military mail.
-STATE_CHOICES = tuple(sorted(US_STATES + US_TERRITORIES + ARMED_FORCES_STATES, key=operator.itemgetter(1)))
+All US states.
 
-#: All US Postal Service locations.
-USPS_CHOICES = tuple(sorted(US_STATES + US_TERRITORIES + ARMED_FORCES_STATES + COFA_STATES, key=operator.itemgetter(1)))
+This tuple is lazily generated and may not work as expected in all cases due
+to tuple optimizations in the Python interpreter which do not account for
+lazily generated tuples.  For example::
+
+  US_STATES + ('XX', _('Select a State'))
+
+should work as expected, but::
+
+  ('XX', _('Select a State')) + US_STATES
+
+may throw:
+
+``TypeError: can only concatenate tuple (not "proxy") to tuple``
+
+due to a Python optimization that causes the concatenation to occur before
+US_STATES has been lazily generated.  To work around these issues, you
+can use a slice index (``[:]``) to force the generation of US_STATES
+before any other operations are processed by the Python interpreter::
+
+  ('XX', _('Select a State')) + US_STATES[:]
+"""
+
+STATE_CHOICES = lazy(lambda: tuple(sorted(
+    CONTIGUOUS_STATES + NON_CONTIGUOUS_STATES + US_TERRITORIES + ARMED_FORCES_STATES,
+    key=operator.itemgetter(1))), tuple)()
+"""
+This docstring is not read by Sphinx, so it has been copied to
+docs/localflavor/us.rst.
+
+All US states and territories plus DC and military mail.
+
+This tuple is lazily generated and may not work as expected in all cases due
+to tuple optimizations in the Python interpreter which do not account for
+lazily generated tuples.  For example::
+
+  STATE_CHOICES + ('XX', _('Select a State'))
+
+should work as expected, but::
+
+  ('XX', _('Select a State')) + STATE_CHOICES
+
+may throw:
+
+``TypeError: can only concatenate tuple (not "proxy") to tuple``
+
+due to a Python optimization that causes the concatenation to occur before
+STATE_CHOICES has been lazily generated.  To work around these issues, you
+can use a slice index (``[:]``) to force the generation of STATE_CHOICES
+before any other operations are processed by the Python interpreter::
+
+  ('XX', _('Select a State')) + STATE_CHOICES[:]
+"""
+
+USPS_CHOICES = lazy(lambda: tuple(sorted(
+    CONTIGUOUS_STATES + NON_CONTIGUOUS_STATES + US_TERRITORIES + ARMED_FORCES_STATES + COFA_STATES,
+    key=operator.itemgetter(1))), tuple)()
+"""
+This docstring is not read by Sphinx, so it has been copied to
+docs/localflavor/us.rst.
+
+All US Postal Service locations.
+
+This tuple is lazily generated and may not work as expected in all cases due
+to tuple optimizations in the Python interpreter which do not account for
+lazily generated tuples.  For example::
+
+  USPS_CHOICES + ('XX', _('Select a State'))
+
+should work as expected, but::
+
+  ('XX', _('Select a State')) + USPS_CHOICES
+
+may throw:
+
+``TypeError: can only concatenate tuple (not "proxy") to tuple``
+
+due to a Python optimization that causes the concatenation to occur before
+USPS_CHOICES has been lazily generated.  To work around these issues, you
+can use a slice index (``[:]``) to force the generation of USPS_CHOICES
+before any other operations are processed by the Python interpreter::
+
+  ('XX', _('Select a State')) + USPS_CHOICES[:]
+"""
 
 #: Normalized versions of state names
 STATES_NORMALIZED = {


### PR DESCRIPTION
Commit 4369237 introduced lazy translations for US state names.
However, US_STATES, STATE_CHOICES, and USPS_CHOICES are sorted at import
time based on the translated state names.  This causes two problems:
1) If localflavor.us is imported during Django initialization, then an
   exception will be thrown because translations cannot be made during
   Django initialization.
   (See https://github.com/django/django-localflavor/issues/203)
2) When the run-time translations are different than the import-time
   translations, US_STATES, STATE_CHOICES, and USPS_CHOICES are not
   re-sorted based on the run-time translations, so those lists may be
   mis-sorted.

This commit corrects these problems by lazily sorting US_STATES,
STATE_CHOICES, and USPS_CHOICES.  (Fixes #203)

Unfortunately, while this works as expected in most cases, the lazy
evaluation may not work as expected in every case due to internal tuple
optimizations in the Python interpreter.  For example,
`US_STATES + ('XX', _('Select a State'))` works as expected, but
`('XX', _('Select a State')) + US_STATES` throws
'TypeError: can only concatenate tuple (not "__proxy__") to tuple'
because Python concatenates the tuples in C code without making any
Python code calls to the US_STATES object.  To work around this, you can
use a slice index to force the necessary Python code calls:
`('XX', _('Select a State')) + US_STATES[:]`



- [X] Add an entry to the docs/changelog.rst describing the change.

- [X] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [X] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`
