### PR TITLE
Ie model fields

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,6 @@ first version.
 - [ ] Add an entry for your name in the docs/authors.rst file if it's not
       already there.
 
-- [ ] Adjust your imports to a standard form by running this command:
-
-      `isort --recursive --line-width 120 localflavor tests`
-
 **New Fields Only**
 
 - [ ] Prefix the country code to all fields.

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,25 +41,17 @@ matrix:
       env: TOXENV=py37-2.1
     - python: pypy3
       env: TOXENV=pypy3-2.1
-    - python: 3.5
-      env: TOXENV=py35-master
     - python: 3.6
       env: TOXENV=py36-master
     - python: 3.7
       dist: xenial
       env: TOXENV=py37-master
-    - python: pypy3
-      env: TOXENV=pypy3-master
   allow_failures:
-    - python: 3.5
-      env: TOXENV=py35-master
     - python: 3.6
       env: TOXENV=py36-master
     - python: 3.7
       dist: xenial
       env: TOXENV=py37-master
-    - python: pypy3
-      env: TOXENV=pypy3-master
 install:
     - pip wheel -r tests/requirements.txt codecov
     - pip install virtualenv codecov tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,8 @@ matrix:
       env: TOXENV=py35-2.1
     - python: 3.6
       env: TOXENV=py36-2.1
-    # Need to use xenial with sudo for Python 3.7.
-    # https://github.com/travis-ci/travis-ci/issues/9815
     - python: 3.7
       dist: xenial
-      sudo: true
       env: TOXENV=py37-2.1
     - python: pypy3
       env: TOXENV=pypy3-2.1
@@ -50,7 +47,6 @@ matrix:
       env: TOXENV=py36-master
     - python: 3.7
       dist: xenial
-      sudo: true
       env: TOXENV=py37-master
     - python: pypy3
       env: TOXENV=pypy3-master
@@ -61,7 +57,6 @@ matrix:
       env: TOXENV=py36-master
     - python: 3.7
       dist: xenial
-      sudo: true
       env: TOXENV=py37-master
     - python: pypy3
       env: TOXENV=pypy3-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,18 +60,6 @@ matrix:
       dist: xenial
       env: TOXENV=py37-master
   allow_failures:
-    - python: 3.5
-      dist: xenial
-      env: TOXENV=py35-2.2
-    - python: 3.6
-      dist: xenial
-      env: TOXENV=py36-2.2
-    - python: 3.7
-      dist: xenial
-      env: TOXENV=py37-2.2
-    - python: pypy3
-      dist: xenial
-      env: TOXENV=pypy3-2.2
     - python: 3.6
       dist: xenial
       env: TOXENV=py36-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,39 @@ matrix:
       env: TOXENV=py37-2.1
     - python: pypy3
       env: TOXENV=pypy3-2.1
+    - python: 3.5
+      dist: xenial
+      env: TOXENV=py35-2.2
     - python: 3.6
+      dist: xenial
+      env: TOXENV=py36-2.2
+    - python: 3.7
+      dist: xenial
+      env: TOXENV=py37-2.2
+    - python: pypy3
+      dist: xenial
+      env: TOXENV=pypy3-2.2
+    - python: 3.6
+      dist: xenial
       env: TOXENV=py36-master
     - python: 3.7
       dist: xenial
       env: TOXENV=py37-master
   allow_failures:
+    - python: 3.5
+      dist: xenial
+      env: TOXENV=py35-2.2
     - python: 3.6
+      dist: xenial
+      env: TOXENV=py36-2.2
+    - python: 3.7
+      dist: xenial
+      env: TOXENV=py37-2.2
+    - python: pypy3
+      dist: xenial
+      env: TOXENV=pypy3-2.2
+    - python: 3.6
+      dist: xenial
       env: TOXENV=py36-master
     - python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env: TOXENV=py35-1.11
     - python: 3.6
       env: TOXENV=py36-1.11
-    - python: pypy3
+    - python: pypy3.5
       env: TOXENV=pypy3-1.11
     - python: 3.4
       env: TOXENV=py34-2.0
@@ -30,7 +30,7 @@ matrix:
       env: TOXENV=py35-2.0
     - python: 3.6
       env: TOXENV=py36-2.0
-    - python: pypy3
+    - python: pypy3.5
       env: TOXENV=pypy3-2.0
     - python: 3.5
       env: TOXENV=py35-2.1
@@ -39,7 +39,7 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOXENV=py37-2.1
-    - python: pypy3
+    - python: pypy3.5
       env: TOXENV=pypy3-2.1
     - python: 3.5
       dist: xenial
@@ -50,7 +50,7 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOXENV=py37-2.2
-    - python: pypy3
+    - python: pypy3.5
       dist: xenial
       env: TOXENV=pypy3-2.2
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ cache: pip
 
 matrix:
   include:
+    # Need to use xenial in the docs build for a more recent version of sqlite.
     - python: 3.6
+      dist: xenial
       env: TOXENV=docs
     - python: 3.5
       env: TOXENV=prospector

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: TOXENV=docs
     - python: 3.5
       env: TOXENV=prospector
-    - python: 3.6
-      env: TOXENV=isort
     - python: 2.7
       env: TOXENV=py27-1.11
     - python: pypy

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -79,6 +79,7 @@ Authors
 * Mike Lissner
 * Olivier Sels
 * Olle Vidner
+* Paul Cunnane
 * Paul Donohue
 * Paulo Poiati
 * Peter J. Farrell

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ New flavors:
 
 New fields for existing flavors:
 
-- None
+- `EircodeField` in IE flavor
 
 Modifications to existing flavors:
 

--- a/localflavor/generic/validators.py
+++ b/localflavor/generic/validators.py
@@ -219,7 +219,7 @@ class BICValidator(object):
     """
 
     def __eq__(self, other):
-        # The is no outside modification of properties so this should always be true by default.
+        # There is no outside modification of properties so this should always be true by default.
         return True
 
     def __call__(self, value):

--- a/localflavor/ie/forms.py
+++ b/localflavor/ie/forms.py
@@ -1,6 +1,12 @@
 """IE-specific Form helpers."""
 
-from django.forms.fields import Select
+from __future__ import unicode_literals
+
+import re
+
+from django.forms import ValidationError
+from django.forms.fields import Select, CharField
+from django.utils.translation import ugettext_lazy as _
 
 from .ie_counties import IE_COUNTY_CHOICES
 
@@ -10,3 +16,25 @@ class IECountySelect(Select):
 
     def __init__(self, attrs=None):
         super(IECountySelect, self).__init__(attrs, choices=IE_COUNTY_CHOICES)
+
+
+class EircodeField(CharField):
+    """
+    A form field that validates its input is a valid Eircode (Irish postcode).
+
+    The value is uppercased and has the internal space removed, if any.
+    """
+
+    default_error_messages = {"invalid": _("Enter a valid Eircode.")}
+    eircode_regex = re.compile(
+        r"^(D6W|[AC-FHKNPRTV-Y][0-9]{2}) ?([AC-FHKNPRTV-Y0-9]{4})$"
+    )
+
+    def clean(self, value):
+        value = super(EircodeField, self).clean(value)
+        if value in self.empty_values:
+            return self.empty_value
+        eircode = value.upper().strip()
+        if not self.eircode_regex.search(eircode):
+            raise ValidationError(self.error_messages["invalid"])
+        return eircode.replace(" ", "")

--- a/localflavor/no/forms.py
+++ b/localflavor/no/forms.py
@@ -129,7 +129,7 @@ class NOBankAccountNumber(CharField):
         elif not value.isdigit():
             # You must only contain decimals.
             raise ValidationError(self.error_messages['invalid'])
-        elif len(value) is not 11:
+        elif len(value) != 11:
             # They only have one length: the number is 10!
             # That being said, you always store them with the check digit included, so 11.
             raise ValidationError(self.error_messages['invalid_length'])
@@ -144,7 +144,7 @@ class NOBankAccountNumber(CharField):
         remainder = result % 11
         # The checksum is 0 in the event there's no remainder, seeing as we cannot have a checksum of 11
         # when 11 is one digit longer than we've got room for
-        checksum = 0 if remainder is 0 else 11 - remainder
+        checksum = 0 if remainder == 0 else 11 - remainder
 
         if checksum != check_digit:
             raise ValidationError(self.error_messages['invalid_checksum'])

--- a/tests/test_ie.py
+++ b/tests/test_ie.py
@@ -2,14 +2,13 @@ from __future__ import unicode_literals
 
 from django.test import SimpleTestCase
 
-from localflavor.ie.forms import IECountySelect
+from localflavor.ie.forms import IECountySelect, EircodeField
 
 
 class IELocalFlavorTests(SimpleTestCase):
-
     def test_IECountySelect(self):
         f = IECountySelect()
-        out = '''<select name="counties">
+        out = """<select name="counties">
 <option value="carlow">Carlow</option>
 <option value="cavan">Cavan</option>
 <option value="clare">Clare</option>
@@ -36,5 +35,28 @@ class IELocalFlavorTests(SimpleTestCase):
 <option value="westmeath">Westmeath</option>
 <option value="wexford">Wexford</option>
 <option value="wicklow">Wicklow</option>
-</select>'''
-        self.assertHTMLEqual(f.render('counties', 'dublin'), out)
+</select>"""
+        self.assertHTMLEqual(f.render("counties", "dublin"), out)
+
+    def test_EircodeField(self):
+        error_invalid = ["Enter a valid Eircode."]
+        valid = {
+            "A65 F4E2": "A65F4E2",
+            "a65f4e2": "A65F4E2",
+            "D6w123A": "D6W123A",
+            " f28 e50f ": "F28E50F",
+        }
+        invalid = {
+            "A65F 4E2": error_invalid,
+            "A65  F4E2": error_invalid,
+            "A 65 F4E2": error_invalid,
+            "D4W 1234": error_invalid,
+            "Z99ABCF": error_invalid,
+            "a65 123b": error_invalid,
+            " b0gUS": error_invalid,
+        }
+        self.assertFieldOutput(EircodeField, valid, invalid)
+        valid = {}
+        invalid = {"1NV 4L1D": ["Enter a bloody eircode!"]}
+        kwargs = {"error_messages": {"invalid": "Enter a bloody eircode!"}}
+        self.assertFieldOutput(EircodeField, valid, invalid, field_kwargs=kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 args_are_paths = false
 envlist =
-    docs,prospector,isort
+    docs,prospector
     {py27,pypy,py34,py35,py36,pypy3}-1.11
     {py34,py35,py36,pypy3}-2.0
     {py35,py36,py37,pypy3}-2.1
@@ -45,8 +45,3 @@ deps =
 # Prospector 0.12.4 doesn't work with Python 3.6.
 basepython = python3.5
 commands = prospector --profile localflavor.prospector.yaml {toxinidir}
-
-[testenv:isort]
-deps = isort>=4.2,<4.3
-basepython = python3.6
-commands = isort --recursive --line-width 120 --diff --check {toxinidir}/localflavor {toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     {py27,pypy,py34,py35,py36,pypy3}-1.11
     {py34,py35,py36,pypy3}-2.0
     {py35,py36,py37,pypy3}-2.1
+    {py35,py36,py37,pypy3}-2.2
     {py36,py37,pypy3}-master
 
 [testenv]
@@ -24,6 +25,7 @@ deps =
     1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1
     2.1: Django>=2.1,<2.2
+    2.2: Django==2.2b1
     master: https://github.com/django/django/archive/master.tar.gz
     -r{toxinidir}/tests/requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     {py27,pypy,py34,py35,py36,pypy3}-1.11
     {py34,py35,py36,pypy3}-2.0
     {py35,py36,py37,pypy3}-2.1
-    {py35,py36,py37,pypy3}-master
+    {py36,py37,pypy3}-master
 
 [testenv]
 basepython =


### PR DESCRIPTION
This change adds an "EircodeField" to the Irish local flavour. An Eircode is
an Irish postcode (https://www.eircode.ie). The format of the Eircode is
validated, but its existence is not.

Thanks for your contribution!

A checklist is included below which helps us keep the code contributions
consistent and helps speed up the review process. You can add additional
commits to your pull request if you haven't met all of these points on your
first version.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- [ ] Adjust your imports to a standard form by running this command:

      `isort --recursive --line-width 120 localflavor tests`

**New Fields Only**

- [ ] Prefix the country code to all fields.

      I haven't done this, because "Eircode" is a uniquely Irish name for
      a postcode.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [ ] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

      Again, it's called "Eircode" because we just don't call them postal codes.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [ ] Add documentation for all fields.
