### PR TITLE
Fixed IBANFormField to support empty iban

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -92,3 +92,4 @@ Authors
 * Tom Forbes
 * Venelin Stoykov
 * Vladimir Nani
+* Tom Raz

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Other changes:
 
 - Fixed crash with USZipCodeField form validation when null=True is allowed
   (`gh-295 <https://github.com/django/django-localflavor/pull/295>`_)
+- Fixed IBANFormField to support empty iban
 
 1.5   (2017-05-26)
 ------------------

--- a/localflavor/generic/forms.py
+++ b/localflavor/generic/forms.py
@@ -93,6 +93,8 @@ class IBANFormField(forms.CharField):
 
     def to_python(self, value):
         value = super(IBANFormField, self).to_python(value)
+        if value is None:
+            return value
         return value.upper().replace(' ', '').replace('-', '')
 
     def prepare_value(self, value):


### PR DESCRIPTION
Currently, when using IBANField in django admin, and the field is nullable and blank=true, an exception is raised when trying to save the form without an iban.
I added handling of this case in the IBANFormField.
**All Changes**

- [V ] Add an entry to the docs/changelog.rst describing the change.

- [ V] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [V ] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`
