### PR TITLE
Allowed invalid message to be overridden in ESIdentityCardNumberField.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,8 @@ New fields for existing flavors:
 
 Modifications to existing flavors:
 
-- None
+- Allowed invalid message to be overridden in ESIdentityCardNumberField
+  (`gh-339 <https://github.com/django/django-localflavor/issues/339>`_).
 
 Other changes:
 

--- a/localflavor/es/forms.py
+++ b/localflavor/es/forms.py
@@ -75,8 +75,10 @@ class ESIdentityCardNumberField(RegexField):
                                  self.nif_control + self.cif_control),
                                 re.IGNORECASE)
 
-        error_messages = kwargs.get('error_messages') or {}
-        error_messages['invalid'] = self.default_error_messages['invalid%s' % (self.only_nif and '_only_nif' or '')]
+        error_messages = {
+            'invalid': self.default_error_messages['invalid%s' % (self.only_nif and '_only_nif' or '')]
+        }
+        error_messages.update(kwargs.get('error_messages', {}))
         kwargs['error_messages'] = error_messages
 
         super(ESIdentityCardNumberField, self).__init__(id_card_re, *args, **kwargs)

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -147,6 +147,12 @@ class ESLocalFlavorTests(SimpleTestCase):
         }
         self.assertFieldOutput(ESIdentityCardNumberField, valid, invalid)
 
+    def test_ESIdentityCardNumberField_invalid_error_override(self):
+        # https://github.com/django/django-localflavor/issues/336
+        invalid_override_message = 'Please enter a valid number.'
+        form = ESIdentityCardNumberField(error_messages={'invalid': invalid_override_message})
+        self.assertEqual(form.error_messages['invalid'], invalid_override_message)
+
     def test_ESCCCField(self):
         error_invalid = ['Please enter a valid bank account number in format XXXX-XXXX-XX-XXXXXXXXXX.']
         error_checksum = ['Invalid checksum for bank account number.']


### PR DESCRIPTION
Fixes #336
