### PR TITLE
Fix the BSN wikipedia link and include a warning

### DIFF
--- a/localflavor/nl/forms.py
+++ b/localflavor/nl/forms.py
@@ -36,7 +36,9 @@ class NLBSNFormField(forms.CharField):
     """
     A Dutch social security number (BSN) field.
 
-    http://nl.wikipedia.org/wiki/Sofinummer
+    https://nl.wikipedia.org/wiki/Burgerservicenummer
+
+    Note that you may only process the BSN if you have a legal basis to do so!
 
     .. versionadded:: 1.6
     """


### PR DESCRIPTION
The previously included link was to the old social security number that was replaced by the BSN in 2007.

Additionally, includes a note that warns that the BSN may only be processed if there is a valid legal basis to do so.