### PR TITLE
Use the value returned by field's clean()

### DIFF
--- a/localflavor/ca/forms.py
+++ b/localflavor/ca/forms.py
@@ -52,7 +52,7 @@ class CAProvinceField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
         try:
@@ -97,7 +97,7 @@ class CASocialInsuranceNumberField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 

--- a/localflavor/ch/forms.py
+++ b/localflavor/ch/forms.py
@@ -86,7 +86,7 @@ class CHIdentityCardNumberField(Field):
         return str(calculated_checksum)[-1] == given_checksum
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 

--- a/localflavor/cl/forms.py
+++ b/localflavor/cl/forms.py
@@ -44,7 +44,7 @@ class CLRutField(RegexField):
 
     def clean(self, value):
         """Check and clean the Chilean RUT."""
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         rut, verificador = self._canonify(value)

--- a/localflavor/cn/forms.py
+++ b/localflavor/cn/forms.py
@@ -107,7 +107,7 @@ class CNIDCardField(CharField):
     def clean(self, value):
         """Check whether the input is a valid ID Card Number."""
         # Check the length of the ID card number.
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         # Check whether this ID card number has valid format

--- a/localflavor/cu/forms.py
+++ b/localflavor/cu/forms.py
@@ -21,7 +21,7 @@ class CURegionField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return ''
         try:
@@ -57,7 +57,7 @@ class CUProvinceField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return ''
         try:

--- a/localflavor/cz/forms.py
+++ b/localflavor/cz/forms.py
@@ -55,7 +55,7 @@ class CZBirthNumberField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
 
         if value in EMPTY_VALUES:
             return ''
@@ -104,7 +104,7 @@ class CZICNumberField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
 
         if value in EMPTY_VALUES:
             return ''

--- a/localflavor/de/forms.py
+++ b/localflavor/de/forms.py
@@ -71,7 +71,7 @@ class DEIdentityCardNumberField(Field):
         return str(calculated_checksum)[-1] == given_checksum
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
         match = re.match(ID_RE, value)

--- a/localflavor/ee/forms.py
+++ b/localflavor/ee/forms.py
@@ -62,7 +62,7 @@ class EEPersonalIdentificationCode(Field):
         return check % 10
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 

--- a/localflavor/eg/forms.py
+++ b/localflavor/eg/forms.py
@@ -30,7 +30,7 @@ class EGNationalIDNumberField(RegexField):
         super().__init__(r'\d{14}', max_length=max_length, min_length=min_length, *args, **kwargs)
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 

--- a/localflavor/es/forms.py
+++ b/localflavor/es/forms.py
@@ -80,7 +80,7 @@ class ESIdentityCardNumberField(RegexField):
         super().__init__(id_card_re, *args, **kwargs)
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 
@@ -149,7 +149,7 @@ class ESCCCField(RegexField):
         super().__init__(r'^\d{4}[ -]?\d{4}[ -]?\d{2}[ -]?\d{10}$', *args, **kwargs)
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         m = re.match(r'^(\d{4})[ -]?(\d{4})[ -]?(\d{2})[ -]?(\d{10})$', value)

--- a/localflavor/fi/forms.py
+++ b/localflavor/fi/forms.py
@@ -40,7 +40,7 @@ class FISocialSecurityNumber(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -102,7 +102,7 @@ class FRNationalIdentificationNumber(CharField):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 
@@ -173,7 +173,7 @@ class FRSIRENENumberMixin:
     """Abstract class for SIREN and SIRET numbers, from the SIRENE register."""
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 

--- a/localflavor/gr/forms.py
+++ b/localflavor/gr/forms.py
@@ -41,7 +41,7 @@ class GRTaxNumberCodeField(Field):
         super().__init__(*args, **kwargs)
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 
@@ -87,7 +87,7 @@ class GRSocialSecurityNumberCodeField(RegexField):
             raise ValidationError(self.error_messages['invalid'])
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         val = re.sub('[\-\s]', '', force_str(value))

--- a/localflavor/hr/forms.py
+++ b/localflavor/hr/forms.py
@@ -57,7 +57,7 @@ class HRJMBGField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 
@@ -110,7 +110,7 @@ class HROIBField(RegexField):
         )
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 
@@ -140,7 +140,7 @@ class HRLicensePlateField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 
@@ -177,7 +177,7 @@ class HRPostalCodeField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 
@@ -207,7 +207,7 @@ class HRJMBAGField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 

--- a/localflavor/id_/forms.py
+++ b/localflavor/id_/forms.py
@@ -29,7 +29,7 @@ class IDPostCodeField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 
@@ -84,7 +84,7 @@ class IDLicensePlateField(Field):
     foreign_vehicles_prefixes = ('CD', 'CC')
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
         plate_number = re.sub(r'\s+', ' ', force_str(value.strip())).upper()
@@ -167,7 +167,7 @@ class IDNationalIdentityNumberField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 

--- a/localflavor/kw/forms.py
+++ b/localflavor/kw/forms.py
@@ -53,7 +53,7 @@ class KWCivilIDNumberField(RegexField):
         )
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 

--- a/localflavor/lt/forms.py
+++ b/localflavor/lt/forms.py
@@ -45,7 +45,7 @@ class LTIDCodeField(RegexField):
         super().__init__(r'^\d{11}$', *args, **kwargs)
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
 
         if value in self.empty_values:
             return self.empty_value

--- a/localflavor/lv/forms.py
+++ b/localflavor/lv/forms.py
@@ -61,7 +61,7 @@ class LVPersonalCodeField(Field):
         return ((1 - check) % 11) % 10
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 

--- a/localflavor/no/forms.py
+++ b/localflavor/no/forms.py
@@ -41,7 +41,7 @@ class NOSocialSecurityNumber(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
 

--- a/localflavor/nz/forms.py
+++ b/localflavor/nz/forms.py
@@ -81,7 +81,7 @@ class NZBankAccountNumberField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
         value = re.sub('(\s+|-)', '', smart_str(value))

--- a/localflavor/pl/forms.py
+++ b/localflavor/pl/forms.py
@@ -49,7 +49,7 @@ class PLPESELField(RegexField):
         super().__init__(r'^\d{11}$', *args, **kwargs)
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         if not self.has_valid_checksum(value):
@@ -106,7 +106,7 @@ class PLNationalIDCardNumberField(RegexField):
         super().__init__(r'^[A-Za-z]{3}\d{6}$', *args, **kwargs)
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 
@@ -159,7 +159,7 @@ class PLNIPField(RegexField):
         )
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         value = re.sub("[-]", "", value)
@@ -195,7 +195,7 @@ class PLREGONField(RegexField):
         super().__init__(r'^\d{9,14}$', *args, **kwargs)
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         if not self.has_valid_checksum(value):

--- a/localflavor/pt/forms.py
+++ b/localflavor/pt/forms.py
@@ -37,7 +37,7 @@ class PTCitizenCardNumberField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
 
         if value in EMPTY_VALUES:
             return ''
@@ -95,7 +95,7 @@ class PTSocialSecurityNumberField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
 
         if value in EMPTY_VALUES:
             return ''

--- a/localflavor/ro/forms.py
+++ b/localflavor/ro/forms.py
@@ -138,7 +138,7 @@ class ROCountyField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
 
         if value in EMPTY_VALUES:
             return ''

--- a/localflavor/sg/forms.py
+++ b/localflavor/sg/forms.py
@@ -57,7 +57,7 @@ class SGNRICFINField(CharField):
 
         Strips whitespace.
         """
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         value = re.sub('(\s+)', '', force_str(value.upper()))

--- a/localflavor/si/forms.py
+++ b/localflavor/si/forms.py
@@ -25,7 +25,7 @@ class SIEMSOField(CharField):
     emso_regex = re.compile('^(\d{2})(\d{2})(\d{3})(\d{2})(\d{3})(\d)$')
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 
@@ -90,7 +90,7 @@ class SITaxNumberField(CharField):
     sitax_regex = re.compile('^(?:SI)?([1-9]\d{7})$')
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
 

--- a/localflavor/tr/forms.py
+++ b/localflavor/tr/forms.py
@@ -58,7 +58,7 @@ class TRIdentificationNumberField(Field):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
 
         if value in EMPTY_VALUES:
             return ''

--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -63,7 +63,7 @@ class USSocialSecurityNumberField(CharField):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
         if value in self.empty_values:
             return self.empty_value
         match = re.match(ssn_re, value)
@@ -99,7 +99,7 @@ class USStateField(Field):
 
     def clean(self, value):
         from .us_states import STATES_NORMALIZED
-        super().clean(value)
+        value = super().clean(value)
         if value in EMPTY_VALUES:
             return ''
         try:

--- a/localflavor/za/forms.py
+++ b/localflavor/za/forms.py
@@ -23,7 +23,7 @@ class ZAIDField(CharField):
     }
 
     def clean(self, value):
-        super().clean(value)
+        value = super().clean(value)
 
         if value in self.empty_values:
             return self.empty_value


### PR DESCRIPTION
I've noticed that for many flavors the `super().clean()` of fields is called but the result is ignored. Such behavior voids base class validation, for example the `strip=True` setting is always ignored.

This change unifies all flavors by using the results of base class validations.