### PR TITLE
Removed unused *args from fields that use forms.RegexField

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,11 @@ will be displayed when `it.forms.ITRegionProvinceSelect` is used. See the
 `localflavor online docs <https://django-localflavor.readthedocs.io/en/latest/#backwards-compatibility>`_ for
 instructions on how to suppress this warning once the migration has been completed.
 
+Using positional arguments with fields that inherit from Django's `forms.RegexField` previously only worked with Django
+1.11 but were ignored with Django >= 2.0. Positional arguments have now been removed from all fields that inherit from
+Django's `forms.RegexField`. Any options needed on the parent `forms.RegexField`, `forms.CharField` or `forms.Field`
+must now be set with keyword arguments.
+
 New flavors:
 
 - Egypt local flavor
@@ -105,6 +110,9 @@ Modifications to existing flavors:
   - `us.forms.USSocialSecurityNumberField`
   - `us.forms.USStateField`
   - `za.forms.ZAIDField`
+
+- Removed unused positional arguments from fields that inherit from `forms.RegexField`
+  (`gh-405 <https://github.com/django/django-localflavor/pull/405>`_).
 
 Other changes:
 

--- a/localflavor/ar/forms.py
+++ b/localflavor/ar/forms.py
@@ -30,10 +30,10 @@ class ARPostalCodeField(RegexField):
         'invalid': _("Enter a postal code in the format NNNN or ANNNNAAA."),
     }
 
-    def __init__(self, max_length=8, min_length=4, *args, **kwargs):
+    def __init__(self, max_length=8, min_length=4, **kwargs):
         super().__init__(
             r'^\d{4}$|^[A-HJ-NP-Za-hj-np-z]\d{4}\D{3}$',
-            max_length=max_length, min_length=min_length, *args, **kwargs
+            max_length=max_length, min_length=min_length, **kwargs
         )
 
     def clean(self, value):
@@ -96,8 +96,8 @@ class ARCUITField(RegexField):
         'legal_type': _('Invalid legal type. Type must be 27, 20, 30, 23, 24, 33 or 34.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{2}-?\d{8}-?\d$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{2}-?\d{8}-?\d$', **kwargs)
 
     def clean(self, value):
         """Value can be either a string in the format XX-XXXXXXXX-X or an 11-digit number."""

--- a/localflavor/at/forms.py
+++ b/localflavor/at/forms.py
@@ -22,8 +22,8 @@ class ATZipCodeField(RegexField):
         'invalid': _('Enter a zip code in the format XXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^[1-9]{1}\d{3}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^[1-9]{1}\d{3}$', **kwargs)
 
 
 class ATStateSelect(Select):

--- a/localflavor/au/forms.py
+++ b/localflavor/au/forms.py
@@ -19,8 +19,8 @@ class AUPostCodeField(RegexField):
         'invalid': _('Enter a 4 digit postcode.'),
     }
 
-    def __init__(self, max_length=4, *args, **kwargs):
-        super().__init__(r'^\d{4}$', max_length=max_length, *args, **kwargs)
+    def __init__(self, max_length=4, **kwargs):
+        super().__init__(r'^\d{4}$', max_length=max_length, **kwargs)
 
 
 class AUStateSelect(Select):

--- a/localflavor/be/forms.py
+++ b/localflavor/be/forms.py
@@ -23,8 +23,8 @@ class BEPostalCodeField(RegexField):
             'Enter a valid postal code in the range and format 1XXX - 9XXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^[1-9]\d{3}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^[1-9]\d{3}$', **kwargs)
 
 
 class BERegionSelect(Select):

--- a/localflavor/ch/forms.py
+++ b/localflavor/ch/forms.py
@@ -29,8 +29,8 @@ class CHZipCodeField(RegexField):
         'invalid': _('Enter a valid postal code in the range and format 1XXX - 9XXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(zip_re, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(zip_re, **kwargs)
 
 
 class CHStateSelect(Select):

--- a/localflavor/cl/forms.py
+++ b/localflavor/cl/forms.py
@@ -31,16 +31,16 @@ class CLRutField(RegexField):
         'checksum': _('The Chilean RUT is not valid.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         if 'strict' in kwargs:
             del kwargs['strict']
             super().__init__(r'^(\d{1,2}\.)?\d{3}\.\d{3}-[\dkK]$',
                              error_messages={'invalid': self.default_error_messages['strict']},
-                             *args, **kwargs)
+                             **kwargs)
         else:
             # In non-strict mode, accept RUTs that validate but do not exist in
             # the real world.
-            super().__init__(r'^[\d\.]{1,11}-?[\dkK]$', *args, **kwargs)
+            super().__init__(r'^[\d\.]{1,11}-?[\dkK]$', **kwargs)
 
     def clean(self, value):
         """Check and clean the Chilean RUT."""

--- a/localflavor/cn/forms.py
+++ b/localflavor/cn/forms.py
@@ -75,8 +75,8 @@ class CNPostCodeField(RegexField):
         'invalid': _('Enter a post code in the format XXXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(POST_CODE_RE, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(POST_CODE_RE, **kwargs)
 
 
 class CNIDCardField(CharField):

--- a/localflavor/co/forms.py
+++ b/localflavor/co/forms.py
@@ -30,8 +30,8 @@ class CONITField(RegexField):
 
     PRIME_PLACES = [3, 7, 13, 17, 19, 23, 29, 37, 41, 43, 47, 53, 59, 67, 71]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{5,12}-?\d$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{5,12}-?\d$', **kwargs)
 
     def clean(self, value):
         """

--- a/localflavor/cu/forms.py
+++ b/localflavor/cu/forms.py
@@ -93,8 +93,8 @@ class CUPostalCodeField(RegexField):
         'invalid': _('Enter a valid postal code in the format XXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^[1-9]\d{4}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^[1-9]\d{4}$', **kwargs)
 
     def to_python(self, value):
         value = super().to_python(value)
@@ -127,8 +127,8 @@ class CUIdentityCardNumberField(RegexField):
         'invalid': _('Enter a valid identity card number in the format XXXXXXXXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{11}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{11}$', **kwargs)
         self.validators.append(CUIdentityCardNumberBirthdayValidator())
 
     def to_python(self, value):

--- a/localflavor/cz/forms.py
+++ b/localflavor/cz/forms.py
@@ -31,8 +31,8 @@ class CZPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XXXXX or XXX XX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{5}$|^\d{3} \d{2}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{5}$|^\d{3} \d{2}$', **kwargs)
 
     def clean(self, value):
         """

--- a/localflavor/de/forms.py
+++ b/localflavor/de/forms.py
@@ -24,8 +24,8 @@ class DEZipCodeField(RegexField):
         'invalid': _('Enter a zip code in the format XXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^([0]{1}[1-9]{1}|[1-9]{1}[0-9]{1})[0-9]{3}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^([0]{1}[1-9]{1}|[1-9]{1}[0-9]{1})[0-9]{3}$', **kwargs)
 
 
 class DEStateSelect(Select):

--- a/localflavor/ee/forms.py
+++ b/localflavor/ee/forms.py
@@ -24,8 +24,8 @@ class EEZipCodeField(RegexField):
         'invalid': _('Enter a zip code in the format XXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(zipcode, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(zipcode, **kwargs)
 
 
 class EECountySelect(Select):

--- a/localflavor/eg/forms.py
+++ b/localflavor/eg/forms.py
@@ -26,8 +26,8 @@ class EGNationalIDNumberField(RegexField):
         'invalid': _('Enter a valid Egyptian National ID number'),
     }
 
-    def __init__(self, max_length=14, min_length=14, *args, **kwargs):
-        super().__init__(r'\d{14}', max_length=max_length, min_length=min_length, *args, **kwargs)
+    def __init__(self, max_length=14, min_length=14, **kwargs):
+        super().__init__(r'\d{14}', max_length=max_length, min_length=min_length, **kwargs)
 
     def clean(self, value):
         value = super().clean(value)

--- a/localflavor/es/forms.py
+++ b/localflavor/es/forms.py
@@ -22,15 +22,15 @@ class ESPostalCodeField(RegexField):
         'invalid': _('Enter a valid postal code in the range and format 01XXX - 52XXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^(0[1-9]|[1-4][0-9]|5[0-2])\d{3}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^(0[1-9]|[1-4][0-9]|5[0-2])\d{3}$', **kwargs)
 
 
 class ESIdentityCardNumberField(RegexField):
     """
     Spanish NIF/NIE/CIF (Fiscal Identification Number) code.
 
-    Validates three diferent formats:
+    Validates three different formats:
 
         NIF (individuals): 12345678A
         CIF (companies): A12345678
@@ -59,7 +59,7 @@ class ESIdentityCardNumberField(RegexField):
         'invalid_cif': _('Invalid checksum for CIF.'),
     }
 
-    def __init__(self, only_nif=False, *args, **kwargs):
+    def __init__(self, only_nif=False, **kwargs):
         self.only_nif = only_nif
         self.nif_control = 'TRWAGMYFPDXBNJZSQVHLCKE'
         self.cif_control = 'JABCDEFGHI'
@@ -77,7 +77,7 @@ class ESIdentityCardNumberField(RegexField):
         error_messages.update(kwargs.get('error_messages', {}))
         kwargs['error_messages'] = error_messages
 
-        super().__init__(id_card_re, *args, **kwargs)
+        super().__init__(id_card_re, **kwargs)
 
     def clean(self, value):
         value = super().clean(value)
@@ -145,8 +145,8 @@ class ESCCCField(RegexField):
         'checksum': _('Invalid checksum for bank account number.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{4}[ -]?\d{4}[ -]?\d{2}[ -]?\d{10}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{4}[ -]?\d{4}[ -]?\d{2}[ -]?\d{10}$', **kwargs)
 
     def clean(self, value):
         value = super().clean(value)

--- a/localflavor/fi/forms.py
+++ b/localflavor/fi/forms.py
@@ -21,8 +21,8 @@ class FIZipCodeField(RegexField):
         'invalid': _('Enter a zip code in the format XXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{5}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{5}$', **kwargs)
 
 
 class FIMunicipalitySelect(Select):

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -27,11 +27,11 @@ class FRZipCodeField(RegexField):
         'invalid': _('Enter a zip code in the format XXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         kwargs.setdefault('label', _('Zip code'))
         kwargs['max_length'] = 5
         kwargs['min_length'] = 5
-        super().__init__(r'^\d{5}$', *args, **kwargs)
+        super().__init__(r'^\d{5}$', **kwargs)
 
 
 class FRDepartmentSelect(Select):

--- a/localflavor/generic/forms.py
+++ b/localflavor/generic/forms.py
@@ -28,26 +28,26 @@ IBAN_MIN_LENGTH = min(IBAN_COUNTRY_CODE_LENGTH.values())
 class DateField(forms.DateField):
     """A date input field which uses non-US date input formats by default."""
 
-    def __init__(self, input_formats=None, *args, **kwargs):
+    def __init__(self, input_formats=None, **kwargs):
         input_formats = input_formats or DEFAULT_DATE_INPUT_FORMATS
-        super().__init__(input_formats=input_formats, *args, **kwargs)
+        super().__init__(input_formats=input_formats, **kwargs)
 
 
 class DateTimeField(forms.DateTimeField):
     """A date and time input field which uses non-US date and time input formats by default."""
 
-    def __init__(self, input_formats=None, *args, **kwargs):
+    def __init__(self, input_formats=None, **kwargs):
         input_formats = input_formats or DEFAULT_DATETIME_INPUT_FORMATS
-        super().__init__(input_formats=input_formats, *args, **kwargs)
+        super().__init__(input_formats=input_formats, **kwargs)
 
 
 class SplitDateTimeField(forms.SplitDateTimeField):
     """Split date and time input fields which use non-US date and time input formats by default."""
 
-    def __init__(self, input_date_formats=None, input_time_formats=None, *args, **kwargs):
+    def __init__(self, input_date_formats=None, input_time_formats=None, **kwargs):
         input_date_formats = input_date_formats or DEFAULT_DATE_INPUT_FORMATS
         super().__init__(input_date_formats=input_date_formats,
-                         input_time_formats=input_time_formats, *args, **kwargs)
+                         input_time_formats=input_time_formats, **kwargs)
 
 
 class IBANFormField(forms.CharField):

--- a/localflavor/gr/forms.py
+++ b/localflavor/gr/forms.py
@@ -20,8 +20,8 @@ class GRPostalCodeField(RegexField):
         'invalid': _('Enter a valid 5-digit greek postal code.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^[12345678]\d{4}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^[12345678]\d{4}$', **kwargs)
 
 
 class GRTaxNumberCodeField(Field):
@@ -76,9 +76,9 @@ class GRSocialSecurityNumberCodeField(RegexField):
         'invalid': _('Enter a valid greek social security number (AMKA - 11 digits).'),
     }
 
-    def __init__(self, allow_test_value=False, *args, **kwargs):
+    def __init__(self, allow_test_value=False, **kwargs):
         self.allow_test_value = allow_test_value
-        super().__init__(r'^[0-9\s\-]+$', *args, **kwargs)
+        super().__init__(r'^[0-9\s\-]+$', **kwargs)
 
     def check_date(self, val):
         try:

--- a/localflavor/hr/forms.py
+++ b/localflavor/hr/forms.py
@@ -103,10 +103,10 @@ class HROIBField(RegexField):
         'invalid': _('Enter a valid 11 digit OIB'),
     }
 
-    def __init__(self, min_length=11, max_length=11, *args, **kwargs):
+    def __init__(self, min_length=11, max_length=11, **kwargs):
         super().__init__(
             r'^\d{11}$', max_length=max_length, min_length=min_length,
-            *args, **kwargs
+            **kwargs
         )
 
     def clean(self, value):

--- a/localflavor/ie/forms.py
+++ b/localflavor/ie/forms.py
@@ -27,10 +27,10 @@ class EircodeField(RegexField):
 
     default_error_messages = {"invalid": _("Enter a valid Eircode.")}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         kwargs.setdefault('strip', True)
         super().__init__("^(D6W|[AC-FHKNPRTV-Y][0-9]{2})([AC-FHKNPRTV-Y0-9]{4})$",
-                         *args, **kwargs)
+                         **kwargs)
 
     def to_python(self, value):
         # The Eircode should be stored as uppercase without spaces (see page 7):

--- a/localflavor/il/forms.py
+++ b/localflavor/il/forms.py
@@ -21,8 +21,8 @@ class ILPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XXXXXXX (or XXXXX) - digits only'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{5}$|^\d{7}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{5}$|^\d{7}$', **kwargs)
 
     def clean(self, value):
         if value not in self.empty_values:

--- a/localflavor/in_/forms.py
+++ b/localflavor/in_/forms.py
@@ -20,8 +20,8 @@ class INZipCodeField(RegexField):
         'invalid': _('Enter a zip code in the format XXXXXX or XXX XXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{3}\s?\d{3}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{3}\s?\d{3}$', **kwargs)
 
     def clean(self, value):
         value = super().clean(value)

--- a/localflavor/ir/forms.py
+++ b/localflavor/ir/forms.py
@@ -39,8 +39,8 @@ class IRPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XXXXXXXXXX - digits only'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'\b(?!(\d)\1{3})[13-9]{4}[1346-9][013-9]{5}\b$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'\b(?!(\d)\1{3})[13-9]{4}[1346-9][013-9]{5}\b$', **kwargs)
 
     def clean(self, value):
         if value not in self.empty_values:

--- a/localflavor/is_/forms.py
+++ b/localflavor/is_/forms.py
@@ -22,10 +22,10 @@ class ISIdNumberField(RegexField):
         'checksum': _('The Icelandic identification number is not valid.'),
     }
 
-    def __init__(self, max_length=11, min_length=10, *args, **kwargs):
+    def __init__(self, max_length=11, min_length=10, **kwargs):
         super().__init__(
             r'^\d{6}(-| )?\d{4}$', max_length=max_length, min_length=min_length,
-            *args, **kwargs
+            **kwargs
         )
 
     def clean(self, value):

--- a/localflavor/it/forms.py
+++ b/localflavor/it/forms.py
@@ -24,8 +24,8 @@ class ITZipCodeField(RegexField):
         'invalid': _('Enter a valid zip code.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{5}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{5}$', **kwargs)
 
 
 class ITRegionSelect(Select):
@@ -69,9 +69,9 @@ class ITSocialSecurityNumberField(RegexField):
         'invalid': _('Enter a valid Tax code.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(
-            r'^\w{3}\s*\w{3}\s*\w{5}\s*\w{5}$|\d{10}', *args, **kwargs
+            r'^\w{3}\s*\w{3}\s*\w{5}\s*\w{5}$|\d{10}', **kwargs
         )
 
     def clean(self, value):

--- a/localflavor/jp/forms.py
+++ b/localflavor/jp/forms.py
@@ -17,8 +17,8 @@ class JPPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XXXXXXX or XXX-XXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{3}-\d{4}$|^\d{7}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{3}-\d{4}$|^\d{7}$', **kwargs)
 
     def clean(self, value):
         """

--- a/localflavor/kw/forms.py
+++ b/localflavor/kw/forms.py
@@ -46,10 +46,10 @@ class KWCivilIDNumberField(RegexField):
         'invalid': _('Enter a valid Kuwaiti Civil ID number'),
     }
 
-    def __init__(self, max_length=12, min_length=12, *args, **kwargs):
+    def __init__(self, max_length=12, min_length=12, **kwargs):
         super().__init__(
             r'\d{12}', max_length=max_length, min_length=min_length,
-            *args, **kwargs
+            **kwargs
         )
 
     def clean(self, value):

--- a/localflavor/lt/forms.py
+++ b/localflavor/lt/forms.py
@@ -41,8 +41,8 @@ class LTIDCodeField(RegexField):
         'date': _('ID Code contains invalid date.')
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{11}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{11}$', **kwargs)
 
     def clean(self, value):
         value = super().clean(value)

--- a/localflavor/ma/forms.py
+++ b/localflavor/ma/forms.py
@@ -19,11 +19,11 @@ class MAPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         kwargs.setdefault('label', _('Postal code'))
         kwargs['max_length'] = 5
         kwargs['min_length'] = 5
-        super().__init__(r'^\d{5}$', *args, **kwargs)
+        super().__init__(r'^\d{5}$', **kwargs)
 
 
 class MAProvinceSelect(Select):

--- a/localflavor/mk/forms.py
+++ b/localflavor/mk/forms.py
@@ -19,11 +19,11 @@ class MKIdentityCardNumberField(RegexField):
                      ' either 4 to 7 digits or an uppercase letter and 7 digits.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         kwargs['min_length'] = None
         kwargs['max_length'] = 8
         regex = r'(^[A-Z]{1}\d{7}$)|(^\d{4,7}$)'
-        super().__init__(regex, *args, **kwargs)
+        super().__init__(regex, **kwargs)
 
 
 class MKMunicipalitySelect(Select):
@@ -59,10 +59,10 @@ class UMCNField(RegexField):
         'checksum': _('The UMCN is not valid.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         kwargs['min_length'] = None
         kwargs['max_length'] = 13
-        super().__init__(r'^\d{13}$', *args, **kwargs)
+        super().__init__(r'^\d{13}$', **kwargs)
 
     def clean(self, value):
         value = super().clean(value)

--- a/localflavor/mt/forms.py
+++ b/localflavor/mt/forms.py
@@ -15,5 +15,5 @@ class MTPostalCodeField(RegexField):
         'invalid': _('Enter a valid postal code in format AAA 0000.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^[A-Z]{3}\ \d{4}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^[A-Z]{3}\ \d{4}$', **kwargs)

--- a/localflavor/mx/forms.py
+++ b/localflavor/mx/forms.py
@@ -59,9 +59,9 @@ class MXZipCodeField(RegexField):
         'invalid': _('Enter a valid zip code in the format XXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         zip_code_re = r'^(0[1-9]|[1][0-6]|[2-9]\d)(\d{3})$'
-        super().__init__(zip_code_re, *args, **kwargs)
+        super().__init__(zip_code_re, **kwargs)
 
 
 class MXRFCField(RegexField):
@@ -104,10 +104,10 @@ class MXRFCField(RegexField):
         'invalid_checksum': _('Invalid checksum for RFC.'),
     }
 
-    def __init__(self, min_length=12, max_length=13, *args, **kwargs):
+    def __init__(self, min_length=12, max_length=13, **kwargs):
         rfc_re = re.compile(r'^([A-Z&Ññ]{3}|[A-Z][AEIOU][A-Z]{2})%s[A-Z0-9]{2}[0-9A]$' % DATE_RE,
                             re.IGNORECASE)
-        super().__init__(rfc_re, min_length=min_length, max_length=max_length, *args, **kwargs)
+        super().__init__(rfc_re, min_length=min_length, max_length=max_length, **kwargs)
 
     def clean(self, value):
         value = super().clean(value)
@@ -177,9 +177,9 @@ class MXCLABEField(RegexField):
         'invalid_checksum': _('Invalid checksum for CLABE.'),
     }
 
-    def __init__(self, min_length=18, max_length=18, *args, **kwargs):
+    def __init__(self, min_length=18, max_length=18, **kwargs):
         clabe_re = r'^\d{18}$'
-        super().__init__(clabe_re, min_length=min_length, max_length=max_length, *args, **kwargs)
+        super().__init__(clabe_re, min_length=min_length, max_length=max_length, **kwargs)
 
     def _checksum(self, value):
         verification_digit = int(value[-1])
@@ -233,14 +233,14 @@ class MXCURPField(RegexField):
         'invalid_checksum': _('Invalid checksum for CURP.'),
     }
 
-    def __init__(self, min_length=18, max_length=18, *args, **kwargs):
+    def __init__(self, min_length=18, max_length=18, **kwargs):
         states_re = r'(AS|BC|BS|CC|CL|CM|CS|CH|DF|DG|GT|GR|HG|JC|MC|MN|' \
                     r'MS|NT|NL|OC|PL|QT|QR|SP|SL|SR|TC|TS|TL|VZ|YN|ZS|NE)'
         consonants_re = r'[B-DF-HJ-NP-TV-Z]'
         curp_re = (r'^[A-Z][AEIOU][A-Z]{2}%s[HM]%s%s{3}[0-9A-Z]\d$' %
                    (DATE_RE, states_re, consonants_re))
         curp_re = re.compile(curp_re, re.IGNORECASE)
-        super().__init__(curp_re, min_length=min_length, max_length=max_length, *args, **kwargs)
+        super().__init__(curp_re, min_length=min_length, max_length=max_length, **kwargs)
 
     def clean(self, value):
         value = super().clean(value)
@@ -295,10 +295,10 @@ class MXSocialSecurityNumberField(RegexField):
         'invalid_checksum': _('Invalid checksum for Social Security Number.'),
     }
 
-    def __init__(self, min_length=11, max_length=11, *args, **kwargs):
+    def __init__(self, min_length=11, max_length=11, **kwargs):
         ssn_re = r'^\d{11}$'
         ssn_re = re.compile(ssn_re)
-        super().__init__(ssn_re, min_length=min_length, max_length=max_length, *args, **kwargs)
+        super().__init__(ssn_re, min_length=min_length, max_length=max_length, **kwargs)
 
     def clean(self, value):
         value = super().clean(value)

--- a/localflavor/no/forms.py
+++ b/localflavor/no/forms.py
@@ -22,8 +22,8 @@ class NOZipCodeField(RegexField):
         'invalid': _('Enter a zip code in the format XXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{4}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{4}$', **kwargs)
 
 
 class NOMunicipalitySelect(Select):

--- a/localflavor/nz/forms.py
+++ b/localflavor/nz/forms.py
@@ -49,8 +49,8 @@ class NZPostCodeField(RegexField):
         'invalid': _('Invalid post code.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{4}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{4}$', **kwargs)
 
 
 class NZBankAccountNumberField(Field):

--- a/localflavor/pk/forms.py
+++ b/localflavor/pk/forms.py
@@ -21,8 +21,8 @@ class PKPostCodeField(RegexField):
         'invalid': _('Enter a 5 digit postcode.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(POSTCODE_DIGITS_RE, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(POSTCODE_DIGITS_RE, **kwargs)
 
 
 class PKStateSelect(Select):

--- a/localflavor/pl/forms.py
+++ b/localflavor/pl/forms.py
@@ -45,8 +45,8 @@ class PLPESELField(RegexField):
         'birthdate': _('The National Identification Number contains an invalid birth date.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{11}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{11}$', **kwargs)
 
     def clean(self, value):
         value = super().clean(value)
@@ -102,8 +102,8 @@ class PLNationalIDCardNumberField(RegexField):
         'checksum': _('Wrong checksum for the National ID Card Number.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^[A-Za-z]{3}\d{6}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^[A-Za-z]{3}\d{6}$', **kwargs)
 
     def clean(self, value):
         value = super().clean(value)
@@ -152,10 +152,10 @@ class PLNIPField(RegexField):
         'checksum': _('Wrong checksum for the Tax Number (NIP).'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(
             r'^\d{3}-\d{3}-\d{2}-\d{2}$|^\d{3}-\d{2}-\d{2}-\d{3}$|^\d{10}$',
-            *args, **kwargs
+            **kwargs
         )
 
     def clean(self, value):
@@ -191,8 +191,8 @@ class PLREGONField(RegexField):
         'checksum': _('Wrong checksum for the National Business Register Number (REGON).'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{9,14}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{9,14}$', **kwargs)
 
     def clean(self, value):
         value = super().clean(value)
@@ -237,5 +237,5 @@ class PLPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XX-XXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{2}-\d{3}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{2}-\d{3}$', **kwargs)

--- a/localflavor/pt/forms.py
+++ b/localflavor/pt/forms.py
@@ -132,5 +132,5 @@ class PTZipCodeField(RegexField):
                      ' (where X is a digit between 1 and 9 and Y is any other digit).'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(ZIP_CODE_REGEX, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(ZIP_CODE_REGEX, **kwargs)

--- a/localflavor/ro/forms.py
+++ b/localflavor/ro/forms.py
@@ -19,10 +19,10 @@ class ROCIFField(RegexField):
         'invalid': _("Enter a valid CIF."),
     }
 
-    def __init__(self, max_length=10, min_length=2, *args, **kwargs):
+    def __init__(self, max_length=10, min_length=2, **kwargs):
         super().__init__(
             r'^(RO)?[0-9]{2,10}', max_length=max_length, min_length=min_length,
-            *args, **kwargs
+            **kwargs
         )
 
     def clean(self, value):
@@ -72,10 +72,10 @@ class ROCNPField(RegexField):
         'invalid': _("Enter a valid CNP."),
     }
 
-    def __init__(self, max_length=13, min_length=13, *args, **kwargs):
+    def __init__(self, max_length=13, min_length=13, **kwargs):
         super().__init__(
             r'^[1-9][0-9]{12}', max_length=max_length, min_length=min_length,
-            *args, **kwargs
+            **kwargs
         )
 
     def clean(self, value):
@@ -179,8 +179,8 @@ class ROPostalCodeField(RegexField):
         'invalid': _('Enter a valid postal code in the format XXXXXX'),
     }
 
-    def __init__(self, max_length=6, min_length=6, *args, **kwargs):
+    def __init__(self, max_length=6, min_length=6, **kwargs):
         super().__init__(
             r'^[0-9][0-8][0-9]{4}$', max_length=max_length,
-            min_length=min_length, *args, **kwargs
+            min_length=min_length, **kwargs
         )

--- a/localflavor/ru/forms.py
+++ b/localflavor/ru/forms.py
@@ -30,8 +30,8 @@ class RUPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XXXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{6}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{6}$', **kwargs)
 
 
 class RUPassportNumberField(RegexField):
@@ -45,8 +45,8 @@ class RUPassportNumberField(RegexField):
         'invalid': _('Enter a passport number in the format XXXX XXXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{4} \d{6}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{4} \d{6}$', **kwargs)
 
 
 class RUAlienPassportNumberField(RegexField):
@@ -60,5 +60,5 @@ class RUAlienPassportNumberField(RegexField):
         'invalid': _('Enter a passport number in the format XX XXXXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{2} \d{7}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{2} \d{7}$', **kwargs)

--- a/localflavor/se/forms.py
+++ b/localflavor/se/forms.py
@@ -167,8 +167,8 @@ class SEPostalCodeField(forms.RegexField):
         'invalid': _('Enter a Swedish postal code in the format XXXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(SE_POSTAL_CODE, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(SE_POSTAL_CODE, **kwargs)
 
     def clean(self, value):
         value = super().clean(value)

--- a/localflavor/sg/forms.py
+++ b/localflavor/sg/forms.py
@@ -24,8 +24,8 @@ class SGPostCodeField(RegexField):
         'invalid': _('Enter a 6-digit postal code.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{6}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{6}$', **kwargs)
 
 
 class SGNRICFINField(CharField):

--- a/localflavor/sk/forms.py
+++ b/localflavor/sk/forms.py
@@ -32,8 +32,8 @@ class SKPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XXXXX or XXX XX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{5}$|^\d{3} \d{2}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{5}$|^\d{3} \d{2}$', **kwargs)
 
     def clean(self, value):
         """

--- a/localflavor/tr/forms.py
+++ b/localflavor/tr/forms.py
@@ -19,10 +19,10 @@ class TRPostalCodeField(RegexField):
         'invalid': _('Enter a postal code in the format XXXXX.'),
     }
 
-    def __init__(self, max_length=5, min_length=5, *args, **kwargs):
+    def __init__(self, max_length=5, min_length=5, **kwargs):
         super().__init__(
             r'^\d{5}$', max_length=max_length, min_length=min_length,
-            *args, **kwargs
+            **kwargs
         )
 
     def clean(self, value):

--- a/localflavor/ua/forms.py
+++ b/localflavor/ua/forms.py
@@ -31,9 +31,9 @@ class UAVatNumberField(RegexField):
         'invalid': _('Enter a valid VAT number.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         kwargs['max_length'] = kwargs['min_length'] = 10
-        super().__init__(r'^\d{10}$', *args, **kwargs)
+        super().__init__(r'^\d{10}$', **kwargs)
 
     def to_python(self, value):
         value = super().to_python(value)
@@ -57,9 +57,9 @@ class UAPostalCodeField(RegexField):
         'invalid': _('Enter a valid postal code.'),
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         kwargs['max_length'] = kwargs['min_length'] = 5
-        super().__init__(r'^(?!00)\d{5}$', *args, **kwargs)
+        super().__init__(r'^(?!00)\d{5}$', **kwargs)
 
     def to_python(self, value):
         value = super().to_python(value)

--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -30,8 +30,8 @@ class USZipCodeField(RegexField):
         'invalid': _('Enter a zip code in the format XXXXX or XXXXX-XXXX.'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{5}(?:-\d{4})?$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{5}(?:-\d{4})?$', **kwargs)
 
     def to_python(self, value):
         value = super().to_python(value)

--- a/localflavor/uy/forms.py
+++ b/localflavor/uy/forms.py
@@ -24,8 +24,8 @@ class UYCIField(RegexField):
         'invalid_validation_digit': _("Enter a valid CI number."),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'(?P<num>(\d{6,7}|(\d\.)?\d{3}\.\d{3}))-?(?P<val>\d)', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'(?P<num>(\d{6,7}|(\d\.)?\d{3}\.\d{3}))-?(?P<val>\d)', **kwargs)
 
     def clean(self, value):
         """

--- a/localflavor/za/forms.py
+++ b/localflavor/za/forms.py
@@ -63,8 +63,8 @@ class ZAPostCodeField(RegexField):
         'invalid': _('Enter a valid South African postal code'),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'^\d{4}$', *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(r'^\d{4}$', **kwargs)
 
 
 class ZAProvinceSelect(Select):


### PR DESCRIPTION
Using positional arguments with fields that inherit from Django's `forms.RegexField` previously only worked with Django 1.11 but were ignored with Django >= 2.0. This PR removes positional arguments from all fields that inherit from Django's `forms.RegexField`. Any options needed on the parent `forms.RegexField`, `forms.CharField` or `forms.Field` must now be set with keyword arguments.
