### PR TITLE
Add NLLicensePlateField with tests

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -53,6 +53,7 @@ Authors
 * James Bennett
 * Jannis Leidel
 * Jan Pieter Waagmeester
+* Jarmo van Lenthe
 * Jérémie Ferry
 * Jocelyn Delalande
 * Johannes Hoppe

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ New fields for existing flavors:
 
 Modifications to existing flavors:
 
-- Added `NLLicensePlateField` to NL flavor.
+- None
 
 Other changes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,11 +10,11 @@ New flavors:
 
 New fields for existing flavors:
 
-- None
+- `NLLicensePlateField` in NL flavor.
 
 Modifications to existing flavors:
 
-- None
+- Added `NLLicensePlateField` to NL flavor.
 
 Other changes:
 

--- a/localflavor/nl/forms.py
+++ b/localflavor/nl/forms.py
@@ -3,11 +3,13 @@
 
 from __future__ import unicode_literals
 
+import re
+
 from django import forms
 from django.utils import six
 
 from .nl_provinces import PROVINCE_CHOICES
-from .validators import NLBSNFieldValidator, NLZipCodeFieldValidator
+from .validators import NLBSNFieldValidator, NLLicensePlateFieldValidator, NLZipCodeFieldValidator
 
 
 class NLZipCodeField(forms.CharField):
@@ -48,3 +50,52 @@ class NLBSNFormField(forms.CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 9
         super(NLBSNFormField, self).__init__(*args, **kwargs)
+
+
+class NLLicensePlateFormField(forms.CharField):
+    """
+    A Dutch license plate field.
+
+    https://www.rdw.nl/
+    https://nl.wikipedia.org/wiki/Nederlands_kenteken
+
+    .. versionadded:: 2.1
+    """
+
+    default_validators = [NLLicensePlateFieldValidator()]
+
+    SANITIZE_REGEXS = {
+        "sidecode1": re.compile(r"^([A-Z]{2})([0-9]{2})([0-9]{2})$"),  # AA-99-99
+        "sidecode2": re.compile(r"^([0-9]{2})([0-9]{2})([A-Z]{2})$"),  # 99-99-AA
+        "sidecode3": re.compile(r"^([0-9]{2})([A-Z]{2})([0-9]{2})$"),  # 99-AA-99
+        "sidecode4": re.compile(r"^([A-Z]{2})([0-9]{2})([A-Z]{2})$"),  # AA-99-AA
+        "sidecode5": re.compile(r"^([A-Z]{2})([A-Z]{2})([0-9]{2})$"),  # AA-AA-99
+        "sidecode6": re.compile(r"^([0-9]{2})([A-Z]{2})([A-Z]{2})$"),  # 99-AA-AA
+        "sidecode7": re.compile(r"^([0-9]{2})([A-Z]{3})([0-9]{1})$"),  # 99-AAA-9
+        "sidecode8": re.compile(r"^([0-9]{1})([A-Z]{3})([0-9]{2})$"),  # 9-AAA-99
+        "sidecode9": re.compile(r"^([A-Z]{2})([0-9]{3})([A-Z]{1})$"),  # AA-999-A
+        "sidecode10": re.compile(r"^([A-Z]{1})([0-9]{3})([A-Z]{2})$"),  # A-999-AA
+        "sidecode11": re.compile(r"^([A-Z]{3})([0-9]{2})([A-Z]{1})$"),  # AAA-99-A
+        "sidecode12": re.compile(r"^([A-Z]{1})([0-9]{2})([A-Z]{3})$"),  # A-99-AAA
+        "sidecode13": re.compile(r"^([0-9]{1})([A-Z]{2})([0-9]{3})$"),  # 9-AA-999
+        "sidecode14": re.compile(r"^([0-9]{3})([A-Z]{2})([0-9]{1})$"),  # 999-AA-9
+        "sidecode_koninklijk_huis": re.compile(r"^(AA)([0-9]{2,3})(([0-9]{2})?)$"),  # AA-99(-99)?
+        "sidecode_internationaal_gerechtshof": re.compile(r"^(CDJ)([0-9]{3})$"),  # CDJ-999
+        "sidecode_bijzondere_toelating": re.compile(r"^(ZZ)([0-9]{2})([0-9]{2})$"),  # ZZ-99-99
+        "sidecode_tijdelijk_voor_een_dag": re.compile(r"^(F)([0-9]{2})([0-9]{2})$"),  # F-99-99
+        "sidecode_voertuig_binnen_of_buiten_nederland_brengen": re.compile(r"^(Z)([0-9]{2})([0-9]{2})$"),  # Z-99-99
+    }
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 8
+        super(NLLicensePlateFormField, self).__init__(*args, **kwargs)
+
+    def clean(self, value):
+        value = super(NLLicensePlateFormField, self).clean(value)
+        if value:
+            value = value.upper().replace('-', '')
+            for sidecode, regex in self.SANITIZE_REGEXS.items():
+                match = regex.match(value)
+                if match:
+                    return '-'.join(match.groups())
+        return value

--- a/localflavor/nl/models.py
+++ b/localflavor/nl/models.py
@@ -86,7 +86,7 @@ class NLBSNField(models.CharField):
 
 class NLLicensePlateField(models.CharField):
     """
-    A Dutch car license plate.
+    A Dutch license plate.
 
     This model field uses :class:`validators.NLLicensePlateFieldValidator` for validation.
 

--- a/localflavor/nl/models.py
+++ b/localflavor/nl/models.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from . import forms
 from .nl_provinces import PROVINCE_CHOICES
-from .validators import NLBSNFieldValidator, NLZipCodeFieldValidator
+from .validators import NLBSNFieldValidator, NLLicensePlateFieldValidator, NLZipCodeFieldValidator
 
 
 class NLZipCodeField(models.CharField):
@@ -82,3 +82,28 @@ class NLBSNField(models.CharField):
         defaults = {'form_class': forms.NLBSNFormField}
         defaults.update(kwargs)
         return super(NLBSNField, self).formfield(**defaults)
+
+
+class NLLicensePlateField(models.CharField):
+    """
+    A Dutch car license plate.
+
+    This model field uses :class:`validators.NLLicensePlateFieldValidator` for validation.
+
+    .. versionadded:: 2.1
+    """
+
+    description = _('Dutch license plate')
+
+    default_form_field = forms.NLLicensePlateFormField
+
+    validators = [NLLicensePlateFieldValidator()]
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('max_length', 8)
+        super(NLLicensePlateField, self).__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.NLLicensePlateFormField}
+        defaults.update(kwargs)
+        return super(NLLicensePlateField, self).formfield(**defaults)

--- a/localflavor/nl/validators.py
+++ b/localflavor/nl/validators.py
@@ -54,3 +54,39 @@ class NLBSNFieldValidator(RegexValidator):
 
         if not self.bsn_checksum_ok(value):
             raise ValidationError(self.error_message)
+
+
+class NLLicensePlateFieldValidator(RegexValidator):
+    """
+    Validation for Dutch license plates.
+
+    .. versionadded:: 2.1
+    """
+
+    error_message = _('Enter a valid license plate')
+
+    VALIDATION_REGEXS = {
+        "sidecode1": r"^[A-Z]{2}-[0-9]{2}-[0-9]{2}$",  # AA-99-99
+        "sidecode2": r"^[0-9]{2}-[0-9]{2}-[A-Z]{2}$",  # 99-99-AA
+        "sidecode3": r"^[0-9]{2}-[A-Z]{2}-[0-9]{2}$",  # 99-AA-99
+        "sidecode4": r"^[A-Z]{2}-[0-9]{2}-[A-Z]{2}$",  # AA-99-AA
+        "sidecode5": r"^[A-Z]{2}-[A-Z]{2}-[0-9]{2}$",  # AA-AA-99
+        "sidecode6": r"^[0-9]{2}-[A-Z]{2}-[A-Z]{2}$",  # 99-AA-AA
+        "sidecode7": r"^[0-9]{2}-[A-Z]{3}-[0-9]{1}$",  # 99-AAA-9
+        "sidecode8": r"^[0-9]{1}-[A-Z]{3}-[0-9]{2}$",  # 9-AAA-99
+        "sidecode9": r"^[A-Z]{2}-[0-9]{3}-[A-Z]{1}$",  # AA-999-A
+        "sidecode10": r"^[A-Z]{1}-[0-9]{3}-[A-Z]{2}$",  # A-999-AA
+        "sidecode11": r"^[A-Z]{3}-[0-9]{2}-[A-Z]{1}$",  # AAA-99-A
+        "sidecode12": r"^[A-Z]{1}-[0-9]{2}-[A-Z]{3}$",  # A-99-AAA
+        "sidecode13": r"^[0-9]{1}-[A-Z]{2}-[0-9]{3}$",  # 9-AA-999
+        "sidecode14": r"^[0-9]{3}-[A-Z]{2}-[0-9]{1}$",  # 999-AA-9
+        "sidecode_koninklijk_huis": r"^AA-[0-9]{2,3}(-[0-9]{2})?$",  # AA-99(-99)?
+        "sidecode_internationaal_gerechtshof": r"^CDJ-[0-9]{3}$",  # CDJ-999
+        "sidecode_bijzondere_toelating": r"^ZZ-[0-9]{2}-[0-9]{2}$",  # ZZ-99-99
+        "sidecode_tijdelijk_voor_een_dag": r"^F-[0-9]{2}-[0-9]{2}$",  # F-99-99
+        "sidecode_voertuig_binnen_of_buiten_nederland_brengen": r"^Z-[0-9]{2}-[0-9]{2}$",  # Z-99-99
+    }
+
+    def __init__(self):
+        regex = r'(' + r'|'.join(self.VALIDATION_REGEXS.values()) + r')'
+        super(NLLicensePlateFieldValidator, self).__init__(regex=regex, message=self.error_message)

--- a/tests/test_nl/forms.py
+++ b/tests/test_nl/forms.py
@@ -1,6 +1,6 @@
 from django.forms import ModelForm
 
-from .models import NLPlace
+from .models import NLCar, NLPlace
 
 
 class NLPlaceForm(ModelForm):
@@ -8,3 +8,10 @@ class NLPlaceForm(ModelForm):
     class Meta:
         model = NLPlace
         fields = ('zipcode', 'province', 'bsn')
+
+
+class NLCarForm(ModelForm):
+
+    class Meta:
+        model = NLCar
+        fields = ('license_plate', )

--- a/tests/test_nl/models.py
+++ b/tests/test_nl/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from localflavor.nl.models import NLBSNField, NLProvinceField, NLZipCodeField
+from localflavor.nl.models import NLBSNField, NLLicensePlateField, NLProvinceField, NLZipCodeField
 
 
 class NLPlace(models.Model):
@@ -8,6 +8,14 @@ class NLPlace(models.Model):
     zipcode = NLZipCodeField()
     province = NLProvinceField(default='ZH')
     bsn = NLBSNField()
+
+    class Meta:
+        app_label = 'test_nl'
+
+
+class NLCar(models.Model):
+
+    license_plate = NLLicensePlateField()
 
     class Meta:
         app_label = 'test_nl'


### PR DESCRIPTION
Added a ModelField and Validator for Dutch License Plates (`NLLicensePlateField`) and a FormField (`NLLicensePlateFormField`) which also sanitizes input.

**All Changes**

- [DONE] Add an entry to the docs/changelog.rst describing the change.

- [DONE] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [DONE] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`

**New Fields Only**

- [DONE] Prefix the country code to all fields.

- [DONE] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [DONE] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [DONE] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [DONE] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [DONE] Add documentation for all fields.
