### PR TITLE
Add r to regexes to remove deprecation warnings

### DIFF
--- a/localflavor/au/validators.py
+++ b/localflavor/au/validators.py
@@ -13,7 +13,7 @@ class AUBusinessNumberFieldValidator(RegexValidator):
     error_message = _('Enter a valid ABN.')
 
     def __init__(self):
-        eleven_digits = '^\d{11}$'
+        eleven_digits = r'^\d{11}$'
         super().__init__(regex=eleven_digits, message=self.error_message)
 
     def _is_valid(self, value):
@@ -57,7 +57,7 @@ class AUCompanyNumberFieldValidator(RegexValidator):
     error_message = _('Enter a valid ACN.')
 
     def __init__(self):
-        nine_digits = '^\d{9}$'
+        nine_digits = r'^\d{9}$'
         super().__init__(regex=nine_digits, message=self.error_message)
 
     def _is_valid(self, value):
@@ -101,7 +101,7 @@ class AUTaxFileNumberFieldValidator(RegexValidator):
 
     def __init__(self):
         """Regex for 8 to 9 digits."""
-        super().__init__(regex='^\d{8,9}$', message=self.error_message)
+        super().__init__(regex=r'^\d{8,9}$', message=self.error_message)
 
     def _is_valid(self, value):
         """

--- a/localflavor/md/validators.py
+++ b/localflavor/md/validators.py
@@ -16,7 +16,7 @@ class MDIDNOFieldValidator(RegexValidator):
     """
 
     error_message = _('Enter a valid IDNO number.')
-    regex = '^\d{13}$'
+    regex = r'^\d{13}$'
     message = error_message
 
 
@@ -29,7 +29,7 @@ class MDLicensePlateValidator(RegexValidator):
     """
 
     error_message = _('Enter a valid license plate.')
-    regex = '^\d{13}$'
+    regex = r'^\d{13}$'
     message = error_message
 
     def __call__(self, value):
@@ -52,44 +52,44 @@ class MDLicensePlateValidator(RegexValidator):
     @staticmethod
     def _is_old_format(value):
         regions = "|".join([code for code, desc in REGION_CHOICES_2002_2015])
-        pattern = '({regions}) [A-Z]{{2}} \d{{1,3}}'.format(regions=regions)
+        pattern = r'({regions}) [A-Z]{{2}} \d{{1,3}}'.format(regions=regions)
         return re.match(pattern, value) is not None
 
     @staticmethod
     def _is_new_format(value):
         if not any(x in value for x, y in LICENSE_PLATE_POLICE):
-            pattern = '^[A-Z]{3} \d{1,3}$'
+            pattern = r'^[A-Z]{3} \d{1,3}$'
             return re.match(pattern, value) is not None
 
     @staticmethod
     def _is_gov_format(value):
         types = "|".join([code for code, desc in LICENSE_PLATE_GOVERNMENT_TYPE])
-        pattern = '^RM ({types}) \d{{3}}$'.format(types=types)
+        pattern = r'^RM ({types}) \d{{3}}$'.format(types=types)
         return re.match(pattern, value) is not None
 
     @staticmethod
     def _is_diplomatic_format(value):
         types = "|".join([code for code, desc in LICENSE_PLATE_DIPLOMATIC])
-        pattern = '^({types}) \d{{3}} A{{1,2}}$'.format(types=types)
+        pattern = r'^({types}) \d{{3}} A{{1,2}}$'.format(types=types)
         return re.match(pattern, value) is not None
 
     @staticmethod
     def _is_police_format(value):
         types = "|".join([code for code, desc in LICENSE_PLATE_POLICE])
-        gov_format = '^({types}) \d{{4}}$'.format(types=types)
+        gov_format = r'^({types}) \d{{4}}$'.format(types=types)
         return re.match(gov_format, value) is not None
 
     @staticmethod
     def _is_president_format(value):
-        pattern = '^RM \d{4}$'
+        pattern = r'^RM \d{4}$'
         return re.match(pattern, value) is not None
 
     @staticmethod
     def _is_state_security_format(value):
-        pattern = '^SP \d{3}$'
+        pattern = r'^SP \d{3}$'
         return re.match(pattern, value) is not None
 
     @staticmethod
     def _is_foreign_format(value):
-        pattern = '^H \d{4}$'
+        pattern = r'^H \d{4}$'
         return re.match(pattern, value) is not None

--- a/localflavor/nl/validators.py
+++ b/localflavor/nl/validators.py
@@ -13,7 +13,7 @@ class NLZipCodeFieldValidator(RegexValidator):
     error_message = _('Enter a valid zip code.')
 
     def __init__(self):
-        super().__init__(regex='^\d{4} ?[A-Z]{2}$', message=self.error_message)
+        super().__init__(regex=r'^\d{4} ?[A-Z]{2}$', message=self.error_message)
 
     def __call__(self, value):
         super().__call__(value)
@@ -32,7 +32,7 @@ class NLBSNFieldValidator(RegexValidator):
     error_message = _('Enter a valid BSN.')
 
     def __init__(self):
-        super().__init__(regex='^\d{9}$', message=self.error_message)
+        super().__init__(regex=r'^\d{9}$', message=self.error_message)
 
     def bsn_checksum_ok(self, value):
         checksum = 0

--- a/localflavor/si/forms.py
+++ b/localflavor/si/forms.py
@@ -22,7 +22,7 @@ class SIEMSOField(CharField):
         'date': _('The first 7 digits of the EMSO must represent a valid past date.'),
         'checksum': _('The EMSO is not valid.'),
     }
-    emso_regex = re.compile('^(\d{2})(\d{2})(\d{3})(\d{2})(\d{3})(\d)$')
+    emso_regex = re.compile(r'^(\d{2})(\d{2})(\d{3})(\d{2})(\d{3})(\d)$')
 
     def clean(self, value):
         value = super().clean(value)
@@ -87,7 +87,7 @@ class SITaxNumberField(CharField):
     default_error_messages = {
         'invalid': _('Enter a valid tax number in form SIXXXXXXXX'),
     }
-    sitax_regex = re.compile('^(?:SI)?([1-9]\d{7})$')
+    sitax_regex = re.compile(r'^(?:SI)?([1-9]\d{7})$')
 
     def clean(self, value):
         value = super().clean(value)


### PR DESCRIPTION
This PR removes these deprecation warnings when running the tests with python -Wd:
```
django-localflavor/localflavor/au/validators.py:16: DeprecationWarning: invalid escape sequence \d
  eleven_digits = '^\d{11}$'
django-localflavor/localflavor/au/validators.py:60: DeprecationWarning: invalid escape sequence \d
  nine_digits = '^\d{9}$'
django-localflavor/localflavor/au/validators.py:104: DeprecationWarning: invalid escape sequence \d
  super().__init__(regex='^\d{8,9}$', message=self.error_message)
django-localflavor/localflavor/md/validators.py:19: DeprecationWarning: invalid escape sequence \d
  regex = '^\d{13}$'
django-localflavor/localflavor/md/validators.py:32: DeprecationWarning: invalid escape sequence \d
  regex = '^\d{13}$'
django-localflavor/localflavor/md/validators.py:55: DeprecationWarning: invalid escape sequence \d
  pattern = '({regions}) [A-Z]{{2}} \d{{1,3}}'.format(regions=regions)
django-localflavor/localflavor/md/validators.py:61: DeprecationWarning: invalid escape sequence \d
  pattern = '^[A-Z]{3} \d{1,3}$'
django-localflavor/localflavor/md/validators.py:67: DeprecationWarning: invalid escape sequence \d
  pattern = '^RM ({types}) \d{{3}}$'.format(types=types)
django-localflavor/localflavor/md/validators.py:73: DeprecationWarning: invalid escape sequence \d
  pattern = '^({types}) \d{{3}} A{{1,2}}$'.format(types=types)
django-localflavor/localflavor/md/validators.py:79: DeprecationWarning: invalid escape sequence \d
  gov_format = '^({types}) \d{{4}}$'.format(types=types)
django-localflavor/localflavor/md/validators.py:84: DeprecationWarning: invalid escape sequence \d
  pattern = '^RM \d{4}$'
django-localflavor/localflavor/md/validators.py:89: DeprecationWarning: invalid escape sequence \d
  pattern = '^SP \d{3}$'
django-localflavor/localflavor/md/validators.py:94: DeprecationWarning: invalid escape sequence \d
  pattern = '^H \d{4}$'
django-localflavor/localflavor/nl/validators.py:16: DeprecationWarning: invalid escape sequence \d
  super().__init__(regex='^\d{4} ?[A-Z]{2}$', message=self.error_message)
django-localflavor/localflavor/nl/validators.py:35: DeprecationWarning: invalid escape sequence \d
  super().__init__(regex='^\d{9}$', message=self.error_message)
django-localflavor/localflavor/si/forms.py:25: DeprecationWarning: invalid escape sequence \d
  emso_regex = re.compile('^(\d{2})(\d{2})(\d{3})(\d{2})(\d{3})(\d)$')
django-localflavor/localflavor/si/forms.py:90: DeprecationWarning: invalid escape sequence \d
  sitax_regex = re.compile('^(?:SI)?([1-9]\d{7})$')
```