### PR TITLE
docs: Fix simple typo, validty -> validity

### DIFF
--- a/localflavor/kw/forms.py
+++ b/localflavor/kw/forms.py
@@ -36,7 +36,7 @@ class KWCivilIDNumberField(RegexField):
     """
     Kuwaiti Civil ID numbers are 12 digits, second to seventh digits represents the person's birthdate.
 
-    Checks the following rules to determine the validty of the number:
+    Checks the following rules to determine the validity of the number:
         * The number consist of 12 digits.
         * The birthdate of the person is a valid date.
         * The calculated checksum equals to the last digit of the Civil ID.


### PR DESCRIPTION
There is a small typo in localflavor/kw/forms.py.

Should read `validity` rather than `validty`.

