### PR TITLE
Fix French national identification number validation with people born overseas

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ New fields for existing flavors:
 
 Modifications to existing flavors:
 
-- None
+- Fix `FRNationalIdentificationNumber` validation for people born overseas
 
 Other changes:
 

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -143,10 +143,6 @@ class FRNationalIdentificationNumber(CharField):
             raise ValidationError(self.error_messages['invalid'])
 
     def _clean_department_and_commune(self, commune_of_origin, current_year, department_of_origin, year_of_birth):
-        # Department number 98 is for Monaco
-        if department_of_origin == '98':
-            raise ValidationError(self.error_messages['invalid'])
-
         # Departments number 20, 2A and 2B represent Corsica
         if department_of_origin in ['20', '2A', '2B']:
             # For people born before 1976, Corsica number was 20
@@ -156,14 +152,23 @@ class FRNationalIdentificationNumber(CharField):
             if (int(year_of_birth) > 75 and department_of_origin not in ['2A', '2B']):
                 raise ValidationError(self.error_messages['invalid'])
 
-        # Overseas department numbers starts with 97 and are 3 digits long
+        # Overseas department numbers starts with 97 or 98 and are 3 digits long
         if department_of_origin == '97':
             department_of_origin += commune_of_origin[:1]
-            if int(department_of_origin) not in range(971, 976):
+            if int(department_of_origin) not in range(971, 978):
                 raise ValidationError(self.error_messages['invalid'])
             commune_of_origin = commune_of_origin[1:]
             if int(commune_of_origin) < 1 or int(commune_of_origin) > 90:
                 raise ValidationError(self.error_messages['invalid'])
+        if department_of_origin == '98':
+            department_of_origin += commune_of_origin[:1]
+            if int(department_of_origin) not in range(984, 989):
+                raise ValidationError(self.error_messages['invalid'])
+            commune_of_origin = commune_of_origin[1:]
+            if int(commune_of_origin) < 1 or int(commune_of_origin) > 90:
+                raise ValidationError(self.error_messages['invalid'])
+        # Last case is for '99' as department_of_origin, eg. people born in a foreign country
+        # In this case, commune_of_origin is the INSEE country code, must be [001-990]
         elif int(commune_of_origin) < 1 or int(commune_of_origin) > 990:
             raise ValidationError(self.error_messages['invalid'])
         return commune_of_origin, department_of_origin

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -94,6 +94,10 @@ class FRNationalIdentificationNumber(CharField):
 
     Validation of the Number, and checksum calculation is detailed at http://en.wikipedia.org/wiki/INSEE_code
 
+    Complete spec of the codification is detailed here:
+      - https://fr.scribd.com/document/456848429/INSEE-Guide-Identification
+      - https://fr.scribd.com/document/456848431/INSEE-Codes-Pays
+
     .. versionadded:: 1.1
     """
 

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -218,6 +218,7 @@ class FRLocalFlavorTests(SimpleTestCase):
             '869067543002289': '869067543002289',
             # Good Overseas
             '869069713002256': '869069713002256',
+            '869069854002248': '869069854002248',
             # Good, old Corsica department number (20) with birthdate < 1976
             '870062009002285': '870062009002285',
             # Good, new Corsica department number (2A) with birthdate >= 1976
@@ -228,6 +229,8 @@ class FRLocalFlavorTests(SimpleTestCase):
             '105062B09002231': '105062B09002231',
             # Good, new Corsica department number (20) with birthdate < 1976 (1905)
             '105062009002231': '105062009002231',
+            # Good foreign
+            '869069913802253': '869069913802253',
             # Good, birth month not known (then, can be 20, [30-42] or [50-99])
             '140200109002223': '140200109002223',
             '141330109002285': '141330109002285',
@@ -249,6 +252,9 @@ class FRLocalFlavorTests(SimpleTestCase):
             '869069773002289': error_format,
             # Good overseas Bad Commune
             '869069710002256': error_format,
+            '869069813002229': error_format,
+            # Bad foreign country code
+            '869069999102271': error_format,
             # Bad Commune
             '869067500002289': error_format,
             # Bad "Person Unique Number"


### PR DESCRIPTION
I realized that localflavor does not allow the entry of NIR with `98` as the birth department, excluding it because `98` would correspond to Monaco.

In fact, `98` is used for "COM" (eg. French Polynesia, Wallis and Futuna, New Caledonia) and people born in Monaco would have `99` as `department_of_origin` and `138` as `commune_of_origin` (`99` stands for a birth abroad and `138` is the INSEE code for Monaco).

This codification is a real mess, I've attached two official INSEE documents, which are more complete and reliable sources than Wikipedia (page 6 is a good summary).

This fix add the following changes:
- Remove "Monaco's" invalidation
- Increase DOM dept range (`[971-976]` -> `[971-978]`)
- Support COM numbers (dept range within `[984-989]`)
- Add info for foreign cases (dept is `99`)
- Add according tests

---

[INSEE Guide identification.pdf](https://github.com/django/django-localflavor/files/4477931/INSEE.Guide.identification.pdf)
[INSEE Codes Pays.pdf](https://github.com/django/django-localflavor/files/4477930/INSEE.Codes.Pays.pdf)
