### PR TITLE
Empty value django 1.11

### DIFF
--- a/localflavor/ar/forms.py
+++ b/localflavor/ar/forms.py
@@ -3,10 +3,11 @@
 
 from __future__ import unicode_literals
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor.compat import EmptyValueCompatMixin
 
 from .ar_provinces import PROVINCE_CHOICES
 
@@ -18,7 +19,7 @@ class ARProvinceSelect(Select):
         super(ARProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 
 
-class ARPostalCodeField(RegexField):
+class ARPostalCodeField(EmptyValueCompatMixin, RegexField):
     """
     A field that accepts a 'classic' NNNN Postal Code or a CPA.
 
@@ -38,8 +39,8 @@ class ARPostalCodeField(RegexField):
 
     def clean(self, value):
         value = super(ARPostalCodeField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if len(value) not in (4, 8):
             raise ValidationError(self.error_messages['invalid'])
         if len(value) == 8:
@@ -47,7 +48,7 @@ class ARPostalCodeField(RegexField):
         return value
 
 
-class ARDNIField(CharField):
+class ARDNIField(EmptyValueCompatMixin, CharField):
     """A field that validates 'Documento Nacional de Identidad' (DNI) numbers."""
 
     default_error_messages = {
@@ -62,8 +63,8 @@ class ARDNIField(CharField):
     def clean(self, value):
         """Value can be a string either in the [X]X.XXX.XXX or [X]XXXXXXX formats."""
         value = super(ARDNIField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if not value.isdigit():
             value = value.replace('.', '')
         if not value.isdigit():
@@ -74,7 +75,7 @@ class ARDNIField(CharField):
         return value
 
 
-class ARCUITField(RegexField):
+class ARCUITField(EmptyValueCompatMixin, RegexField):
     """
     This field validates a CUIT (Código Único de Identificación Tributaria).
 
@@ -100,8 +101,8 @@ class ARCUITField(RegexField):
     def clean(self, value):
         """Value can be either a string in the format XX-XXXXXXXX-X or an 11-digit number."""
         value = super(ARCUITField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value, cd = self._canon(value)
         if not value[:2] in ['27', '20', '30', '23', '24', '33']:
             raise ValidationError(self.error_messages['legal_type'])
@@ -132,7 +133,7 @@ class ARCUITField(RegexField):
         return '%s-%s-%s' % (cuit[:2], cuit[2:], check_digit)
 
 
-class ARCBUField(CharField):
+class ARCBUField(EmptyValueCompatMixin, CharField):
     """
     This field validates a CBU (Clave Bancaria Uniforme).
 
@@ -184,8 +185,8 @@ class ARCBUField(CharField):
     def clean(self, value):
         """Value must be a 22 digits long number."""
         value = super(ARCBUField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if not value.isdigit():
             raise ValidationError(self.error_messages['invalid'])
         if not self._checksum(value):

--- a/localflavor/au/forms.py
+++ b/localflavor/au/forms.py
@@ -4,12 +4,12 @@ from __future__ import unicode_literals
 
 import re
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .au_states import STATE_CHOICES
@@ -35,7 +35,7 @@ class AUPostCodeField(RegexField):
                                               max_length, min_length, *args, **kwargs)
 
 
-class AUPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class AUPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     A form field that validates input as an Australian phone number.
 
@@ -49,8 +49,8 @@ class AUPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
     def clean(self, value):
         """Validate a phone number. Strips parentheses, whitespace and hyphens."""
         super(AUPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub('(\(|\)|\s+|-)', '', force_text(value))
         phone_match = PHONE_DIGITS_RE.search(value)
         if phone_match:
@@ -65,7 +65,7 @@ class AUStateSelect(Select):
         super(AUStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
 
-class AUBusinessNumberField(CharField):
+class AUBusinessNumberField(EmptyValueCompatMixin, CharField):
     """
     A form field that validates input as an Australian Business Number (ABN).
 
@@ -77,6 +77,8 @@ class AUBusinessNumberField(CharField):
 
     def to_python(self, value):
         value = super(AUBusinessNumberField, self).to_python(value)
+        if value in self.empty_values:
+            return self.empty_value
         return value.upper().replace(' ', '')
 
     def prepare_value(self, value):
@@ -88,7 +90,7 @@ class AUBusinessNumberField(CharField):
         return '{} {} {} {}'.format(spaceless[:2], spaceless[2:5], spaceless[5:8], spaceless[8:])
 
 
-class AUCompanyNumberField(CharField):
+class AUCompanyNumberField(EmptyValueCompatMixin, CharField):
     """
     A form field that validates input as an Australian Company Number (ACN).
 
@@ -99,6 +101,8 @@ class AUCompanyNumberField(CharField):
 
     def to_python(self, value):
         value = super(AUCompanyNumberField, self).to_python(value)
+        if value in self.empty_values:
+            return self.empty_value
         return value.upper().replace(' ', '')
 
     def prepare_value(self, value):

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -11,6 +11,7 @@ from django.forms.fields import CharField, Field, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .br_states import STATE_CHOICES
@@ -103,7 +104,7 @@ def DV_maker(v):  # noqa
     return dv_maker(v)
 
 
-class BRCPFField(CharField):
+class BRCPFField(EmptyValueCompatMixin, CharField):
     """
     A form field that validates a CPF number or a CPF string.
 
@@ -124,8 +125,8 @@ class BRCPFField(CharField):
     def clean(self, value):
         """Value can be either a string in the format XXX.XXX.XXX-XX or an 11-digit number."""
         value = super(BRCPFField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         orig_value = value[:]
         if not value.isdigit():
             cpf = cpf_digits_re.search(value)
@@ -153,7 +154,7 @@ class BRCPFField(CharField):
         return orig_value
 
 
-class BRCNPJField(CharField):
+class BRCNPJField(EmptyValueCompatMixin, CharField):
     """
     A form field that validates input as `Brazilian CNPJ`_.
 
@@ -183,8 +184,8 @@ class BRCNPJField(CharField):
     def clean(self, value):
         """Value can be either a string in the format XX.XXX.XXX/XXXX-XX or a group of 14 characters."""
         value = super(BRCNPJField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         orig_value = value[:]
         if not value.isdigit():
             cnpj = cnpj_digits_re.search(value)
@@ -213,7 +214,7 @@ def mod_97_base10(value):
     return 98 - ((value * 100 % 97) % 97)
 
 
-class BRProcessoField(CharField):
+class BRProcessoField(EmptyValueCompatMixin, CharField):
     """
     A form field that validates a Legal Process(Processo) number or a Legal Process string.
 
@@ -232,8 +233,8 @@ class BRProcessoField(CharField):
     def clean(self, value):
         """Value can be either a string in the format NNNNNNN-DD.AAAA.J.TR.OOOO or an 20-digit number."""
         value = super(BRProcessoField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         orig_value = value[:]
         if not value.isdigit():

--- a/localflavor/ca/forms.py
+++ b/localflavor/ca/forms.py
@@ -10,6 +10,7 @@ from django.forms.fields import CharField, Field, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.checksums import luhn
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
@@ -17,7 +18,7 @@ phone_digits_re = re.compile(r'^(?:1-?)?(\d{3})[-\.]?(\d{3})[-\.]?(\d{4})$')
 sin_re = re.compile(r"^(\d{3})-(\d{3})-(\d{3})$")
 
 
-class CAPostalCodeField(CharField):
+class CAPostalCodeField(EmptyValueCompatMixin, CharField):
     """
     Canadian postal code form field.
 
@@ -36,8 +37,8 @@ class CAPostalCodeField(CharField):
 
     def clean(self, value):
         value = super(CAPostalCodeField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         postcode = value.upper().strip()
         m = self.postcode_regex.match(postcode)
         if not m:

--- a/localflavor/cl/forms.py
+++ b/localflavor/cl/forms.py
@@ -2,11 +2,12 @@
 
 from __future__ import unicode_literals
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor.compat import EmptyValueCompatMixin
 
 from .cl_regions import REGION_CHOICES
 
@@ -18,7 +19,7 @@ class CLRegionSelect(Select):
         super(CLRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
-class CLRutField(RegexField):
+class CLRutField(EmptyValueCompatMixin, RegexField):
     """
     Chilean "Rol Unico Tributario" (RUT) field.
 
@@ -48,8 +49,8 @@ class CLRutField(RegexField):
     def clean(self, value):
         """Check and clean the Chilean RUT."""
         super(CLRutField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         rut, verificador = self._canonify(value)
         if self._algorithm(rut) == verificador:
             return self._format(rut, verificador)

--- a/localflavor/cn/forms.py
+++ b/localflavor/cn/forms.py
@@ -8,6 +8,7 @@ from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .cn_provinces import CN_PROVINCE_CHOICES
@@ -87,7 +88,7 @@ class CNPostCodeField(RegexField):
         super(CNPostCodeField, self).__init__(POST_CODE_RE, *args, **kwargs)
 
 
-class CNIDCardField(CharField):
+class CNIDCardField(EmptyValueCompatMixin, CharField):
     """
     A form field that validates input as a Resident Identity Card (PRC) number.
 
@@ -116,8 +117,8 @@ class CNIDCardField(CharField):
         """Check whether the input is a valid ID Card Number."""
         # Check the length of the ID card number.
         super(CNIDCardField, self).clean(value)
-        if not value:
-            return ""
+        if value in self.empty_values:
+            return self.empty_value
         # Check whether this ID card number has valid format
         if not re.match(ID_CARD_RE, value):
             raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/compat.py
+++ b/localflavor/compat.py
@@ -1,0 +1,18 @@
+
+class EmptyValueCompatMixin(object):
+    """
+    forms.CharField in Django >= 1.11 has an 'empty_value' keyword argument for representing a value for "empty".
+
+    https://docs.djangoproject.com/en/1.11/ref/forms/fields/#django.forms.CharField.empty_value
+
+    This mixin adds self.empty_value set to an empty string for Django <= 1.10. This allows localflavor form fields to
+    use self.empty_value consistently across Django versions.
+
+    This mixin does not add an 'empty_value' keyword argument to versions of Django that don't already support it.
+
+    This mixin can be removed when localflavor removes support for Django <= 1.10.
+    """
+    def __init__(self, *args, **kwargs):
+        super(EmptyValueCompatMixin, self).__init__(*args, **kwargs)
+        if not hasattr(self, 'empty_value'):
+            self.empty_value = ''

--- a/localflavor/cz/forms.py
+++ b/localflavor/cz/forms.py
@@ -9,6 +9,8 @@ from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
+
 from .cz_regions import REGION_CHOICES
 
 birth_number = re.compile(r'^(?P<birth>\d{6})/?(?P<id>\d{3,4})$')
@@ -22,7 +24,7 @@ class CZRegionSelect(Select):
         super(CZRegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
-class CZPostalCodeField(RegexField):
+class CZPostalCodeField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates its input as Czech postal code.
 
@@ -43,8 +45,10 @@ class CZPostalCodeField(RegexField):
 
         Returns an empty string for empty values.
         """
-        v = super(CZPostalCodeField, self).clean(value)
-        return v.replace(' ', '')
+        value = super(CZPostalCodeField, self).clean(value)
+        if value in self.empty_values:
+            return self.empty_value
+        return value.replace(' ', '')
 
 
 class CZBirthNumberField(Field):

--- a/localflavor/es/forms.py
+++ b/localflavor/es/forms.py
@@ -5,12 +5,12 @@ from __future__ import unicode_literals
 
 import re
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .es_provinces import PROVINCE_CHOICES
@@ -57,7 +57,7 @@ class ESPhoneNumberField(RegexField, DeprecatedPhoneNumberFormFieldMixin):
                                                  max_length, min_length, *args, **kwargs)
 
 
-class ESIdentityCardNumberField(RegexField):
+class ESIdentityCardNumberField(EmptyValueCompatMixin, RegexField):
     """
     Spanish NIF/NIE/CIF (Fiscal Identification Number) code.
 
@@ -110,8 +110,8 @@ class ESIdentityCardNumberField(RegexField):
 
     def clean(self, value):
         super(ESIdentityCardNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = value.upper().replace(' ', '').replace('-', '')
         m = re.match(self.id_card_pattern %
@@ -148,7 +148,7 @@ class ESIdentityCardNumberField(RegexField):
         return self.nif_control[int(d) % 23]
 
 
-class ESCCCField(RegexField):
+class ESCCCField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates its input as a Spanish bank account or CCC (Codigo Cuenta Cliente).
 
@@ -182,8 +182,8 @@ class ESCCCField(RegexField):
 
     def clean(self, value):
         super(ESCCCField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         m = re.match(r'^(\d{4})[ -]?(\d{4})[ -]?(\d{2})[ -]?(\d{10})$', value)
         entity, office, checksum, account = m.groups()
         if get_checksum('00' + entity + office) + get_checksum(account) == checksum:

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -11,6 +11,7 @@ from django.forms.fields import CharField, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.checksums import luhn
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
@@ -41,7 +42,7 @@ class FRZipCodeField(RegexField):
         super(FRZipCodeField, self).__init__(r'^\d{5}$', *args, **kwargs)
 
 
-class FRPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class FRPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     Validate local French phone number (not international ones).
 
@@ -64,8 +65,8 @@ class FRPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
 
     def clean(self, value):
         value = super(FRPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub('(\.|\s)', '', force_text(value))
         m = self.phone_digits_re.search(value)
         if m:
@@ -139,7 +140,7 @@ class FRRegionField(CharField):
         super(FRRegionField, self).__init__(*args, **kwargs)
 
 
-class FRNationalIdentificationNumber(CharField):
+class FRNationalIdentificationNumber(EmptyValueCompatMixin, CharField):
     """
     Validates input as a French National Identification number.
 
@@ -154,8 +155,8 @@ class FRNationalIdentificationNumber(CharField):
 
     def clean(self, value):
         super(FRNationalIdentificationNumber, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = value.replace(' ', '').replace('-', '')
 
@@ -225,8 +226,8 @@ class FRSIRENENumberMixin(object):
 
     def clean(self, value):
         super(FRSIRENENumberMixin, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = value.replace(' ', '').replace('-', '')
         if not self.r_valid.match(value) or not luhn(value):
@@ -234,7 +235,7 @@ class FRSIRENENumberMixin(object):
         return value
 
 
-class FRSIRENField(FRSIRENENumberMixin, CharField):
+class FRSIRENField(EmptyValueCompatMixin, FRSIRENENumberMixin, CharField):
     """
     SIREN stands for "Système d'identification du répertoire des entreprises".
 
@@ -257,7 +258,7 @@ class FRSIRENField(FRSIRENENumberMixin, CharField):
         return ' '.join((value[:3], value[3:6], value[6:]))
 
 
-class FRSIRETField(FRSIRENENumberMixin, CharField):
+class FRSIRETField(EmptyValueCompatMixin, FRSIRENENumberMixin, CharField):
     """
     SIRET stands for "Système d'identification du répertoire des établissements".
 

--- a/localflavor/gb/forms.py
+++ b/localflavor/gb/forms.py
@@ -8,10 +8,12 @@ from django.forms import ValidationError
 from django.forms.fields import CharField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
+
 from .gb_regions import GB_NATIONS_CHOICES, GB_REGION_CHOICES
 
 
-class GBPostcodeField(CharField):
+class GBPostcodeField(EmptyValueCompatMixin, CharField):
     """
     A form field that validates its input is a UK postcode.
 
@@ -31,8 +33,8 @@ class GBPostcodeField(CharField):
 
     def clean(self, value):
         value = super(GBPostcodeField, self).clean(value)
-        if value == '':
-            return value
+        if value in self.empty_values:
+            return self.empty_value
         postcode = value.upper().strip()
         # Put a single space before the incode (second part).
         postcode = self.space_regex.sub(r' \1', postcode)

--- a/localflavor/generic/forms.py
+++ b/localflavor/generic/forms.py
@@ -4,6 +4,7 @@ import warnings
 
 from django import forms
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.deprecation import RemovedInLocalflavor20Warning
 
 from .validators import IBAN_COUNTRY_CODE_LENGTH, BICValidator, IBANValidator
@@ -56,7 +57,7 @@ class SplitDateTimeField(forms.SplitDateTimeField):
                                                  input_time_formats=input_time_formats, *args, **kwargs)
 
 
-class IBANFormField(forms.CharField):
+class IBANFormField(EmptyValueCompatMixin, forms.CharField):
     """
     An IBAN consists of up to 34 alphanumeric characters.
 
@@ -93,6 +94,8 @@ class IBANFormField(forms.CharField):
 
     def to_python(self, value):
         value = super(IBANFormField, self).to_python(value)
+        if value in self.empty_values:
+            return self.empty_value
         return value.upper().replace(' ', '').replace('-', '')
 
     def prepare_value(self, value):
@@ -104,7 +107,7 @@ class IBANFormField(forms.CharField):
         return ' '.join(value[i:i + grouping] for i in range(0, len(value), grouping))
 
 
-class BICFormField(forms.CharField):
+class BICFormField(EmptyValueCompatMixin, forms.CharField):
     """
     A BIC consists of 8 (BIC8) or 11 (BIC11) alphanumeric characters.
 
@@ -125,6 +128,8 @@ class BICFormField(forms.CharField):
         # BIC is always written in upper case.
         # https://www2.swift.com/uhbonline/books/public/en_uk/bic_policy/bic_policy.pdf
         value = super(BICFormField, self).to_python(value)
+        if value in self.empty_values:
+            return self.empty_value
         return value.upper()
 
     def prepare_value(self, value):

--- a/localflavor/hk/forms.py
+++ b/localflavor/hk/forms.py
@@ -3,11 +3,11 @@ from __future__ import unicode_literals
 
 import re
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import CharField, ValidationError
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 hk_phone_digits_re = re.compile(r'^(?:852-?)?(\d{4})[-\.]?(\d{4})$')
@@ -17,7 +17,7 @@ hk_formats = ['XXXX-XXXX', '852-XXXX-XXXX', '(+852) XXXX-XXXX',
               'XXXX XXXX', 'XXXXXXXX']
 
 
-class HKPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class HKPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     A form field that validates Hong Kong phone numbers.
 
@@ -49,8 +49,8 @@ class HKPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
     def clean(self, value):
         super(HKPhoneNumberField, self).clean(value)
 
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = re.sub('(\(|\)|\s+|\+)', '', force_text(value))
         m = hk_phone_digits_re.search(value)

--- a/localflavor/hr/forms.py
+++ b/localflavor/hr/forms.py
@@ -11,6 +11,7 @@ from django.forms.fields import Field, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.checksums import luhn
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
@@ -107,7 +108,7 @@ class HRJMBGField(Field):
         return '%s' % (value, )
 
 
-class HROIBField(RegexField):
+class HROIBField(EmptyValueCompatMixin, RegexField):
     """
     Personal Identification Number of Croatia (OIB) field.
 
@@ -124,8 +125,8 @@ class HROIBField(RegexField):
 
     def clean(self, value):
         super(HROIBField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         return '%s' % (value, )
 

--- a/localflavor/il/forms.py
+++ b/localflavor/il/forms.py
@@ -30,8 +30,8 @@ class ILPostalCodeField(RegexField):
         super(ILPostalCodeField, self).__init__(r'^\d{5}$|^\d{7}$', *args, **kwargs)
 
     def clean(self, value):
-        if value not in EMPTY_VALUES:
-            value = value.replace(" ", "")
+        if value not in self.empty_values:
+            value = value.replace(' ', '')
         return super(ILPostalCodeField, self).clean(value)
 
 

--- a/localflavor/in_/forms.py
+++ b/localflavor/in_/forms.py
@@ -10,6 +10,7 @@ from django.forms.fields import CharField, Field, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .in_states import STATE_CHOICES, STATES_NORMALIZED
@@ -38,7 +39,7 @@ phone_digits_re = re.compile(r"""
 aadhaar_re = re.compile(r"^(?P<part1>\d{4})[-\ ]?(?P<part2>\d{4})[-\ ]?(?P<part3>\d{4})$")
 
 
-class INZipCodeField(RegexField):
+class INZipCodeField(EmptyValueCompatMixin, RegexField):
     """A form field that validates input as an Indian zip code, with the format XXXXXXX."""
 
     default_error_messages = {
@@ -51,8 +52,8 @@ class INZipCodeField(RegexField):
 
     def clean(self, value):
         value = super(INZipCodeField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         # Convert to "NNNNNN" if "NNN NNN" given
         value = re.sub(r'^(\d{3})\s(\d{3})$', r'\1\2', value)
         return value
@@ -149,7 +150,7 @@ class INStateSelect(Select):
         super(INStateSelect, self).__init__(attrs, choices=STATE_CHOICES)
 
 
-class INPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class INPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     INPhoneNumberField validates that the data is a valid Indian phone number, including the STD code.
 
@@ -167,8 +168,8 @@ class INPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
 
     def clean(self, value):
         value = super(INPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = force_text(value)
         m = phone_digits_re.match(value)
         if m:

--- a/localflavor/is_/forms.py
+++ b/localflavor/is_/forms.py
@@ -2,19 +2,19 @@
 
 from __future__ import unicode_literals
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField
 from django.forms.widgets import Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .is_postalcodes import IS_POSTALCODES
 
 
-class ISIdNumberField(RegexField):
+class ISIdNumberField(EmptyValueCompatMixin, RegexField):
     """
     Icelandic identification number (kennitala).
 
@@ -33,8 +33,8 @@ class ISIdNumberField(RegexField):
     def clean(self, value):
         value = super(ISIdNumberField, self).clean(value)
 
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = self._canonify(value)
         if self._validate(value):
@@ -60,7 +60,7 @@ class ISIdNumberField(RegexField):
         return force_text(value[:6] + '-' + value[6:])
 
 
-class ISPhoneNumberField(RegexField, DeprecatedPhoneNumberFormFieldMixin):
+class ISPhoneNumberField(EmptyValueCompatMixin, RegexField, DeprecatedPhoneNumberFormFieldMixin):
     """
     Icelandic phone number.
 
@@ -74,8 +74,8 @@ class ISPhoneNumberField(RegexField, DeprecatedPhoneNumberFormFieldMixin):
     def clean(self, value):
         value = super(ISPhoneNumberField, self).clean(value)
 
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         return value.replace('-', '').replace(' ', '')
 

--- a/localflavor/it/forms.py
+++ b/localflavor/it/forms.py
@@ -10,6 +10,7 @@ from django.forms.fields import CharField, Field, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .it_province import PROVINCE_CHOICES
@@ -56,7 +57,7 @@ class ITProvinceSelect(Select):
         super(ITProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
 
 
-class ITSocialSecurityNumberField(RegexField):
+class ITSocialSecurityNumberField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates Italian Tax code (codice fiscale) for both persons and entities.
 
@@ -82,8 +83,8 @@ class ITSocialSecurityNumberField(RegexField):
 
     def clean(self, value):
         value = super(ITSocialSecurityNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub('\s', '', value).upper()
         # Entities SSN are numeric-only
         if value.isdigit():
@@ -116,7 +117,7 @@ class ITVatNumberField(Field):
             raise ValidationError(self.error_messages['invalid'])
 
 
-class ITPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class ITPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     A form field that validates input as an Italian phone number.
 
@@ -131,8 +132,8 @@ class ITPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
 
     def clean(self, value):
         super(ITPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub(r'[^\+\d]', '', force_text(value))
         m = phone_digits_re.match(value)
         if m:

--- a/localflavor/jp/forms.py
+++ b/localflavor/jp/forms.py
@@ -3,10 +3,12 @@
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
+
 from .jp_prefectures import JP_PREFECTURE_CODES, JP_PREFECTURES
 
 
-class JPPostalCodeField(RegexField):
+class JPPostalCodeField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates its input is a Japanese postcode.
 
@@ -24,10 +26,10 @@ class JPPostalCodeField(RegexField):
     def clean(self, value):
         """
         Validates the input and returns a string that contains only numbers.
-
-        Returns an empty string for empty values.
         """
         value = super(JPPostalCodeField, self).clean(value)
+        if value in self.empty_values:
+            return self.empty_value
         return value.replace('-', '')
 
 

--- a/localflavor/kw/forms.py
+++ b/localflavor/kw/forms.py
@@ -5,10 +5,11 @@ import re
 import textwrap
 from datetime import date
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils.translation import gettext_lazy as _
+
+from localflavor.compat import EmptyValueCompatMixin
 
 from .kw_governorates import GOVERNORATE_CHOICES
 
@@ -34,7 +35,7 @@ def is_valid_kw_civilid_checksum(value):
     return True
 
 
-class KWCivilIDNumberField(RegexField):
+class KWCivilIDNumberField(EmptyValueCompatMixin, RegexField):
     """
     Kuwaiti Civil ID numbers are 12 digits, second to seventh digits represents the person's birthdate.
 
@@ -55,8 +56,8 @@ class KWCivilIDNumberField(RegexField):
 
     def clean(self, value):
         super(KWCivilIDNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         cc = value[0]  # Century value
         yy, mm, dd = textwrap.wrap(value[1:7], 2)  # Date parts

--- a/localflavor/lt/forms.py
+++ b/localflavor/lt/forms.py
@@ -9,6 +9,8 @@ from django.forms.fields import Field, RegexField, Select
 from django.utils.six import text_type
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
+
 from .lt_choices import COUNTY_CHOICES, MUNICIPALITY_CHOICES
 
 postalcode = re.compile(r'^(LT\s?-\s?)?(?P<code>\d{5})$', re.IGNORECASE)
@@ -29,7 +31,7 @@ class LTMunicipalitySelect(Select):
                                                    choices=MUNICIPALITY_CHOICES)
 
 
-class LTIDCodeField(RegexField):
+class LTIDCodeField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates as Lithuanian ID Code.
 
@@ -51,8 +53,8 @@ class LTIDCodeField(RegexField):
     def clean(self, value):
         super(LTIDCodeField, self).clean(value)
 
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         if not self.valid_date(value):
             raise ValidationError(self.error_messages['date'])

--- a/localflavor/mk/forms.py
+++ b/localflavor/mk/forms.py
@@ -2,10 +2,11 @@ from __future__ import unicode_literals
 
 import datetime
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor.compat import EmptyValueCompatMixin
 
 from .mk_choices import MK_MUNICIPALITIES
 
@@ -40,7 +41,7 @@ class MKMunicipalitySelect(Select):
         super(MKMunicipalitySelect, self).__init__(attrs, choices=MK_MUNICIPALITIES)
 
 
-class UMCNField(RegexField):
+class UMCNField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates input as a unique master citizen number.
 
@@ -70,8 +71,8 @@ class UMCNField(RegexField):
     def clean(self, value):
         value = super(UMCNField, self).clean(value)
 
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         if not self._validate_date_part(value):
             raise ValidationError(self.error_messages['date'])

--- a/localflavor/mx/forms.py
+++ b/localflavor/mx/forms.py
@@ -4,11 +4,12 @@ from __future__ import unicode_literals
 
 import re
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor.compat import EmptyValueCompatMixin
 
 from .mx_states import STATE_CHOICES
 
@@ -69,7 +70,7 @@ class MXZipCodeField(RegexField):
         super(MXZipCodeField, self).__init__(zip_code_re, *args, **kwargs)
 
 
-class MXRFCField(RegexField):
+class MXRFCField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates a Mexican *Registro Federal de Contribuyentes*.
 
@@ -117,8 +118,8 @@ class MXRFCField(RegexField):
 
     def clean(self, value):
         value = super(MXRFCField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = value.upper()
         if self._has_homoclave(value):
             if not value[-1] == self._checksum(value[:-1]):
@@ -165,7 +166,7 @@ class MXRFCField(RegexField):
         return first_four in RFC_INCONVENIENT_WORDS
 
 
-class MXCLABEField(RegexField):
+class MXCLABEField(EmptyValueCompatMixin, RegexField):
     """
     This field validates a CLABE (Clave Bancaria Estandarizada).
 
@@ -199,8 +200,8 @@ class MXCLABEField(RegexField):
 
     def clean(self, value):
         value = super(MXCLABEField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if not value.isdigit():
             raise ValidationError(self.error_messages['invalid'])
         if not self._checksum(value):
@@ -209,7 +210,7 @@ class MXCLABEField(RegexField):
         return value
 
 
-class MXCURPField(RegexField):
+class MXCURPField(EmptyValueCompatMixin, RegexField):
     """
     A field that validates a Mexican Clave Única de Registro de Población.
 
@@ -251,8 +252,8 @@ class MXCURPField(RegexField):
 
     def clean(self, value):
         value = super(MXCURPField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = value.upper()
         if value[-1] != self._checksum(value[:-1]):
             raise ValidationError(self.error_messages['invalid_checksum'])
@@ -275,7 +276,7 @@ class MXCURPField(RegexField):
         return first_four in CURP_INCONVENIENT_WORDS
 
 
-class MXSocialSecurityNumberField(RegexField):
+class MXSocialSecurityNumberField(EmptyValueCompatMixin, RegexField):
     """
     A field that validates a Mexican Social Security Number.
 
@@ -312,8 +313,8 @@ class MXSocialSecurityNumberField(RegexField):
 
     def clean(self, value):
         value = super(MXSocialSecurityNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if value[-1] != self.__checksum(value[:-1]):
             raise ValidationError(self.error_messages['invalid_checksum'])
         return value

--- a/localflavor/no/forms.py
+++ b/localflavor/no/forms.py
@@ -10,6 +10,7 @@ from django.forms import ValidationError
 from django.forms.fields import CharField, Field, RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .no_municipalities import MUNICIPALITY_CHOICES
@@ -98,7 +99,7 @@ class NOSocialSecurityNumber(Field):
         return birthday
 
 
-class NOBankAccountNumber(CharField):
+class NOBankAccountNumber(EmptyValueCompatMixin, CharField):
     """
     A form field for Norwegian bank account numbers.
 
@@ -126,7 +127,7 @@ class NOBankAccountNumber(CharField):
     def validate(self, value):
         super(NOBankAccountNumber, self).validate(value)
 
-        if value is '':
+        if value in self.empty_values:
             # It's alright to be empty.
             return
         elif not value.isdigit():
@@ -154,11 +155,13 @@ class NOBankAccountNumber(CharField):
 
     def to_python(self, value):
         value = super(NOBankAccountNumber, self).to_python(value)
+        if value in self.empty_values:
+            return self.empty_value
         return value.replace('.', '').replace(' ', '')
 
     def prepare_value(self, value):
-        if value in EMPTY_VALUES:
-            return value
+        if value in self.empty_values:
+            return self.empty_value
         return '{}.{}.{}'.format(value[0:4], value[4:6], value[6:11])
 
 

--- a/localflavor/pe/forms.py
+++ b/localflavor/pe/forms.py
@@ -3,10 +3,11 @@
 
 from __future__ import unicode_literals
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, Select
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor.compat import EmptyValueCompatMixin
 
 from .pe_region import REGION_CHOICES
 
@@ -18,7 +19,7 @@ class PERegionSelect(Select):
         super(PERegionSelect, self).__init__(attrs, choices=REGION_CHOICES)
 
 
-class PEDNIField(CharField):
+class PEDNIField(EmptyValueCompatMixin, CharField):
     """A field that validates Documento Nacional de Identidad (DNI) numbers."""
 
     default_error_messages = {
@@ -33,8 +34,8 @@ class PEDNIField(CharField):
     def clean(self, value):
         """Value must be a string in the XXXXXXXX formats."""
         value = super(PEDNIField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if not value.isdigit():
             raise ValidationError(self.error_messages['invalid'])
         if len(value) != 8:
@@ -43,7 +44,7 @@ class PEDNIField(CharField):
         return value
 
 
-class PERUCField(CharField):
+class PERUCField(EmptyValueCompatMixin, CharField):
     """
     This field validates a RUC (Registro Unico de Contribuyentes).
 
@@ -62,8 +63,8 @@ class PERUCField(CharField):
     def clean(self, value):
         """Value must be an 11-digit number."""
         value = super(PERUCField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if not value.isdigit():
             raise ValidationError(self.error_messages['invalid'])
         if len(value) != 11:

--- a/localflavor/pk/forms.py
+++ b/localflavor/pk/forms.py
@@ -4,12 +4,12 @@ from __future__ import unicode_literals
 
 import re
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .pk_states import STATE_CHOICES
@@ -33,7 +33,7 @@ class PKPostCodeField(RegexField):
         super(PKPostCodeField, self).__init__(POSTCODE_DIGITS_RE, *args, **kwargs)
 
 
-class PKPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class PKPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     A form field that validates input as an Pakistani phone number.
 
@@ -51,8 +51,8 @@ class PKPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
         Strips parentheses, whitespace and hyphens.
         """
         super(PKPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub('(\(|\)|\s+|-)', '', force_text(value))
         phone_match = PHONE_DIGITS_RE.search(value)
         if phone_match:

--- a/localflavor/pl/forms.py
+++ b/localflavor/pl/forms.py
@@ -5,10 +5,11 @@ from __future__ import unicode_literals
 import datetime
 import re
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor.compat import EmptyValueCompatMixin
 
 from .pl_administrativeunits import ADMINISTRATIVE_UNIT_CHOICES
 from .pl_voivodeships import VOIVODESHIP_CHOICES
@@ -28,7 +29,7 @@ class PLCountySelect(Select):
         super(PLCountySelect, self).__init__(attrs, choices=ADMINISTRATIVE_UNIT_CHOICES)
 
 
-class PLPESELField(RegexField):
+class PLPESELField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates as Polish Identification Number (PESEL).
 
@@ -54,8 +55,8 @@ class PLPESELField(RegexField):
 
     def clean(self, value):
         super(PLPESELField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if not self.has_valid_checksum(value):
             raise ValidationError(self.error_messages['checksum'])
         if not self.has_valid_birth_date(value):
@@ -90,7 +91,7 @@ class PLPESELField(RegexField):
             return False
 
 
-class PLNationalIDCardNumberField(RegexField):
+class PLNationalIDCardNumberField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates as Polish National ID Card Number.
 
@@ -113,8 +114,8 @@ class PLNationalIDCardNumberField(RegexField):
 
     def clean(self, value):
         super(PLNationalIDCardNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = value.upper()
 
@@ -144,7 +145,7 @@ class PLNationalIDCardNumberField(RegexField):
         return result % 10 == 0
 
 
-class PLNIPField(RegexField):
+class PLNIPField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates as Polish Tax Number (NIP).
 
@@ -165,8 +166,8 @@ class PLNIPField(RegexField):
 
     def clean(self, value):
         super(PLNIPField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub("[-]", "", value)
         if not self.has_valid_checksum(value):
             raise ValidationError(self.error_messages['checksum'])
@@ -183,7 +184,7 @@ class PLNIPField(RegexField):
         return result == int(number[-1])
 
 
-class PLREGONField(RegexField):
+class PLREGONField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates its input is a REGON number.
 
@@ -202,8 +203,8 @@ class PLREGONField(RegexField):
 
     def clean(self, value):
         super(PLREGONField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if not self.has_valid_checksum(value):
             raise ValidationError(self.error_messages['checksum'])
         return '%s' % value

--- a/localflavor/ro/forms.py
+++ b/localflavor/ro/forms.py
@@ -9,6 +9,7 @@ from django.core.validators import EMPTY_VALUES
 from django.forms import Field, RegexField, Select, ValidationError
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from ..generic.forms import IBANFormField
@@ -17,7 +18,7 @@ from .ro_counties import COUNTIES_CHOICES
 phone_digits_re = re.compile(r'^[0-9\-\.\(\)\s]{3,20}$')
 
 
-class ROCIFField(RegexField):
+class ROCIFField(EmptyValueCompatMixin, RegexField):
     """
     A Romanian fiscal identity code (CIF) field.
 
@@ -39,9 +40,12 @@ class ROCIFField(RegexField):
         Args:
             value: the CIF code
         """
-        value = super(ROCIFField, self).clean(value).strip()
-        if value in EMPTY_VALUES:
-            return ''
+        value = super(ROCIFField, self).clean(value)
+        if value in self.empty_values:
+            return self.empty_value
+
+        # This can be removed when support for Django <= 1.8 is dropped.
+        value = value.strip()
 
         # strip RO part
         if value[0:2] == 'RO':
@@ -66,7 +70,7 @@ class ROCIFField(RegexField):
         return value[::-1]
 
 
-class ROCNPField(RegexField):
+class ROCNPField(EmptyValueCompatMixin, RegexField):
     """
     A Romanian personal identity code (CNP) field.
 
@@ -89,8 +93,8 @@ class ROCNPField(RegexField):
             value: the CNP code
         """
         value = super(ROCNPField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         # check birthdate digits
         try:
@@ -192,7 +196,7 @@ class ROIBANField(IBANFormField):
         super(ROIBANField, self).__init__(*args, **kwargs)
 
 
-class ROPhoneNumberField(RegexField, DeprecatedPhoneNumberFormFieldMixin):
+class ROPhoneNumberField(EmptyValueCompatMixin, RegexField, DeprecatedPhoneNumberFormFieldMixin):
     """
     Romanian phone number field.
 
@@ -227,8 +231,8 @@ class ROPhoneNumberField(RegexField, DeprecatedPhoneNumberFormFieldMixin):
             value: the phone number
         """
         value = super(ROPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = re.sub('[()-. ]', '', value)
         length = len(value)

--- a/localflavor/sg/forms.py
+++ b/localflavor/sg/forms.py
@@ -4,12 +4,12 @@ from __future__ import unicode_literals
 
 import re
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 PHONE_DIGITS_RE = re.compile(r'^[689](\d{7})$')
@@ -35,7 +35,7 @@ class SGPostCodeField(RegexField):
         super(SGPostCodeField, self).__init__(r'^\d{6}$', *args, **kwargs)
 
 
-class SGPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class SGPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     A form field that validates input as a Singapore phone number.
 
@@ -51,8 +51,8 @@ class SGPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
     def clean(self, value):
         """Validate a phone number. Strips parentheses, whitespace and hyphens."""
         super(SGPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub('(\(|\)|\s+|-)', '', force_text(value))
         phone_match = PHONE_DIGITS_RE.search(value)
         if phone_match:
@@ -61,7 +61,7 @@ class SGPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
 
 
 # TODO change to a pep8 compatible class name
-class SGNRIC_FINField(CharField):  # noqa
+class SGNRIC_FINField(EmptyValueCompatMixin, CharField):  # noqa
     """
     A form field that validates input as a Singapore National Registration.
 
@@ -91,8 +91,8 @@ class SGNRIC_FINField(CharField):  # noqa
         Strips whitespace.
         """
         super(SGNRIC_FINField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub('(\s+)', '', force_text(value.upper()))
         match = NRIC_FIN_RE.search(value)
         if not match:

--- a/localflavor/si/forms.py
+++ b/localflavor/si/forms.py
@@ -5,17 +5,17 @@ from __future__ import unicode_literals
 import datetime
 import re
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, ChoiceField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .si_postalcodes import SI_POSTALCODES_CHOICES
 
 
-class SIEMSOField(CharField):
+class SIEMSOField(EmptyValueCompatMixin, CharField):
     """
     A form for validating Slovenian personal identification number.
 
@@ -31,8 +31,8 @@ class SIEMSOField(CharField):
 
     def clean(self, value):
         super(SIEMSOField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = value.strip()
 
@@ -82,7 +82,7 @@ class SIEMSOField(CharField):
             raise ValidationError(self.error_messages['checksum'])
 
 
-class SITaxNumberField(CharField):
+class SITaxNumberField(EmptyValueCompatMixin, CharField):
     """
     Slovenian tax number field.
 
@@ -98,8 +98,8 @@ class SITaxNumberField(CharField):
 
     def clean(self, value):
         super(SITaxNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = value.strip()
 
@@ -139,7 +139,7 @@ class SIPostalCodeSelect(Select):
                                                  choices=SI_POSTALCODES_CHOICES)
 
 
-class SIPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class SIPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     Slovenian phone number field.
 
@@ -163,8 +163,8 @@ class SIPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
 
     def clean(self, value):
         super(SIPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         value = value.replace(' ', '').replace('-', '').replace('/', '')
         m = self.phone_regex.match(value)

--- a/localflavor/sk/forms.py
+++ b/localflavor/sk/forms.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
+
 from .sk_districts import DISTRICT_CHOICES
 from .sk_regions import REGION_CHOICES
 
@@ -23,7 +25,7 @@ class SKDistrictSelect(Select):
         super(SKDistrictSelect, self).__init__(attrs, choices=DISTRICT_CHOICES)
 
 
-class SKPostalCodeField(RegexField):
+class SKPostalCodeField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates its input as Slovak postal code.
 
@@ -44,5 +46,7 @@ class SKPostalCodeField(RegexField):
 
         Returns an empty string for empty values.
         """
-        v = super(SKPostalCodeField, self).clean(value)
-        return v.replace(' ', '')
+        value = super(SKPostalCodeField, self).clean(value)
+        if value in self.empty_values:
+            return self.empty_value
+        return value.replace(' ', '')

--- a/localflavor/tr/forms.py
+++ b/localflavor/tr/forms.py
@@ -8,6 +8,7 @@ from django.forms.fields import CharField, Field, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 from .tr_provinces import PROVINCE_CHOICES
@@ -15,7 +16,7 @@ from .tr_provinces import PROVINCE_CHOICES
 phone_digits_re = re.compile(r'^(\+90|0)? ?(([1-9]\d{2})|\([1-9]\d{2}\)) ?([2-9]\d{2} ?\d{2} ?\d{2})$')
 
 
-class TRPostalCodeField(RegexField):
+class TRPostalCodeField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates input as a Turkish zip code.
 
@@ -32,8 +33,8 @@ class TRPostalCodeField(RegexField):
 
     def clean(self, value):
         value = super(TRPostalCodeField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         if len(value) != 5:
             raise ValidationError(self.error_messages['invalid'])
         province_code = int(value[:2])
@@ -42,7 +43,7 @@ class TRPostalCodeField(RegexField):
         return value
 
 
-class TRPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class TRPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """
     A form field that validates input as a Turkish phone number.
 
@@ -56,8 +57,8 @@ class TRPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
 
     def clean(self, value):
         super(TRPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub('(\(|\)|\s+)', '', force_text(value))
         m = phone_digits_re.search(value)
         if m:

--- a/localflavor/ua/forms.py
+++ b/localflavor/ua/forms.py
@@ -1,6 +1,8 @@
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
+
 from .ua_regions import UA_REGION_CHOICES
 
 
@@ -16,7 +18,7 @@ class UARegionSelect(Select):
         super(UARegionSelect, self).__init__(*args, **kwargs)
 
 
-class UAVatNumberField(RegexField):
+class UAVatNumberField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates input as a Ukrainian analog of a VAT number.
 
@@ -37,10 +39,12 @@ class UAVatNumberField(RegexField):
 
     def to_python(self, value):
         value = super(UAVatNumberField, self).to_python(value)
+        if value in self.empty_values:
+            return self.empty_value
         return value.strip()
 
 
-class UAPostalCodeField(RegexField):
+class UAPostalCodeField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates input as a Ukrainian postal code.
 
@@ -61,4 +65,6 @@ class UAPostalCodeField(RegexField):
 
     def to_python(self, value):
         value = super(UAPostalCodeField, self).to_python(value)
+        if value in self.empty_values:
+            return self.empty_value
         return value.strip()

--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -10,13 +10,14 @@ from django.forms.fields import CharField, Field, RegexField, Select
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.forms import DeprecatedPhoneNumberFormFieldMixin
 
 phone_digits_re = re.compile(r'^(?:1-?)?(\d{3})[-\.]?(\d{3})[-\.]?(\d{4})$')
 ssn_re = re.compile(r"^(?P<area>\d{3})[-\ ]?(?P<group>\d{2})[-\ ]?(?P<serial>\d{4})$")
 
 
-class USZipCodeField(RegexField):
+class USZipCodeField(EmptyValueCompatMixin, RegexField):
     """
     A form field that validates input as a U.S. ZIP code.
 
@@ -42,13 +43,12 @@ class USZipCodeField(RegexField):
 
     def to_python(self, value):
         value = super(USZipCodeField, self).to_python(value)
-        if value:
-            return value.strip()
-        else:
-            return value
+        if value in self.empty_values:
+            return self.empty_value
+        return value.strip()
 
 
-class USPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
+class USPhoneNumberField(EmptyValueCompatMixin, CharField, DeprecatedPhoneNumberFormFieldMixin):
     """A form field that validates input as a U.S. phone number."""
 
     default_error_messages = {
@@ -57,8 +57,8 @@ class USPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
 
     def clean(self, value):
         super(USPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         value = re.sub('(\(|\)|\s+)', '', force_text(value))
         m = phone_digits_re.search(value)
         if m:
@@ -66,7 +66,7 @@ class USPhoneNumberField(CharField, DeprecatedPhoneNumberFormFieldMixin):
         raise ValidationError(self.error_messages['invalid'])
 
 
-class USSocialSecurityNumberField(CharField):
+class USSocialSecurityNumberField(EmptyValueCompatMixin, CharField):
     """
     A United States Social Security number.
 
@@ -90,8 +90,8 @@ class USSocialSecurityNumberField(CharField):
 
     def clean(self, value):
         super(USSocialSecurityNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         match = re.match(ssn_re, value)
         if not match:
             raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/uy/forms.py
+++ b/localflavor/uy/forms.py
@@ -3,10 +3,11 @@
 
 from __future__ import unicode_literals
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils.translation import ugettext_lazy as _
+
+from localflavor.compat import EmptyValueCompatMixin
 
 from .util import get_validation_digit
 
@@ -19,7 +20,7 @@ class UYDepartmentSelect(Select):
         super(UYDepartmentSelect, self).__init__(attrs, choices=DEPARTMENT_CHOICES)
 
 
-class UYCIField(RegexField):
+class UYCIField(EmptyValueCompatMixin, RegexField):
     """A field that validates Uruguayan 'Cedula de identidad' (CI) numbers."""
 
     default_error_messages = {
@@ -42,8 +43,8 @@ class UYCIField(RegexField):
         [X]XXXXXXX, [X]XXXXXX-X and [X.]XXX.XXX-X.
         """
         value = super(UYCIField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
         match = self.regex.match(value)
         if not match:
             raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/za/forms.py
+++ b/localflavor/za/forms.py
@@ -4,17 +4,17 @@ from __future__ import unicode_literals
 import re
 from datetime import date
 
-from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField, Select
 from django.utils.translation import gettext_lazy as _
 
+from localflavor.compat import EmptyValueCompatMixin
 from localflavor.generic.checksums import luhn
 
 id_re = re.compile(r'^(?P<yy>\d\d)(?P<mm>\d\d)(?P<dd>\d\d)(?P<mid>\d{4})(?P<end>\d{3})')
 
 
-class ZAIDField(CharField):
+class ZAIDField(EmptyValueCompatMixin, CharField):
     """
     A form field for South African ID numbers.
 
@@ -29,8 +29,8 @@ class ZAIDField(CharField):
     def clean(self, value):
         super(ZAIDField, self).clean(value)
 
-        if value in EMPTY_VALUES:
-            return ''
+        if value in self.empty_values:
+            return self.empty_value
 
         # strip spaces and dashes
         value = value.strip().replace(' ', '').replace('-', '')

--- a/tests/test_ar.py
+++ b/tests/test_ar.py
@@ -46,7 +46,6 @@ class ARLocalFlavorTests(SimpleTestCase):
             'c1064AAB': 'C1064AAB',
             'C1064aab': 'C1064AAB',
             '4400': '4400',
-            'C1064AAB': 'C1064AAB',
         }
         invalid = {
             'C1064AABB': error_atmost + error_format,
@@ -62,8 +61,6 @@ class ARLocalFlavorTests(SimpleTestCase):
         error_length = ['This field requires 7 or 8 digits.']
         error_digitsonly = ['This field requires only numbers.']
         valid = {
-            '20123456': '20123456',
-            '20.123.456': '20123456',
             '20123456': '20123456',
             '20.123.456': '20123456',
             '20.123456': '20123456',
@@ -83,7 +80,6 @@ class ARLocalFlavorTests(SimpleTestCase):
         error_legal_type = ['Invalid legal type. Type must be 27, 20, 30, 23, 24 or 33.']
         valid = {
             '20-10123456-9': '20-10123456-9',
-            '20-10123456-9': '20-10123456-9',
             '27-10345678-4': '27-10345678-4',
             '20101234569': '20-10123456-9',
             '27103456784': '27-10345678-4',
@@ -98,7 +94,6 @@ class ARLocalFlavorTests(SimpleTestCase):
             '20-10123456': error_format,
             '20-10123456-': error_format,
             '20-10123456-5': error_invalid,
-            '27-10345678-1': error_invalid,
             '27-10345678-1': error_invalid,
             '11211111110': error_legal_type,
         }

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -15,26 +15,8 @@ import localflavor
 
 class GeneralTests(TestCase):
 
-    @classmethod
-    def _find_subclasses_for_package_py32(cls, base_class, package):
-        classes = []
-        for attr in dir(localflavor):
-            if attr.startswith('_'):
-                continue
-            sub_module = importlib.import_module(package.__name__ + '.' + attr)
-            sub_module_fields = cls._find_subclasses_for_package(base_class, sub_module)
-            if len(sub_module_fields) > 0:
-                classes.extend(sub_module_fields)
-
-        return classes
-
-    @classmethod
-    def _find_subclasses_for_package(cls, base_class, package):
-        # Finding the localflavor model classes directly with walk_packages doesn't work with Python 3.2. The workaround
-        # is to find the classes in all of the submodules.
-        if sys.version_info[:2] == (3, 2):
-            return cls._find_subclasses_for_package_py32(base_class, package)
-
+    @staticmethod
+    def _find_subclasses_for_package(base_class, package):
         classes = []
         for importer, modname, ispkg in pkgutil.walk_packages(path=package.__path__, prefix=package.__name__ + '.',
                                                               onerror=lambda x: None):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -5,7 +5,8 @@ import importlib
 import pkgutil
 import sys
 
-from django.db.models import Field
+from django import forms
+from django.db import models
 from django.test.testcases import TestCase
 from django.utils import six
 
@@ -14,44 +15,53 @@ import localflavor
 
 class GeneralTests(TestCase):
 
-    def _find_package_model_fields(self, package):
-        model_fields = []
+    @classmethod
+    def _find_subclasses_for_package_py32(cls, base_class, package):
+        classes = []
+        for attr in dir(localflavor):
+            if attr.startswith('_'):
+                continue
+            sub_module = importlib.import_module(package.__name__ + '.' + attr)
+            sub_module_fields = cls._find_subclasses_for_package(base_class, sub_module)
+            if len(sub_module_fields) > 0:
+                classes.extend(sub_module_fields)
+
+        return classes
+
+    @classmethod
+    def _find_subclasses_for_package(cls, base_class, package):
+        # Finding the localflavor model classes directly with walk_packages doesn't work with Python 3.2. The workaround
+        # is to find the classes in all of the submodules.
+        if sys.version_info[:2] == (3, 2):
+            return cls._find_subclasses_for_package_py32(base_class, package)
+
+        classes = []
         for importer, modname, ispkg in pkgutil.walk_packages(path=package.__path__, prefix=package.__name__ + '.',
                                                               onerror=lambda x: None):
             if ispkg:
                 continue
-
             module = importlib.import_module(modname)
             for f in dir(module):
                 if f.startswith('_'):
                     continue
-
                 item = getattr(module, f)
-                if package.__name__ in six.text_type(item) and type(item) == type and issubclass(item, Field):
-                    model_fields.append(item)
-
-        return model_fields
+                if package.__name__ in six.text_type(item):
+                    try:
+                        if issubclass(item, base_class):
+                            classes.append(item)
+                    except TypeError:
+                        # item is not a class.
+                        pass
+        return classes
 
     def test_model_field_deconstruct_methods_with_default_options(self):
         # This test can only check the choices and max_length options. Specific tests are required for model fields
         # with options that users can set. See to the IBAN tests for an example.
 
-        # Finding the localflavor model fields directly with walk_packages doesn't work with Python 3.2. The workaround
-        # is to find the model fields in all of the submodules.
-        if sys.version_info[:2] == (3, 2):
-            model_fields = []
-            for attr in dir(localflavor):
-                if attr.startswith('_'):
-                    continue
-                sub_module = importlib.import_module(localflavor.__name__ + '.' + attr)
-                sub_module_fields = self._find_package_model_fields(sub_module)
-                if len(sub_module_fields) > 0:
-                    model_fields.extend(sub_module_fields)
-        else:
-            model_fields = self._find_package_model_fields(localflavor)
-        self.assertTrue(len(model_fields) > 0, 'No localflavor model fields were found.')
+        model_classes = self._find_subclasses_for_package(models.Field, localflavor)
+        self.assertTrue(len(model_classes) > 0, 'No localflavor models.Field classes were found.')
 
-        for cls in model_fields:
+        for cls in model_classes:
             test_instance = cls()
             name, path, args, kwargs = test_instance.deconstruct()
 
@@ -69,3 +79,17 @@ class GeneralTests(TestCase):
             new_instance = cls(*args, **kwargs)
             for attr in ('choices', 'max_length'):
                 self.assertEqual(getattr(test_instance, attr), getattr(new_instance, attr))
+
+    def test_forms_char_field_empty_value_allows_none(self):
+        form_classes = self._find_subclasses_for_package(forms.CharField, localflavor)
+        self.assertTrue(len(form_classes) > 0, 'No localflavor forms.CharField classes were found.')
+
+        for cls in form_classes:
+            failure_message = '{} does not handle does not properly handle values that are None.'.format(cls.__name__)
+            # Django < 1.11 doesn't support empty_value
+            try:
+                field = cls(required=False, empty_value=None)
+                self.assertIsNone(field.clean(None), failure_message)
+            except TypeError:
+                field = cls(required=False)
+                self.assertEqual('', field.clean(None), failure_message)

--- a/tests/test_no.py
+++ b/tests/test_no.py
@@ -69,7 +69,7 @@ class NOLocalFlavorTests(SimpleTestCase):
         self.assertEqual(form.prepare_value('76940512057'), '7694.05.12057')
         # In the event there's already empty/blank/null values present.
         # Any invalid data should be stopped by form.validate, which the above test should take care of.
-        self.assertEqual(form.prepare_value(None), None)
+        self.assertEqual(form.prepare_value(None), '')
         self.assertEqual(form.prepare_value(''), '')
 
     def test_NOSocialSecurityNumber(self):

--- a/tests/test_us/tests.py
+++ b/tests/test_us/tests.py
@@ -265,15 +265,6 @@ class USLocalFlavorTests(TestCase):
         }
         self.assertFieldOutput(forms.USZipCodeField, valid, invalid)
 
-    def test_USZipCodeField_null(self):
-        # Django < 1.11 doesn't support empty_value
-        try:
-            field = forms.USZipCodeField(required=False, empty_value=None)
-            self.assertIsNone(field.clean(None))
-        except TypeError:
-            field = forms.USZipCodeField(required=False)
-            self.assertEqual('', field.clean(None))
-
     def test_USZipCodeField_formfield(self):
         """Test that the full US ZIP code field is really the full list."""
         self.assertHTMLEqual(str(self.form['zip_code']),


### PR DESCRIPTION
This PR adds support for the `empty_value` kwarg that was added to `forms.CharField` in Django 1.11.

On Django < 1.11, form fields that inherit from `forms.CharField` set an empty string for values that are in `self.empty_values`. On Django >= 1.11, form fields that inherit from `forms.CharField` set `self.empty_value` for values that are in `self.empty_values`. This means all of the fields now support the `empty_value` kwarg even when it's `None`.

The downside to this change is that form fields that inherit from `forms.CharField` will need to use the `EmptyValueCompatMixin` until we drop support for Django < 1.11.

Related #294 #295
Closes #297 
