### PR TITLE
Remove isort from CI.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,6 @@ first version.
 - [ ] Add an entry for your name in the docs/authors.rst file if it's not
       already there.
 
-- [ ] Adjust your imports to a standard form by running this command:
-
-      `isort --recursive --line-width 120 localflavor tests`
-
 **New Fields Only**
 
 - [ ] Prefix the country code to all fields.

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: TOXENV=docs
     - python: 3.5
       env: TOXENV=prospector
-    - python: 3.6
-      env: TOXENV=isort
     - python: 2.7
       env: TOXENV=py27-1.11
     - python: pypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 args_are_paths = false
 envlist =
-    docs,prospector,isort
+    docs,prospector
     {py27,pypy,py34,py35,py36,pypy3}-1.11
     {py34,py35,py36,pypy3}-2.0
     {py35,py36,py37,pypy3}-2.1
@@ -45,8 +45,3 @@ deps =
 # Prospector 0.12.4 doesn't work with Python 3.6.
 basepython = python3.5
 commands = prospector --profile localflavor.prospector.yaml {toxinidir}
-
-[testenv:isort]
-deps = isort>=4.2,<4.3
-basepython = python3.6
-commands = isort --recursive --line-width 120 --diff --check {toxinidir}/localflavor {toxinidir}/tests


### PR DESCRIPTION
This PR removes the isort check in the CI as suggested by a couple of users. I still like the consistency this brings but too many contributors are running into problems with this check so it's time to remove it. We can always run isort manually once in a while if we want to keep things consistent with the imports.

Any thoughts or opinion on this?