### PR TITLE
BICValidator: Validate location code

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,7 @@ Modifications to existing flavors:
 
 Other changes:
 
-- None
+- Extended validation of BICs to match official SEPA regulations
 
 
 3.0   (2020-02-19)

--- a/localflavor/generic/validators.py
+++ b/localflavor/generic/validators.py
@@ -244,6 +244,11 @@ class BICValidator:
         if country_code not in ISO_3166_1_ALPHA2_COUNTRY_CODES:
             raise ValidationError(_('%s is not a valid country code.') % country_code)
 
+        # Letters 7 and 8 are a "location" code. As per ISO20022 Payments
+        # Maintenance 2009 document, they may only be from the charset [A-Z2-9][A-NP-Z0-9]
+        if '1' in value[6] or 'O' in value[7]:
+            raise ValidationError(_('%s is not a valid location code.') % value[6:8])
+
 
 @deconstructible
 class EANValidator:

--- a/localflavor/generic/validators.py
+++ b/localflavor/generic/validators.py
@@ -246,7 +246,7 @@ class BICValidator:
 
         # Letters 7 and 8 are a "location" code. As per ISO20022 Payments
         # Maintenance 2009 document, they may only be from the charset [A-Z2-9][A-NP-Z0-9]
-        if '1' in value[6] or 'O' in value[7]:
+        if '1' == value[6] or 'O' == value[7]:
             raise ValidationError(_('%s is not a valid location code.') % value[6:8])
 
 

--- a/tests/test_generic/tests.py
+++ b/tests/test_generic/tests.py
@@ -322,6 +322,7 @@ class BICTests(TestCase):
             '': 'BIC codes have either 8 or 11 characters.',
             'CIBCJJH2': 'JJ is not a valid country code.',
             'D3UTDEFF': 'is not a valid institution code.',
+            'DAAEDEDOXXX': 'is not a valid location code.',
             'DÉUTDEFF': 'codes only contain alphabet letters and digits.',
             'NEDSZAJJ XX': 'codes only contain alphabet letters and digits.',
         }


### PR DESCRIPTION
We are still seing some (syntactically) invalid BICs in the wild. These are an annoyance, since banks and banking software validates BICs against the official standards and if we allow BICs that aren't allowed by the standard, we'll run into problems even loading the files in banking software.

The official regex in use in the XML schemas is ``[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}``.
Currently, we do restrict to the same regex, except for the disallowance of ``1`` at position 7 and ``O`` at position 8. This PR adds these restrictions.

Sources

- https://www.credit-suisse.com/media/assets/microsite/docs/zv-migration/pain-001-001-03-six.pdf
- https://wiki.xmldation.com/Support/ISO20022/General_Rules/BIC
- The ``pain.008.03.02.xsd`` schema file (and others)

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.