### PR TITLE
Add Australian Company Number validator

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -10,6 +10,7 @@ Authors
 * Alex Gaynor
 * Alex Hill
 * Alex Zhang
+* Alexey Kotlyarov
 * Alix Martineau
 * Alonisser
 * Andreas Pelme

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ New fields for existing flavors:
 
 - Added NOBankAccountNumber form field.
   (`gh-275 <https://github.com/django/django-localflavor/pull/275>`_)
+- Added AUCompanyNumberField model and form field.
+  (`gh-278 <https://github.com/django/django-localflavor/pull/278>`_)
 
 Modifications to existing flavors:
 

--- a/localflavor/au/forms.py
+++ b/localflavor/au/forms.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .au_states import STATE_CHOICES
-from .validators import AUBusinessNumberFieldValidator, AUTaxFileNumberFieldValidator
+from .validators import AUBusinessNumberFieldValidator, AUCompanyNumberFieldValidator, AUTaxFileNumberFieldValidator
 
 PHONE_DIGITS_RE = re.compile(r'^(\d{10})$')
 
@@ -86,6 +86,28 @@ class AUBusinessNumberField(CharField):
 
         spaceless = ''.join(value.split())
         return '{} {} {} {}'.format(spaceless[:2], spaceless[2:5], spaceless[5:8], spaceless[8:])
+
+
+class AUCompanyNumberField(CharField):
+    """
+    A form field that validates input as an Australian Company Number (ACN).
+
+    .. versionadded:: 1.5
+    """
+
+    default_validators = [AUCompanyNumberFieldValidator()]
+
+    def to_python(self, value):
+        value = super(AUCompanyNumberField, self).to_python(value)
+        return value.upper().replace(' ', '')
+
+    def prepare_value(self, value):
+        """Format the value for display."""
+        if value is None:
+            return value
+
+        spaceless = ''.join(value.split())
+        return '{} {} {}'.format(spaceless[:3], spaceless[3:6], spaceless[6:])
 
 
 class AUTaxFileNumberField(CharField):

--- a/localflavor/au/models.py
+++ b/localflavor/au/models.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from localflavor.generic.models import DeprecatedPhoneNumberField
 from . import forms
 from .au_states import STATE_CHOICES
-from .validators import AUBusinessNumberFieldValidator, AUTaxFileNumberFieldValidator
+from .validators import AUBusinessNumberFieldValidator, AUCompanyNumberFieldValidator, AUTaxFileNumberFieldValidator
 
 
 class AUStateField(CharField):
@@ -84,6 +84,36 @@ class AUBusinessNumberField(CharField):
     def to_python(self, value):
         """Ensure the ABN is stored without spaces."""
         value = super(AUBusinessNumberField, self).to_python(value)
+
+        if value is not None:
+            return ''.join(value.split())
+
+        return value
+
+
+class AUCompanyNumberField(CharField):
+    """
+    A model field that checks that the value is a valid Australian Company Number (ACN).
+
+    .. versionadded:: 1.5
+    """
+
+    description = _("Australian Company Number")
+
+    validators = [AUCompanyNumberFieldValidator()]
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 9
+        super(AUCompanyNumberField, self).__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.AUCompanyNumberField}
+        defaults.update(kwargs)
+        return super(AUCompanyNumberField, self).formfield(**defaults)
+
+    def to_python(self, value):
+        """Ensure the ACN is stored without spaces."""
+        value = super(AUCompanyNumberField, self).to_python(value)
 
         if value is not None:
             return ''.join(value.split())

--- a/localflavor/au/validators.py
+++ b/localflavor/au/validators.py
@@ -51,6 +51,49 @@ class AUBusinessNumberFieldValidator(RegexValidator):
             raise ValidationError(self.error_message)
 
 
+class AUCompanyNumberFieldValidator(RegexValidator):
+    """
+    Validation for Australian Company Numbers.
+
+    .. versionadded:: 1.5
+    """
+
+    error_message = _('Enter a valid ACN.')
+
+    def __init__(self):
+        nine_digits = '^\d{9}$'
+        super(AUCompanyNumberFieldValidator, self).__init__(
+            regex=nine_digits, message=self.error_message)
+
+    def _is_valid(self, value):
+        """
+        Return whether the given value is a valid ACN.
+
+        See http://www.clearwater.com.au/code/acn for a description of the
+        validation algorithm.
+
+        """
+        digits = [int(i) for i in list(value)]
+
+        # 1. Multiply each digit by its weighting factor.
+        weighting_factors = [8, 7, 6, 5, 4, 3, 2, 1]
+        weighted = [digit * weight for digit, weight in zip(digits, weighting_factors)]
+
+        # 3. Sum the resulting values.
+        total = sum(weighted)
+
+        # 4. Calculate the check digit
+        check = (10 - total % 10) % 10
+
+        # 5. Check against the last digit
+        return check == digits[8]
+
+    def __call__(self, value):
+        super(AUCompanyNumberFieldValidator, self).__call__(value)
+        if not self._is_valid(value):
+            raise ValidationError(self.error_message)
+
+
 class AUTaxFileNumberFieldValidator(RegexValidator):
     """
     Validation for Australian Tax File Numbers.

--- a/tests/test_au/models.py
+++ b/tests/test_au/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 
-from localflavor.au.models import (AUBusinessNumberField, AUPhoneNumberField, AUPostCodeField, AUStateField,
-                                   AUTaxFileNumberField)
+from localflavor.au.models import (AUBusinessNumberField, AUCompanyNumberField, AUPhoneNumberField, AUPostCodeField,
+                                   AUStateField, AUTaxFileNumberField)
 
 
 class AustralianPlace(models.Model):
@@ -14,4 +14,5 @@ class AustralianPlace(models.Model):
     phone = AUPhoneNumberField(blank=True)
     name = models.CharField(max_length=20)
     abn = AUBusinessNumberField()
+    acn = AUCompanyNumberField()
     tfn = AUTaxFileNumberField()

--- a/tests/test_au/tests.py
+++ b/tests/test_au/tests.py
@@ -133,6 +133,18 @@ class AULocalflavorTests(TestCase):
         }
         self.assertFieldOutput(forms.AUBusinessNumberField, valid, invalid)
 
+    def test_acn(self):
+        error_format = ['Enter a valid ACN.']
+        valid = {
+            '604327504': '604327504',
+            '604 327 504': '604327504',
+        }
+        invalid = {
+            '604327505': error_format,
+            '60A327504': error_format,
+        }
+        self.assertFieldOutput(forms.AUCompanyNumberField, valid, invalid)
+
     def test_tfn(self):
         error_format = ['Enter a valid TFN.']
         valid = {

--- a/tests/test_au/tests.py
+++ b/tests/test_au/tests.py
@@ -322,6 +322,22 @@ class AULocalFlavourAUBusinessNumberFormFieldTests(TestCase):
         self.assertEqual('53 004 085 616', field.prepare_value('53 0 04 08561 6'))
 
 
+class AULocalFlavourAUCompanyNumberFormFieldTests(TestCase):
+
+    def test_abn_with_spaces_remains_unchanged(self):
+        """Test that an ACN with the formatting we expect is unchanged."""
+        field = forms.AUCompanyNumberField()
+
+        self.assertEqual('604 327 504', field.prepare_value('604 327 504'))
+
+    def test_spaces_are_reconfigured(self):
+        """Test that an ACN with formatting we don't expect is transformed."""
+        field = forms.AUCompanyNumberField()
+
+        self.assertEqual('604 327 504', field.prepare_value('604327504'))
+        self.assertEqual('604 327 504', field.prepare_value('60 4 32750 4'))
+
+
 class AULocalFlavourAUTaxFileNumberFormFieldTests(TestCase):
 
     def test_tfn_with_spaces_remains_unchanged(self):

--- a/tests/test_au/tests.py
+++ b/tests/test_au/tests.py
@@ -150,49 +150,45 @@ class AULocalFlavorAUBusinessNumberFieldValidatorTests(TestCase):
 
     def test_no_error_for_a_valid_abn(self):
         """Test a valid ABN does not cause an error."""
+
         valid_abn = '53004085616'
-
         validator = AUBusinessNumberFieldValidator()
-
         validator(valid_abn)
 
     def test_raises_error_for_abn_containing_a_letter(self):
         """Test an ABN containing a letter is invalid."""
+
         invalid_abn = '5300408561A'
-
         validator = AUBusinessNumberFieldValidator()
-
         self.assertRaises(ValidationError, lambda: validator(invalid_abn))
 
     def test_raises_error_for_too_short_abn(self):
         """Test an ABN with fewer than eleven digits is invalid."""
+
         invalid_abn = '5300408561'
-
         validator = AUBusinessNumberFieldValidator()
-
         self.assertRaises(ValidationError, lambda: validator(invalid_abn))
 
     def test_raises_error_for_too_long_abn(self):
         """Test an ABN with more than eleven digits is invalid."""
+
         invalid_abn = '530040856160'
         validator = AUBusinessNumberFieldValidator()
         self.assertRaises(ValidationError, lambda: validator(invalid_abn))
 
     def test_raises_error_for_whitespace(self):
         """Test an ABN can be valid when it contains whitespace."""
-        # NB: Form field should strip the whitespace before regex valdation is run.
+
+        # NB: Form field should strip the whitespace before regex validation is run.
         invalid_abn = '5300 4085 616'
-
         validator = AUBusinessNumberFieldValidator()
-
         self.assertRaises(ValidationError, lambda: validator(invalid_abn))
 
     def test_raises_error_for_invalid_abn(self):
         """Test that an ABN must pass the ATO's validation algorithm."""
+
         invalid_abn = '53004085617'
-
         validator = AUBusinessNumberFieldValidator()
-
         self.assertRaises(ValidationError, lambda: validator(invalid_abn))
 
 
@@ -200,49 +196,45 @@ class AULocalFlavorAUCompanyNumberFieldValidatorTests(TestCase):
 
     def test_no_error_for_a_valid_acn(self):
         """Test a valid ACN does not cause an error."""
+
         valid_acn = '604327504'
-
         validator = AUCompanyNumberFieldValidator()
-
         validator(valid_acn)
 
     def test_raises_error_for_acn_containing_a_letter(self):
         """Test an ACN containing a letter is invalid."""
+
         invalid_acn = '60432750A'
-
         validator = AUCompanyNumberFieldValidator()
-
         self.assertRaises(ValidationError, lambda: validator(invalid_acn))
 
     def test_raises_error_for_too_short_acn(self):
         """Test an ACN with fewer than nine digits is invalid."""
+
         invalid_acn = '60432750'
-
         validator = AUCompanyNumberFieldValidator()
-
         self.assertRaises(ValidationError, lambda: validator(invalid_acn))
 
     def test_raises_error_for_too_long_acn(self):
         """Test an ACN with more than nine digits is invalid."""
+
         invalid_acn = '6043275040'
         validator = AUCompanyNumberFieldValidator()
         self.assertRaises(ValidationError, lambda: validator(invalid_acn))
 
     def test_raises_error_for_whitespace(self):
         """Test an ACN can be valid when it contains whitespace."""
-        # NB: Form field should strip the whitespace before regex valdation is run.
+
+        # NB: Form field should strip the whitespace before regex validation is run.
         invalid_acn = '604 327 504'
-
         validator = AUCompanyNumberFieldValidator()
-
         self.assertRaises(ValidationError, lambda: validator(invalid_acn))
 
     def test_raises_error_for_invalid_acn(self):
         """Test that an ACN must pass the ATO's validation algorithm."""
+
         invalid_acn = '604327509'
-
         validator = AUCompanyNumberFieldValidator()
-
         self.assertRaises(ValidationError, lambda: validator(invalid_acn))
 
 

--- a/tests/test_au/tests.py
+++ b/tests/test_au/tests.py
@@ -6,7 +6,8 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from localflavor.au import forms, models
-from localflavor.au.validators import AUBusinessNumberFieldValidator, AUTaxFileNumberFieldValidator
+from localflavor.au.validators import (AUBusinessNumberFieldValidator, AUCompanyNumberFieldValidator,
+                                       AUTaxFileNumberFieldValidator)
 
 from .forms import AustralianPlaceForm
 from .models import AustralianPlace
@@ -193,6 +194,56 @@ class AULocalFlavorAUBusinessNumberFieldValidatorTests(TestCase):
         validator = AUBusinessNumberFieldValidator()
 
         self.assertRaises(ValidationError, lambda: validator(invalid_abn))
+
+
+class AULocalFlavorAUCompanyNumberFieldValidatorTests(TestCase):
+
+    def test_no_error_for_a_valid_acn(self):
+        """Test a valid ACN does not cause an error."""
+        valid_acn = '604327504'
+
+        validator = AUCompanyNumberFieldValidator()
+
+        validator(valid_acn)
+
+    def test_raises_error_for_acn_containing_a_letter(self):
+        """Test an ACN containing a letter is invalid."""
+        invalid_acn = '60432750A'
+
+        validator = AUCompanyNumberFieldValidator()
+
+        self.assertRaises(ValidationError, lambda: validator(invalid_acn))
+
+    def test_raises_error_for_too_short_acn(self):
+        """Test an ACN with fewer than nine digits is invalid."""
+        invalid_acn = '60432750'
+
+        validator = AUCompanyNumberFieldValidator()
+
+        self.assertRaises(ValidationError, lambda: validator(invalid_acn))
+
+    def test_raises_error_for_too_long_acn(self):
+        """Test an ACN with more than nine digits is invalid."""
+        invalid_acn = '6043275040'
+        validator = AUCompanyNumberFieldValidator()
+        self.assertRaises(ValidationError, lambda: validator(invalid_acn))
+
+    def test_raises_error_for_whitespace(self):
+        """Test an ACN can be valid when it contains whitespace."""
+        # NB: Form field should strip the whitespace before regex valdation is run.
+        invalid_acn = '604 327 504'
+
+        validator = AUCompanyNumberFieldValidator()
+
+        self.assertRaises(ValidationError, lambda: validator(invalid_acn))
+
+    def test_raises_error_for_invalid_acn(self):
+        """Test that an ACN must pass the ATO's validation algorithm."""
+        invalid_acn = '604327509'
+
+        validator = AUCompanyNumberFieldValidator()
+
+        self.assertRaises(ValidationError, lambda: validator(invalid_acn))
 
 
 class AULocalFlavorAUTaxFileNumberFieldValidatorTests(TestCase):


### PR DESCRIPTION
Add [Australian Company Number](https://en.wikipedia.org/wiki/Australian_Company_Number) model and form fields.

Note that running `isort --recursive --line-width 120 localflavor tests` produced changes in otherwise unchanged files. I've limited my changes to the files I touched.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`

**New Fields Only**

- [x] Prefix the country code to all fields.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [x] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [x] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [x] Add documentation for all fields.
