### PR TITLE
Add 34 prefix value (ar localflavor ARCUITField).

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,10 +22,12 @@ Modifications to existing flavors:
 
 Other changes:
 
-- Added VAT identifcation number validator for all EU locales.
+- Added VAT identification number validator for all EU locales.
 - Fix EAN validation when intermediate checksum is 10
   (`gh-331 <https://github.com/django/django-localflavor/issues/331>`_).
 - Confirmed support for Django 2.1.
+- Added 34 as a valid CUIT prefix value for `ARCUITField`
+  (`gh-342 <https://github.com/django/django-localflavor/pull/342>`_).
 
 
 2.0   (2017-12-30)

--- a/localflavor/ar/forms.py
+++ b/localflavor/ar/forms.py
@@ -11,8 +11,7 @@ from .ar_provinces import PROVINCE_CHOICES
 
 
 class ARProvinceSelect(Select):
-    """A Select widget that uses a list of Argentinean provinces/autonomous
-    cities as its choices."""
+    """A Select widget that uses a list of Argentinean provinces/autonomous cities as its choices."""
 
     def __init__(self, attrs=None):
         super(ARProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)

--- a/localflavor/ar/forms.py
+++ b/localflavor/ar/forms.py
@@ -85,6 +85,10 @@ class ARCUITField(RegexField):
 
     Info in English:
     http://www.justlanded.com/english/Argentina/Argentina-Guide/Visas-Permits/Other-Legal-Documents
+
+    .. versionchanged:: 2.1
+
+        ``ARCUITField`` now also accepts CUIT with prefix 34.
     """
 
     default_error_messages = {

--- a/localflavor/ar/forms.py
+++ b/localflavor/ar/forms.py
@@ -11,7 +11,8 @@ from .ar_provinces import PROVINCE_CHOICES
 
 
 class ARProvinceSelect(Select):
-    """A Select widget that uses a list of Argentinean provinces/autonomous cities as its choices."""
+    """A Select widget that uses a list of Argentinean provinces/autonomous
+    cities as its choices."""
 
     def __init__(self, attrs=None):
         super(ARProvinceSelect, self).__init__(attrs, choices=PROVINCE_CHOICES)
@@ -22,8 +23,9 @@ class ARPostalCodeField(RegexField):
     A field that accepts a 'classic' NNNN Postal Code or a CPA.
 
     See:
-        http://www.correoargentino.com.ar/cpa/que_es
-        http://www.correoargentino.com.ar/cpa/como_escribirlo
+
+    * http://www.correoargentino.com.ar/cpa/que_es
+    * http://www.correoargentino.com.ar/cpa/como_escribirlo
     """
 
     default_error_messages = {
@@ -77,19 +79,19 @@ class ARCUITField(RegexField):
     """
     This field validates a CUIT (Código Único de Identificación Tributaria).
 
-    ACUIT is of the form XX-XXXXXXXX-V. The last digit is a check digit.
+    A CUIT is of the form XX-XXXXXXXX-V. The last digit is a check digit.
 
     More info:
     http://es.wikipedia.org/wiki/Clave_%C3%9Anica_de_Identificaci%C3%B3n_Tributaria
 
-    English info:
+    Info in English:
     http://www.justlanded.com/english/Argentina/Argentina-Guide/Visas-Permits/Other-Legal-Documents
     """
 
     default_error_messages = {
         'invalid': _('Enter a valid CUIT in XX-XXXXXXXX-X or XXXXXXXXXXXX format.'),
         'checksum': _("Invalid CUIT."),
-        'legal_type': _('Invalid legal type. Type must be 27, 20, 30, 23, 24 or 33.'),
+        'legal_type': _('Invalid legal type. Type must be 27, 20, 30, 23, 24, 33 or 34.'),
     }
 
     def __init__(self, *args, **kwargs):
@@ -101,7 +103,7 @@ class ARCUITField(RegexField):
         if value in self.empty_values:
             return self.empty_value
         value, cd = self._canon(value)
-        if not value[:2] in ['27', '20', '30', '23', '24', '33']:
+        if not value[:2] in ['27', '20', '30', '23', '24', '33', '34']:
             raise ValidationError(self.error_messages['legal_type'])
         if self._calc_cd(value) != cd:
             raise ValidationError(self.error_messages['checksum'])

--- a/tests/test_ar.py
+++ b/tests/test_ar.py
@@ -77,7 +77,7 @@ class ARLocalFlavorTests(SimpleTestCase):
     def test_ARCUITField(self):
         error_format = ['Enter a valid CUIT in XX-XXXXXXXX-X or XXXXXXXXXXXX format.']
         error_invalid = ['Invalid CUIT.']
-        error_legal_type = ['Invalid legal type. Type must be 27, 20, 30, 23, 24 or 33.']
+        error_legal_type = ['Invalid legal type. Type must be 27, 20, 30, 23, 24, 33 or 34.']
         valid = {
             '20-10123456-9': '20-10123456-9',
             '27-10345678-4': '27-10345678-4',
@@ -87,6 +87,7 @@ class ARLocalFlavorTests(SimpleTestCase):
             '24117166062': '24-11716606-2',
             '33500001599': '33-50000159-9',
             '23000052264': '23-00005226-4',
+            '34546198105': '34-54619810-5',
         }
         invalid = {
             '2-10123456-9': error_format,


### PR DESCRIPTION
There are now CUIT assigned that use a 34 prefix. This PR adds support for it.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [x] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`
