### PR TITLE
Validate 8-digit Australian tax file numbers properly

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -10,6 +10,7 @@ Authors
 * Alex Gaynor
 * Alex Hill
 * Alex Zhang
+* Alexey Kotlyarov
 * Alix Martineau
 * Alonisser
 * Andreas Pelme

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ Modifications to existing flavors:
   (`gh-277 <https://github.com/django/django-localflavor/pull/277>`_)
 - Fixed Dutch NLZipCodeField field not to store empty value as a single space.
   (`gh-280 <https://github.com/django/django-localflavor/pull/280>`_)
+- Fixed validation for old Australian tax file numbers.
+  (`gh-284 <https://github.com/django/django-localflavor/pull/284>`_)
 
 Other changes:
 

--- a/localflavor/au/validators.py
+++ b/localflavor/au/validators.py
@@ -56,6 +56,7 @@ class AUTaxFileNumberFieldValidator(RegexValidator):
     Validation for Australian Tax File Numbers.
 
     .. versionadded:: 1.4
+    .. versionchanged:: 1.5
     """
 
     error_message = _('Enter a valid TFN.')
@@ -75,7 +76,12 @@ class AUTaxFileNumberFieldValidator(RegexValidator):
         """
         # 1. Multiply each digit by its weighting factor.
         digits = [int(i) for i in list(value)]
-        weighting_factors = [1, 4, 3, 7, 5, 8, 6, 9, 10]
+
+        if len(digits) == 8:
+            weighting_factors = [10, 7, 8, 4, 6, 3, 5, 1]
+        else:
+            weighting_factors = [1, 4, 3, 7, 5, 8, 6, 9, 10]
+
         weighted = [digit * weight for digit, weight in zip(digits, weighting_factors)]
 
         # 2. Sum the resulting values.

--- a/tests/test_au/tests.py
+++ b/tests/test_au/tests.py
@@ -233,6 +233,14 @@ class AULocalFlavorAUTaxFileNumberFieldValidatorTests(TestCase):
         validator = AUTaxFileNumberFieldValidator()
         self.assertRaises(ValidationError, lambda: validator(invalid_tfn))
 
+    def test_old_tfn(self):
+        """Test old, 8-digit TFNs."""
+        validator = AUTaxFileNumberFieldValidator()
+        old_valid_tfn = '38593474'
+        validator(old_valid_tfn)
+        old_invalid_tfn = '38593475'
+        self.assertRaises(ValidationError, lambda: validator(old_invalid_tfn))
+
 
 class AULocalFlavorAUBusinessNumberModelTests(TestCase):
 


### PR DESCRIPTION
Fix validating 8-digit [Australian tax file numbers](https://en.wikipedia.org/wiki/Tax_file_number).

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`