### PR TITLE
Fix EAN validation when intermediate checksum is 10

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -29,6 +29,7 @@ Authors
 * Daniela Ponader
 * Danielle Madeley
 * Daniel Roschka
+* Didier 'OdyX' Raboud
 * Diederik van der Boor
 * Dmitry Dygalo
 * d.merc

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,9 @@ Modifications to existing flavors:
 Other changes:
 
 - Added VAT identifcation number validator for all EU locales.
+- Fix EAN validation when intermediate checksum is 10
+  (`gh-331 <https://github.com/django/django-localflavor/issues/331>`_).
+
 
 2.0   (2017-12-30)
 ------------------

--- a/localflavor/generic/checksums.py
+++ b/localflavor/generic/checksums.py
@@ -40,7 +40,7 @@ def ean(candidate):
     try:
         calculated_checksum = sum(
             int(digit) * EAN_LOOKUP[i % 2] for i, digit in enumerate(reversed(given_number)))
-        calculated_checksum = 10 - (calculated_checksum % 10)
+        calculated_checksum = 9 - ((calculated_checksum - 1) % 10)
         return str(calculated_checksum) == given_checksum
     except ValueError:  # Raised if an int conversion fails
         return False

--- a/tests/test_generic/test_checksums.py
+++ b/tests/test_generic/test_checksums.py
@@ -43,6 +43,8 @@ class TestUtilsChecksums(unittest.TestCase):
             (73513538, False),
             ('4006381333931', True),
             (4006381333931, True),
+            (7567554394380, True),
+            ('7567554394380', True),
             ('abc', False),
             (None, False),
             (object(), False),


### PR DESCRIPTION
It was buggy because:
* `calculated_checksum % 10` could be `0` if `calculated_checksum` is a multiple of 10
* `10 - 0 = 10`
* `10` cannot be validly string-compared to a single-digit

Fixes: #331

- [x] Add an entry to the docs/changelog.rst describing the change.
- [x] Add an entry for your name in the docs/authors.rst file if it's not already there.
- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`