### PR TITLE
ie model fields - rebase

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -82,6 +82,7 @@ Authors
 * Morgane Alonso
 * Olivier Sels
 * Olle Vidner
+* Paul Cunnane
 * Paul Donohue
 * Paulo Poiati
 * Peter J. Farrell

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ New flavors:
 New fields for existing flavors:
 - Added BRPostalCodeField, BRCPFField, BRCNPJField models fields.
 
+- `EircodeField` in IE flavor
+
 Modifications to existing flavors:
 
 - Deprecated `generic.checksums.luhn` and `generic.checksums.ean`. Please use the python-stdnum library instead.

--- a/localflavor/ie/forms.py
+++ b/localflavor/ie/forms.py
@@ -1,6 +1,12 @@
 """IE-specific Form helpers."""
 
-from django.forms.fields import Select
+from __future__ import unicode_literals
+
+import re
+
+from django.forms import ValidationError
+from django.forms.fields import Select, CharField
+from django.utils.translation import ugettext_lazy as _
 
 from .ie_counties import IE_COUNTY_CHOICES
 
@@ -10,3 +16,25 @@ class IECountySelect(Select):
 
     def __init__(self, attrs=None):
         super(IECountySelect, self).__init__(attrs, choices=IE_COUNTY_CHOICES)
+
+
+class EircodeField(CharField):
+    """
+    A form field that validates its input is a valid Eircode (Irish postcode).
+
+    The value is uppercased and has the internal space removed, if any.
+    """
+
+    default_error_messages = {"invalid": _("Enter a valid Eircode.")}
+    eircode_regex = re.compile(
+        r"^(D6W|[AC-FHKNPRTV-Y][0-9]{2}) ?([AC-FHKNPRTV-Y0-9]{4})$"
+    )
+
+    def clean(self, value):
+        value = super(EircodeField, self).clean(value)
+        if value in self.empty_values:
+            return self.empty_value
+        eircode = value.upper().strip()
+        if not self.eircode_regex.search(eircode):
+            raise ValidationError(self.error_messages["invalid"])
+        return eircode.replace(" ", "")

--- a/localflavor/ie/forms.py
+++ b/localflavor/ie/forms.py
@@ -2,10 +2,7 @@
 
 from __future__ import unicode_literals
 
-import re
-
-from django.forms import ValidationError
-from django.forms.fields import Select, CharField
+from django.forms.fields import Select, RegexField
 from django.utils.translation import ugettext_lazy as _
 
 from .ie_counties import IE_COUNTY_CHOICES
@@ -18,23 +15,36 @@ class IECountySelect(Select):
         super(IECountySelect, self).__init__(attrs, choices=IE_COUNTY_CHOICES)
 
 
-class EircodeField(CharField):
+class EircodeField(RegexField):
     """
     A form field that validates its input is a valid Eircode (Irish postcode).
 
     The value is uppercased and has the internal space removed, if any.
+
+    See page 12 for the validation syntax:
+    https://www.eircode.ie/docs/default-source/Common/prepareyourbusinessforeircode-edition3published.pdf?sfvrsn=2
+
+    .. versionadded:: 2.2
     """
 
     default_error_messages = {"invalid": _("Enter a valid Eircode.")}
-    eircode_regex = re.compile(
-        r"^(D6W|[AC-FHKNPRTV-Y][0-9]{2}) ?([AC-FHKNPRTV-Y0-9]{4})$"
-    )
 
-    def clean(self, value):
-        value = super(EircodeField, self).clean(value)
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('strip', True)
+        super(EircodeField, self).__init__("^(D6W|[AC-FHKNPRTV-Y][0-9]{2})([AC-FHKNPRTV-Y0-9]{4})$",
+                                           *args, **kwargs)
+
+    def to_python(self, value):
+        # The Eircode should be stored as uppercase without spaces (see page 7):
+        # https://www.eircode.ie/docs/default-source/Common/prepareyourbusinessforeircode-edition3published.pdf?sfvrsn=2
+        value = super(EircodeField, self).to_python(value)
         if value in self.empty_values:
             return self.empty_value
-        eircode = value.upper().strip()
-        if not self.eircode_regex.search(eircode):
-            raise ValidationError(self.error_messages["invalid"])
-        return eircode.replace(" ", "")
+        return value.upper().replace(" ", "")
+
+    def prepare_value(self, value):
+        # Display the Eircode with a space.
+        value = self.to_python(value)
+        if value in self.empty_values:
+            return self.empty_value
+        return '{} {}'.format(value[0:3], value[3:8])

--- a/tests/test_ie.py
+++ b/tests/test_ie.py
@@ -2,14 +2,13 @@ from __future__ import unicode_literals
 
 from django.test import SimpleTestCase
 
-from localflavor.ie.forms import IECountySelect
+from localflavor.ie.forms import IECountySelect, EircodeField
 
 
 class IELocalFlavorTests(SimpleTestCase):
-
     def test_IECountySelect(self):
         f = IECountySelect()
-        out = '''<select name="counties">
+        out = """<select name="counties">
 <option value="carlow">Carlow</option>
 <option value="cavan">Cavan</option>
 <option value="clare">Clare</option>
@@ -36,5 +35,28 @@ class IELocalFlavorTests(SimpleTestCase):
 <option value="westmeath">Westmeath</option>
 <option value="wexford">Wexford</option>
 <option value="wicklow">Wicklow</option>
-</select>'''
-        self.assertHTMLEqual(f.render('counties', 'dublin'), out)
+</select>"""
+        self.assertHTMLEqual(f.render("counties", "dublin"), out)
+
+    def test_EircodeField(self):
+        error_invalid = ["Enter a valid Eircode."]
+        valid = {
+            "A65 F4E2": "A65F4E2",
+            "a65f4e2": "A65F4E2",
+            "D6w123A": "D6W123A",
+            " f28 e50f ": "F28E50F",
+        }
+        invalid = {
+            "A65F 4E2": error_invalid,
+            "A65  F4E2": error_invalid,
+            "A 65 F4E2": error_invalid,
+            "D4W 1234": error_invalid,
+            "Z99ABCF": error_invalid,
+            "a65 123b": error_invalid,
+            " b0gUS": error_invalid,
+        }
+        self.assertFieldOutput(EircodeField, valid, invalid)
+        valid = {}
+        invalid = {"1NV 4L1D": ["Enter a bloody eircode!"]}
+        kwargs = {"error_messages": {"invalid": "Enter a bloody eircode!"}}
+        self.assertFieldOutput(EircodeField, valid, invalid, field_kwargs=kwargs)

--- a/tests/test_ie.py
+++ b/tests/test_ie.py
@@ -47,16 +47,27 @@ class IELocalFlavorTests(SimpleTestCase):
             " f28 e50f ": "F28E50F",
         }
         invalid = {
-            "A65F 4E2": error_invalid,
-            "A65  F4E2": error_invalid,
-            "A 65 F4E2": error_invalid,
+            "A65F 4EI": error_invalid,
+            "A65  F4EI": error_invalid,
+            "A 65 F4EI": error_invalid,
             "D4W 1234": error_invalid,
             "Z99ABCF": error_invalid,
             "a65 123b": error_invalid,
             " b0gUS": error_invalid,
         }
         self.assertFieldOutput(EircodeField, valid, invalid)
+
+    def test_EircodeField_error_message_can_be_overridden(self):
         valid = {}
         invalid = {"1NV 4L1D": ["Enter a bloody eircode!"]}
         kwargs = {"error_messages": {"invalid": "Enter a bloody eircode!"}}
         self.assertFieldOutput(EircodeField, valid, invalid, field_kwargs=kwargs)
+
+    def test_EircodeField_formatting(self):
+        field = EircodeField()
+        self.assertEqual(field.prepare_value("A65 F4E2"),  "A65 F4E2")
+        self.assertEqual(field.prepare_value("a65f4e2"), "A65 F4E2",)
+        self.assertEqual(field.prepare_value("D6w123A"), "D6W 123A")
+        self.assertEqual(field.prepare_value(" f28 e50f "), "F28 E50F")
+        self.assertEqual(field.prepare_value(None), '')
+        self.assertEqual(field.prepare_value(''), '')


### PR DESCRIPTION
This PR contains the code by @paulcunnane in #360 rebased to master. I started doing a review but after my investigation I had 80% of the updates done so I thought I'd just finish it.

Changes:
* Convert to using `RegexField`
* Remove space from regex so that it accepts Eircodes without spaces
* Add a display format with a space
* Use the the built-in strip option

@paulcunnane Could you test this version out to make sure it's working well?

Closes #360 