### PR TITLE
Add testing for Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ matrix:
     - python: pypy3
       env: TOXENV=pypy3-2.0
     - python: 3.5
+      env: TOXENV=py35-2.1
+    - python: 3.6
+      env: TOXENV=py36-2.1
+    - python: pypy3
+      env: TOXENV=pypy3-2.1
+    - python: 3.5
       env: TOXENV=py35-master
     - python: 3.6
       env: TOXENV=py36-master

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Other changes:
 - Added VAT identifcation number validator for all EU locales.
 - Fix EAN validation when intermediate checksum is 10
   (`gh-331 <https://github.com/django/django-localflavor/issues/331>`_).
+- Confirmed support for Django 2.1.
 
 
 2.0   (2017-12-30)

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     docs,prospector,isort
     {py27,pypy,py34,py35,py36,pypy3}-1.11
     {py34,py35,py36,pypy3}-2.0
+    {py35,py36,pypy3}-2.1
     {py35,py36,pypy3}-master
 
 [testenv]
@@ -21,6 +22,7 @@ commands =
 deps =
     1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1
+    2.1: Django>=2.1a1,<2.2
     master: https://github.com/django/django/archive/master.tar.gz
     -r{toxinidir}/tests/requirements.txt
 


### PR DESCRIPTION
This will have to wait until after the Django 2.1 beta release as the test failures will be fixed by https://github.com/django/django/pull/10003. (now done)