### PR TITLE
Fix Czech birth number validation. Fixes #315

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -30,6 +30,7 @@ Authors
 * Danielle Madeley
 * Daniel Roschka
 * Diederik van der Boor
+* Dmitry Dygalo
 * d.merc
 * Douglas Miranda
 * Elliott Fawcett

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,8 @@ Modifications to existing flavors:
 
 Other changes:
 
-- None
+- Fixed validation of Czech birth numbers for birth dates after 1st January 1954
+  (`gh-315 <https://github.com/django/django-localflavor/issues/315>`_).
 
 1.6   (2017-11-22)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,12 +14,12 @@ New fields for existing flavors:
 
 Modifications to existing flavors:
 
-- None
+- Fixed validation of Czech birth numbers for birth dates after 1st January 1954
+  (`gh-315 <https://github.com/django/django-localflavor/issues/315>`_).
 
 Other changes:
 
-- Fixed validation of Czech birth numbers for birth dates after 1st January 1954
-  (`gh-315 <https://github.com/django/django-localflavor/issues/315>`_).
+- None
 
 1.6   (2017-11-22)
 ------------------

--- a/localflavor/cz/forms.py
+++ b/localflavor/cz/forms.py
@@ -72,7 +72,7 @@ class CZBirthNumberField(Field):
         birth, id = match.groupdict()['birth'], match.groupdict()['id']
 
         # Three digits for verification number were used until 1. january 1954
-        if len(id) == 3:
+        if len(id) == 3 and int(birth[:2]) < 54:
             return '%s' % value
 
         # Birth number is in format YYMMDD. Females have month value raised by 50.

--- a/tests/test_cz.py
+++ b/tests/test_cz.py
@@ -47,9 +47,9 @@ class CZLocalFlavorTests(SimpleTestCase):
         valid = {
             '880523/1237': '880523/1237',
             '8805231237': '8805231237',
-            '880523/000': '880523/000',
-            '880523000': '880523000',
             '882101/0011': '882101/0011',
+            '520110/000': '520110/000',
+            '520110000': '520110000',
         }
         invalid = {
             '123456/12': error_format,
@@ -59,6 +59,8 @@ class CZLocalFlavorTests(SimpleTestCase):
             '880523/1239': error_invalid,
             '8805231239': error_invalid,
             '990101/0011': error_invalid,
+            '880523000': error_invalid,
+            '880523/000': error_invalid,
         }
         self.assertFieldOutput(CZBirthNumberField, valid, invalid)
 


### PR DESCRIPTION
As I described the issue in #315 these changes fix validation for birth numbers, that are issued after 1st of January 1954. All numbers after that date should have control digit.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.