### PR TITLE
Fixes #294

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -73,6 +73,7 @@ Authors
 * Olivier Sels
 * Paul Donohue
 * Paulo Poiati
+* Peter J. Farrell
 * Rael Max
 * Ramiro Morales
 * Rolf Erik Lekang

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,8 @@ Modifications to existing flavors:
 
 Other changes:
 
-- None
+- Fixed crash with USZipCodeField form validation when null=True is allowed
+  (`gh-295 <https://github.com/django/django-localflavor/pull/295>`_)
 
 1.5   (2017-05-26)
 ------------------

--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -42,7 +42,10 @@ class USZipCodeField(RegexField):
 
     def to_python(self, value):
         value = super(USZipCodeField, self).to_python(value)
-        return value.strip()
+        if value:
+            return value.strip()
+        else:
+            return value
 
 
 class USPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):

--- a/tests/test_us/tests.py
+++ b/tests/test_us/tests.py
@@ -265,6 +265,10 @@ class USLocalFlavorTests(TestCase):
         }
         self.assertFieldOutput(forms.USZipCodeField, valid, invalid)
 
+    def test_USZipCodeField_null(self):
+        field = forms.USZipCodeField(required=False, empty_value=None)
+        self.assertIsNone(field.clean(None))
+
     def test_USZipCodeField_formfield(self):
         """Test that the full US ZIP code field is really the full list."""
         self.assertHTMLEqual(str(self.form['zip_code']),

--- a/tests/test_us/tests.py
+++ b/tests/test_us/tests.py
@@ -266,8 +266,13 @@ class USLocalFlavorTests(TestCase):
         self.assertFieldOutput(forms.USZipCodeField, valid, invalid)
 
     def test_USZipCodeField_null(self):
-        field = forms.USZipCodeField(required=False, empty_value=None)
-        self.assertIsNone(field.clean(None))
+        # Django < 1.11 doesn't support empty_value
+        try:
+            field = forms.USZipCodeField(required=False, empty_value=None)
+            self.assertIsNone(field.clean(None))
+        except TypeError:
+            field = forms.USZipCodeField(required=False)
+            self.assertEqual('', field.clean(None))
 
     def test_USZipCodeField_formfield(self):
         """Test that the full US ZIP code field is really the full list."""


### PR DESCRIPTION
Fixes form validation crash for USZipCodeField when field is null=True, blank=True.  See #294 

Do not call strip on a None.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`