### PR TITLE
Validate character set for BICs

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -84,6 +84,7 @@ Authors
 * Peter J. Farrell
 * Rael Max
 * Ramiro Morales
+* Raphael Michel
 * Rolf Erik Lekang
 * Russell Keith-Magee
 * Serafeim Papastefanos

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ Other changes:
 
 - Added support for Vatican IBAN
 
+- Extended validation of BICs to check for the correct character set
+
 
 2.1   (2018-08-24)
 ------------------

--- a/localflavor/generic/forms.py
+++ b/localflavor/generic/forms.py
@@ -125,7 +125,7 @@ class BICFormField(forms.CharField):
         value = super(BICFormField, self).to_python(value)
         if value in self.empty_values:
             return self.empty_value
-        return value.upper()
+        return value.upper().replace(" ", "")
 
     def prepare_value(self, value):
         # BIC is always written in upper case.

--- a/localflavor/generic/validators.py
+++ b/localflavor/generic/validators.py
@@ -233,6 +233,10 @@ class BICValidator(object):
         if bic_length != 8 and bic_length != 11:
             raise ValidationError(_('BIC codes have either 8 or 11 characters.'))
 
+        # BIC is alphanumeric
+        if any(char not in string.ascii_uppercase + string.digits for char in value):
+            raise ValidationError(_('BIC codes only contain alphabet letters and digits.'))
+
         # First 4 letters are A - Z.
         institution_code = value[:4]
         for x in institution_code:
@@ -314,7 +318,7 @@ VATIN_COUNTRY_CODE_LENGTH = 2
 Length of the country code prefix of a VAT identification number.
 
 Codes are two letter ISO 3166-1 alpha-2 codes except for Greece that uses
-ISO 639-1. 
+ISO 639-1.
 """
 
 

--- a/tests/test_generic/tests.py
+++ b/tests/test_generic/tests.py
@@ -324,7 +324,9 @@ class BICTests(TestCase):
             'NEDSZAJJXX': 'BIC codes have either 8 or 11 characters.',
             '': 'BIC codes have either 8 or 11 characters.',
             'CIBCJJH2': 'JJ is not a valid country code.',
-            'DÉUTDEFF': 'is not a valid institution code.'
+            'D3UTDEFF': 'is not a valid institution code.',
+            'DÉUTDEFF': 'codes only contain alphabet letters and digits.',
+            'NEDSZAJJ XX': 'codes only contain alphabet letters and digits.',
         }
 
         bic_validator = BICValidator()


### PR DESCRIPTION
Hi,

we've noted that a lot of our users try to input spaces into the BIC field and then run into the ``maxlength`` attribute silently. For example, if they want to input ``DEUTDEFFXXX``, they end up inputting ``DEUTDEFF XX``. As I understand [SWIFT](https://www.swift.com/file/5981/download?token=TBNI7gpV), all BICs are alphanumeric, even the branch codes. Therefore, I suggest

* validating that all BICs only contain letters and numbers.

* auto-removing spaces from form input


- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.´