### PR TITLE
Fixes NOBankAccountNumber issue with formatting and uncleaned data

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,8 @@ Other changes:
 - Added support for empty_value kwarg in Django >= 1.11
   (`gh-298 <https://github.com/django/django-localflavor/pull/298>`_).
 - Dropped support for Python 3.2.
+- Fixes issue with `no.forms.NOBankAccountNumber` unclean data.
+  (`gh-311 <https://github.com/django/django-localflavor/pull/311>`_).
 
 1.5   (2017-05-26)
 ------------------

--- a/localflavor/no/forms.py
+++ b/localflavor/no/forms.py
@@ -160,6 +160,7 @@ class NOBankAccountNumber(EmptyValueCompatMixin, CharField):
         return value.replace('.', '').replace(' ', '')
 
     def prepare_value(self, value):
+        value = self.to_python(value)
         if value in self.empty_values:
             return self.empty_value
         return '{}.{}.{}'.format(value[0:4], value[4:6], value[6:11])

--- a/tests/test_no.py
+++ b/tests/test_no.py
@@ -67,6 +67,9 @@ class NOLocalFlavorTests(SimpleTestCase):
     def test_NOBankAccountNumber_formatting(self):
         form = NOBankAccountNumber()
         self.assertEqual(form.prepare_value('76940512057'), '7694.05.12057')
+        self.assertEqual(form.prepare_value(' 7694 05 12057 '), '7694.05.12057')
+        self.assertEqual(form.prepare_value('7694. 05.1205'), '7694.05.1205')
+        self.assertEqual(form.prepare_value('7694.05.120.5'), '7694.05.1205')
         # In the event there's already empty/blank/null values present.
         # Any invalid data should be stopped by form.validate, which the above test should take care of.
         self.assertEqual(form.prepare_value(None), '')


### PR DESCRIPTION
If you would input accounts that were too short or otherwise riddled
with spaces and periods, it would not remove these before returning them again.

Fixes the issue and adds a couple of assertions.

I would :heart: it if this could come before 1.6 though, @benkonrath. 👍 

**All Changes**

- [X] Add an entry to the docs/changelog.rst describing the change.

- [X] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [X] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`