### PR TITLE
Fix saving a single space for empty postcode value.

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -27,6 +27,7 @@ Authors
 * Daniela Ponader
 * Danielle Madeley
 * Daniel Roschka
+* Diederik van der Boor
 * d.merc
 * Douglas Miranda
 * Elliott Fawcett

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ Modifications to existing flavors:
 
 - Added normalized versions of COFA state names for US.
   (`gh-277 <https://github.com/django/django-localflavor/pull/277>`_)
+- Fixed Dutch NLZipCodeField field not to store empty value as a single space.
+  (`gh-280 <https://github.com/django/django-localflavor/pull/280>`_)
 
 Other changes:
 

--- a/localflavor/nl/models.py
+++ b/localflavor/nl/models.py
@@ -30,9 +30,10 @@ class NLZipCodeField(models.CharField):
 
     def to_python(self, value):
         value = super(NLZipCodeField, self).to_python(value)
-        if value is not None:
+        if value:
             value = value.upper().replace(' ', '')
-            return '%s %s' % (value[:4], value[4:])
+            if len(value) == 6:
+                return '%s %s' % (value[:4], value[4:])
         return value
 
     def formfield(self, **kwargs):

--- a/tests/test_nl/tests.py
+++ b/tests/test_nl/tests.py
@@ -92,6 +92,7 @@ class NLLocalFlavorModelTests(SimpleTestCase):
 
         self.assertEqual(field.to_python('1234AB'), '1234 AB')
         self.assertEqual(field.to_python(None), None)
+        self.assertEqual(field.to_python(''), '')
 
         self.assertIsInstance(field.formfield(), forms.NLZipCodeField)
 


### PR DESCRIPTION
When the `NLZipCodeField` contains an empty string, it saves an empty space instead.
This PR updates the test code to check this, and provides the fix.

I've also applied `len(value)` logic found in the formfield `NLZipCodeField.clean()` so the models' `to_python()` becomes more rubust.
