### PR TITLE
Drop support for Django < 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       env: TOXENV=py36-3.0
     - python: 3.7
       env: TOXENV=py37-3.0
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-3.0
     - python: pypy3
       env: TOXENV=pypy3-3.0
@@ -55,7 +55,7 @@ matrix:
       env: TOXENV=py36-master
     - python: 3.7
       env: TOXENV=py37-master
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-master
     - python: pypy3
       env: TOXENV=pypy3-master
@@ -64,7 +64,7 @@ matrix:
       env: TOXENV=py36-master
     - python: 3.7
       env: TOXENV=py37-master
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-master
     - python: pypy3
       env: TOXENV=pypy3-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: no
+sudo: false
 language: python
 cache: pip
 dist: xenial
@@ -9,32 +9,6 @@ matrix:
       env: TOXENV=docs
     - python: 3.5
       env: TOXENV=prospector
-    - python: 3.4
-      env: TOXENV=py34-1.11
-    - python: 3.5
-      env: TOXENV=py35-1.11
-    - python: 3.6
-      env: TOXENV=py36-1.11
-    - python: pypy3
-      env: TOXENV=pypy3-1.11
-    - python: 3.4
-      env: TOXENV=py34-2.0
-    - python: 3.5
-      env: TOXENV=py35-2.0
-    - python: 3.6
-      env: TOXENV=py36-2.0
-    - python: 3.7
-      env: TOXENV=py37-2.0
-    - python: pypy3
-      env: TOXENV=pypy3-2.0
-    - python: 3.5
-      env: TOXENV=py35-2.1
-    - python: 3.6
-      env: TOXENV=py36-2.1
-    - python: 3.7
-      env: TOXENV=py37-2.1
-    - python: pypy3
-      env: TOXENV=pypy3-2.1
     - python: 3.5
       env: TOXENV=py35-2.2
     - python: 3.6

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -5,7 +5,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import CharField, Field, Select
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from .br_states import STATE_CHOICES
@@ -57,10 +57,10 @@ class BRStateChoiceField(Field):
         value = super().clean(value)
         if value in EMPTY_VALUES:
             value = ''
-        value = force_text(value)
+        value = force_str(value)
         if value == '':
             return value
-        valid_values = set([force_text(entry[0]) for entry in self.widget.choices])
+        valid_values = set([force_str(entry[0]) for entry in self.widget.choices])
         if value not in valid_values:
             raise ValidationError(self.error_messages['invalid'])
         return value

--- a/localflavor/cl/forms.py
+++ b/localflavor/cl/forms.py
@@ -2,7 +2,7 @@
 
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from .cl_regions import REGION_CHOICES
@@ -66,7 +66,7 @@ class CLRutField(RegexField):
 
     def _canonify(self, rut):
         """Turns the RUT into one normalized format. Returns a (rut, verifier) tuple."""
-        rut = force_text(rut).replace(' ', '').replace('.', '').replace('-', '')
+        rut = force_str(rut).replace(' ', '').replace('.', '').replace('-', '')
         return rut[:-1], rut[-1].upper()
 
     def _format(self, code, verifier=None):

--- a/localflavor/gr/forms.py
+++ b/localflavor/gr/forms.py
@@ -4,7 +4,7 @@ import re
 
 from django.core.validators import EMPTY_VALUES
 from django.forms import Field, RegexField, ValidationError
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from stdnum import luhn
 
@@ -45,7 +45,7 @@ class GRTaxNumberCodeField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        val = re.sub('[\-\s\(\)]', '', force_text(value))
+        val = re.sub('[\-\s\(\)]', '', force_str(value))
         if(len(val) < 9):
             raise ValidationError(self.error_messages['invalid'])
         if not all(char.isdigit() for char in val):
@@ -90,7 +90,7 @@ class GRSocialSecurityNumberCodeField(RegexField):
         super().clean(value)
         if value in self.empty_values:
             return self.empty_value
-        val = re.sub('[\-\s]', '', force_text(value))
+        val = re.sub('[\-\s]', '', force_str(value))
         if not val or len(val) < 11:
             raise ValidationError(self.error_messages['invalid'])
         if self.allow_test_value and val == '00000000000':

--- a/localflavor/hr/forms.py
+++ b/localflavor/hr/forms.py
@@ -5,7 +5,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, Select
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from stdnum import luhn
 
@@ -144,7 +144,7 @@ class HRLicensePlateField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        value = re.sub(r'[\s\-]+', '', force_text(value.strip())).upper()
+        value = re.sub(r'[\s\-]+', '', force_str(value.strip())).upper()
 
         matches = plate_re.search(value)
         if matches is None:

--- a/localflavor/id_/forms.py
+++ b/localflavor/id_/forms.py
@@ -6,7 +6,7 @@ import time
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, Select
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 postcode_re = re.compile(r'^[1-9]\d{4}$')
@@ -85,7 +85,7 @@ class IDLicensePlateField(Field):
         super().clean(value)
         if value in EMPTY_VALUES:
             return ''
-        plate_number = re.sub(r'\s+', ' ', force_text(value.strip())).upper()
+        plate_number = re.sub(r'\s+', ' ', force_str(value.strip())).upper()
 
         number, prefix, suffix = self._validate_regex_match(plate_number)
         self._validate_prefix(prefix)
@@ -168,7 +168,7 @@ class IDNationalIdentityNumberField(Field):
         if value in EMPTY_VALUES:
             return ''
 
-        value = re.sub(r'[\s.]', '', force_text(value))
+        value = re.sub(r'[\s.]', '', force_str(value))
 
         if not nik_re.search(value):
             raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/in_/forms.py
+++ b/localflavor/in_/forms.py
@@ -5,7 +5,7 @@ import re
 from django.core.validators import EMPTY_VALUES
 from django.forms import ValidationError
 from django.forms.fields import Field, RegexField, Select
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from .in_states import STATE_CHOICES, STATES_NORMALIZED
@@ -60,7 +60,7 @@ class INStateField(Field):
             pass
         else:
             try:
-                return force_text(STATES_NORMALIZED[value.strip().lower()])
+                return force_str(STATES_NORMALIZED[value.strip().lower()])
             except KeyError:
                 pass
         raise ValidationError(self.error_messages['invalid'])

--- a/localflavor/is_/forms.py
+++ b/localflavor/is_/forms.py
@@ -3,7 +3,7 @@
 from django.forms import ValidationError
 from django.forms.fields import RegexField
 from django.forms.widgets import Select
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from .is_postalcodes import IS_POSTALCODES
@@ -54,7 +54,7 @@ class ISIdNumberField(RegexField):
 
     def _format(self, value):
         """Takes in the value in canonical form and returns it in the common display format."""
-        return force_text(value[:6] + '-' + value[6:])
+        return force_str(value[:6] + '-' + value[6:])
 
 
 class ISPostalCodeSelect(Select):

--- a/localflavor/it/util.py
+++ b/localflavor/it/util.py
@@ -1,4 +1,4 @@
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 
@@ -57,16 +57,16 @@ def vat_number_validation(vat_number):
     check_digit = vat_number_check_digit(vat_number[0:10])
     if vat_number[10] != check_digit:
         raise ValueError(_('Check digit does not match.'))
-    return force_text(vat_number)
+    return force_str(vat_number)
 
 
 def vat_number_check_digit(vat_number):
     """Calculate Italian VAT number check digit."""
-    normalized_vat_number = force_text(vat_number).zfill(10)
+    normalized_vat_number = force_str(vat_number).zfill(10)
     total = 0
     for i in range(0, 10, 2):
         total += int(normalized_vat_number[i])
     for i in range(1, 11, 2):
         quotient, remainder = divmod(int(normalized_vat_number[i]) * 2, 10)
         total += quotient + remainder
-    return force_text((10 - total % 10) % 10)
+    return force_str((10 - total % 10) % 10)

--- a/localflavor/sg/forms.py
+++ b/localflavor/sg/forms.py
@@ -4,7 +4,7 @@ import re
 
 from django.forms import ValidationError
 from django.forms.fields import CharField, RegexField
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 NRIC_FIN_RE = re.compile(r'^[SFTG](\d{7})[A-Z]$')
@@ -60,7 +60,7 @@ class SGNRICFINField(CharField):
         super().clean(value)
         if value in self.empty_values:
             return self.empty_value
-        value = re.sub('(\s+)', '', force_text(value.upper()))
+        value = re.sub('(\s+)', '', force_str(value.upper()))
         match = NRIC_FIN_RE.search(value)
         if not match:
             raise ValidationError(self.error_messages['invalid'])

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     package_data=find_package_data(),
     install_requires=[
-        'django>=1.11',
+        'django>=2.2',
         'python-stdnum>=1.6',
     ],
     classifiers=[

--- a/tests/test_nl/tests.py
+++ b/tests/test_nl/tests.py
@@ -93,7 +93,7 @@ class NLLocalFlavorModelTests(SimpleTestCase):
         # correct zipcode, should be clean now
         m.zipcode = '2403 bw'
         m.clean_fields()
-        self.assertEquals(str(m.zipcode), '2403 BW')
+        self.assertEqual(str(m.zipcode), '2403 BW')
 
     def test_NL_car(self):
         m = NLCar(**{
@@ -114,7 +114,7 @@ class NLLocalFlavorModelTests(SimpleTestCase):
         # correct license plate number, should be clean now
         m.license_plate = 'AA-11-AA'
         m.clean_fields()
-        self.assertEquals(str(m.license_plate), 'AA-11-AA')
+        self.assertEqual(str(m.license_plate), 'AA-11-AA')
 
 
 class NLLocalFlavorFormTests(SimpleTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,12 @@
 args_are_paths = false
 envlist =
     docs,prospector
-    {py34,py35,py36,pypy3}-1.11
-    {py34,py35,py36,py37,pypy3}-2.0
-    {py35,py36,py37,pypy3}-2.1
     {py35,py36,py37,pypy3}-2.2
     {py36,py37,py38,pypy3}-3.0
     {py36,py37,py38,pypy3}-master
 
 [testenv]
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7
@@ -22,11 +18,8 @@ pip_pre = true
 commands =
     invoke test {posargs}
 deps =
-    1.11: Django>=1.11,<2.0
-    2.0: Django>=2.0,<2.1
-    2.1: Django>=2.1,<2.2
     2.2: Django>=2.2,<2.3
-    3.0: Django==3.0b1
+    3.0: Django>=3.0,<3.1
     master: https://github.com/django/django/archive/master.tar.gz
     -r{toxinidir}/tests/requirements.txt
 


### PR DESCRIPTION
As per the recommendation in the Django 3.0 release notes, this PR drops support for all versions of Django prior to 2.2. 

https://docs.djangoproject.com/en/3.0/releases/3.0/#third-party-library-support-for-older-version-of-django