### PR TITLE
Use set value of strip in fields that inherit from forms.CharField.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,9 @@ Modifications to existing flavors:
   (`gh-380 <https://github.com/django/django-localflavor/pull/380>`_).
 - Switched incorrect `ar.forms.ARCBUField` implementation to use `python-stdnum <https://arthurdejong.org/python-stdnum/>`_ instead
   (`gh-391 <https://github.com/django/django-localflavor/pull/391>`_).
+- Use set value of `strip` in fields that inherit from `django.forms.CharField`: `gb.forms.GBPostcodeField`,
+  `si.forms.SIEMSOField`, `si.forms.SITaxNumberField` and `za.forms.ZAIDField`
+  (`gh-392 <https://github.com/django/django-localflavor/pull/392>`_).
 
 Other changes:
 

--- a/localflavor/gb/forms.py
+++ b/localflavor/gb/forms.py
@@ -17,8 +17,6 @@ class GBPostcodeField(CharField):
     BS7666 address types: https://data.gov.uk/education-standards/sites/default/files/CL-Address-Line-Type-v3-0.pdf
 
     The value is uppercased and a space added in the correct place, if required.
-
-    .. versionchanged:: 3.0
     """
 
     default_error_messages = {

--- a/localflavor/gb/forms.py
+++ b/localflavor/gb/forms.py
@@ -17,6 +17,8 @@ class GBPostcodeField(CharField):
     BS7666 address types: https://data.gov.uk/education-standards/sites/default/files/CL-Address-Line-Type-v3-0.pdf
 
     The value is uppercased and a space added in the correct place, if required.
+
+    .. versionchanged:: 3.0
     """
 
     default_error_messages = {
@@ -31,7 +33,7 @@ class GBPostcodeField(CharField):
         value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
-        postcode = value.upper().strip()
+        postcode = value.upper()
         # Put a single space before the incode (second part).
         postcode = self.space_regex.sub(r' \1', postcode)
         if not self.postcode_regex.search(postcode):

--- a/localflavor/si/forms.py
+++ b/localflavor/si/forms.py
@@ -15,6 +15,8 @@ class SIEMSOField(CharField):
     A form for validating Slovenian personal identification number.
 
     Additionally stores gender, nationality and birthday to self.info dictionary.
+
+    .. versionchanged:: 3.0
     """
 
     default_error_messages = {
@@ -28,8 +30,6 @@ class SIEMSOField(CharField):
         super().clean(value)
         if value in self.empty_values:
             return self.empty_value
-
-        value = value.strip()
 
         m = self._regex_match(value)
         day, month, year, nationality, gender, checksum = [int(i) for i in m.groups()]
@@ -84,6 +84,8 @@ class SITaxNumberField(CharField):
     Valid input is SIXXXXXXXX or XXXXXXXX where X is a number.
 
     http://zylla.wipos.p.lodz.pl/ut/translation.html#PZSI
+
+    .. versionchanged:: 3.0
     """
 
     default_error_messages = {
@@ -95,8 +97,6 @@ class SITaxNumberField(CharField):
         super().clean(value)
         if value in self.empty_values:
             return self.empty_value
-
-        value = value.strip()
 
         m = self.sitax_regex.match(value)
         if m is None:

--- a/localflavor/si/forms.py
+++ b/localflavor/si/forms.py
@@ -15,8 +15,6 @@ class SIEMSOField(CharField):
     A form for validating Slovenian personal identification number.
 
     Additionally stores gender, nationality and birthday to self.info dictionary.
-
-    .. versionchanged:: 3.0
     """
 
     default_error_messages = {
@@ -84,8 +82,6 @@ class SITaxNumberField(CharField):
     Valid input is SIXXXXXXXX or XXXXXXXX where X is a number.
 
     http://zylla.wipos.p.lodz.pl/ut/translation.html#PZSI
-
-    .. versionchanged:: 3.0
     """
 
     default_error_messages = {

--- a/localflavor/za/forms.py
+++ b/localflavor/za/forms.py
@@ -16,8 +16,6 @@ class ZAIDField(CharField):
 
     The checksum is validated using the Luhn checksum, and uses a simlistic (read: not entirely accurate)
     check for the birth date.
-
-    .. versionchanged:: 3.0
     """
 
     default_error_messages = {

--- a/localflavor/za/forms.py
+++ b/localflavor/za/forms.py
@@ -15,7 +15,9 @@ class ZAIDField(CharField):
     A form field for South African ID numbers.
 
     The checksum is validated using the Luhn checksum, and uses a simlistic (read: not entirely accurate)
-    check for the birthdate
+    check for the birth date.
+
+    .. versionchanged:: 3.0
     """
 
     default_error_messages = {
@@ -29,7 +31,7 @@ class ZAIDField(CharField):
             return self.empty_value
 
         # strip spaces and dashes
-        value = value.strip().replace(' ', '').replace('-', '')
+        value = value.replace(' ', '').replace('-', '')
 
         match = re.match(id_re, value)
 


### PR DESCRIPTION
`django.forms.CharField` already strips the white space if requested. The default is `True` which is why it's safe to just remove the `strip()` in these form fields.
https://docs.djangoproject.com/en/2.2/ref/forms/fields/#django.forms.CharField.strip