### PR TITLE
us: forms: Typo (leter => letter)

### DIFF
--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -112,7 +112,7 @@ class USStateField(Field):
     A form field that validates its input is a U.S. state, territory, or COFA territory.
     The input is validated against a dictionary which includes names and abbreviations.
 
-    It normalizes the input to the standard two-leter postal service
+    It normalizes the input to the standard two-letter postal service
     abbreviation for the given state.
     """
 


### PR DESCRIPTION
Foregoing changelog, authors, etc. since this is a trivial change.