### PR TITLE
[SE] Added support for interim personal identity numbers (interimspersonnummer)

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -72,6 +72,7 @@ Authors
 * Michał Sałaban
 * Mike Lissner
 * Olivier Sels
+* Olle Vidner
 * Paul Donohue
 * Paulo Poiati
 * Peter J. Farrell

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ Modifications to existing flavors:
 - Deprecated br.forms.DV_maker, sg.forms.SGNRIC_FINField, lt.forms.LTPhoneField
   and ro.forms.ROIBANField
   (`gh-305 <https://github.com/django/django-localflavor/pull/305>`_).
+- Added support for Swedish interim personal identity numbers
+  (`gh-308 <https://github.com/django/django-localflavor/pull/308>`_).
 
 Other changes:
 

--- a/localflavor/se/forms.py
+++ b/localflavor/se/forms.py
@@ -17,7 +17,7 @@ __all__ = ('SECountySelect', 'SEOrganisationNumberField',
            'SEPersonalIdentityNumberField', 'SEPostalCodeField')
 
 SWEDISH_ID_NUMBER = re.compile(r'^(?P<century>\d{2})?(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})'
-                               r'(?P<sign>[\-+])?(?P<serial>\d{3})(?P<checksum>\d)$')
+                               r'(?P<sign>[\-+])?(?P<serial>\d{3}|[A-Za-z]\d{2})(?P<checksum>\d)$')
 SE_POSTAL_CODE = re.compile(r'^[1-9]\d{2} ?\d{2}$')
 
 
@@ -98,11 +98,19 @@ class SEPersonalIdentityNumberField(EmptyValueCompatMixin, forms.CharField):
     only allow real personal identity numbers, pass the keyword argument
     coordination_number=False to the constructor.
 
+    Interim numbers (interimspersonnummer), used by educational institutions
+    within the Ladok system, are supported but not accepted by default, since
+    they are not considered valid outside Ladok. They have the same format and
+    semantics as real personal identity numbers, except that the first control
+    digit is replaced by a letter (A-Z). To allow the use of interim numbers,
+    pass the keyword argument interim_numbers=True to the constructor.
+
     The cleaned value will always have the format YYYYMMDDXXXX.
     """
 
-    def __init__(self, coordination_number=True, *args, **kwargs):
+    def __init__(self, coordination_number=True, interim_number=False, *args, **kwargs):
         self.coordination_number = coordination_number
+        self.interim_number = interim_number
         super(SEPersonalIdentityNumberField, self).__init__(*args, **kwargs)
 
     default_error_messages = {
@@ -121,6 +129,8 @@ class SEPersonalIdentityNumberField(EmptyValueCompatMixin, forms.CharField):
             raise forms.ValidationError(self.error_messages['invalid'])
 
         gd = match.groupdict()
+        is_coordination_number = int(gd['day']) > 60
+        is_interim_number = gd['serial'][0].isalpha()
 
         # compare the calculated value with the checksum
         if id_number_checksum(gd) != int(gd['checksum']):
@@ -133,8 +143,18 @@ class SEPersonalIdentityNumberField(EmptyValueCompatMixin, forms.CharField):
             raise forms.ValidationError(self.error_messages['invalid'])
 
         # make sure that co-ordination numbers do not pass if not allowed
-        if not self.coordination_number and int(gd['day']) > 60:
+        if not self.coordination_number and is_coordination_number:
             raise forms.ValidationError(self.error_messages['coordination_number'])
+
+        # make sure that interim numbers do not pass if not allowed. This is
+        # reported as the number being plain invalid, as most people don't know
+        # what an interim number is.
+        if not self.interim_number and is_interim_number:
+            raise forms.ValidationError(self.error_messages['invalid'])
+
+        # Combining the concepts of coordination and interim numbers is invalid.
+        if is_coordination_number and is_interim_number:
+            raise forms.ValidationError(self.error_messages['invalid'])
 
         return format_personal_id_number(birth_day, gd)
 

--- a/localflavor/se/utils.py
+++ b/localflavor/se/utils.py
@@ -7,6 +7,12 @@ def id_number_checksum(gd):
     """Calculates a Swedish ID number checksum, using the "Luhn"-algoritm."""
     n = s = 0
     for c in (gd['year'] + gd['month'] + gd['day'] + gd['serial']):
+        # When validating interim ID numbers, the letter is considered
+        # equivalent to 1. Source:
+        # https://wiki.swami.se/display/Inkubator/norEduPersonNIN+och+Svenska+Personnummer
+        if c.isalpha():
+            c = 1
+
         tmp = ((n % 2) and 1 or 2) * int(c)
 
         if tmp > 9:
@@ -64,7 +70,10 @@ def validate_id_birthday(gd, fix_coordination_number_day=True):
 
 def format_personal_id_number(birth_day, gd):
     # birth_day.strftime cannot be used, since it does not support dates < 1900
-    return six.text_type(str(birth_day.year) + gd['month'] + gd['day'] + gd['serial'] + gd['checksum'])
+    # If the ID number is an interim number, the letter in the serial part
+    # should be normalized to upper case. Source:
+    # https://wiki.swami.se/display/Inkubator/norEduPersonNIN+och+Svenska+Personnummer
+    return six.text_type(str(birth_day.year) + gd['month'] + gd['day'] + gd['serial'].upper() + gd['checksum'])
 
 
 def format_organisation_number(gd):

--- a/tests/test_se.py
+++ b/tests/test_se.py
@@ -131,6 +131,9 @@ class SELocalFlavorTests(SimpleTestCase):
             '870514-1111': error_invalid,
             # Co-ordination number with bad checksum
             '870573-1311': error_invalid,
+            # Interim numbers should be rejected by default, even though they are valid
+            '901129-T003': error_invalid,
+            '19901129T003': error_invalid,
         }
         self.assertFieldOutput(SEPersonalIdentityNumberField, valid, invalid)
 
@@ -146,6 +149,33 @@ class SELocalFlavorTests(SimpleTestCase):
             '870573-1311': error_invalid,
         }
         kwargs = {'coordination_number': False}
+        self.assertFieldOutput(SEPersonalIdentityNumberField, valid, invalid,
+                               field_kwargs=kwargs)
+
+        valid = {
+            # All ordinary numbers should work when switching the first serial
+            # digit to a letter. Additionally, lower case letters should be
+            # accepted and normalized to upper case.
+            '870512-T989': '19870512T989',
+            '870512-r120': '19870512R120',
+            '19870512-S989': '19870512S989',
+            '19870512u989': '19870512U989',
+            '081015-W316': '19081015W316',
+            '081015x316': '19081015X316',
+            '870514J060': '19870514J060',
+            '081015+k316': '18081015K316',
+        }
+        invalid = {
+            # The concepts of interim and coordination numbers can not be
+            # combined and should be considered invalid
+            '870574-L315': error_invalid,
+            '870574+m315': error_invalid,
+            '870574N315': error_invalid,
+            # Invalid interim numbers should be reported as invalid
+            '870512-T988': error_invalid,
+            '870512-r121': error_invalid,
+        }
+        kwargs = {'interim_number': True}
         self.assertFieldOutput(SEPersonalIdentityNumberField, valid, invalid,
                                field_kwargs=kwargs)
 


### PR DESCRIPTION
Added support for interim personal identity numbers (*interimspersonnummer*) to the existing `SEPersonalIdentityNumberField`. Interim numbers are used instead of coordination numbers by Swedish educational institutions, within the *Ladok* system. It is disabled by default since most projects will probably not need (or want) it.

There is more information about *interimspersonnummer* available (in Swedish) at https://wiki.swami.se/display/Inkubator/norEduPersonNIN+och+Svenska+Personnummer and https://confluence.its.umu.se/confluence/display/LDSV/Interimspersonnummer 

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`