### PR TITLE
Add FRRNAField

### DIFF
--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -253,3 +253,26 @@ class FRSIRETField(FRSIRENENumberMixin, CharField):
             return value
         value = value.replace(' ', '').replace('-', '')
         return ' '.join((value[:3], value[3:6], value[6:9], value[9:]))
+
+class FRRNAField(CharField):
+    """
+    RNA Stands for "Répertoire National des Associations"
+
+    It's under the authority of the French Minister of the Interior.
+    See https://fr.wikipedia.org/wiki/R%C3%A9pertoire_national_des_associations for more information.
+    """
+    default_error_messages = {
+        'invalid': _('Enter a valid French RNA number.'),
+    }
+
+    def clean(self, value):
+        value = super().clean(value)
+
+        if value in self.empty_values:
+            return self.empty_value
+
+        value = value.replace(' ', '').replace('-', '').replace('.', '')
+
+        if not re.compile(r'^W\d{9}$').match(value):
+            raise ValidationError(self.error_messages['invalid'], code=['invalid'])
+        return value

--- a/localflavor/fr/models.py
+++ b/localflavor/fr/models.py
@@ -40,3 +40,21 @@ class FRSIRETField(CharField):
         defaults = {'form_class': forms.FRSIRETField}
         defaults.update(kwargs)
         return super().formfield(**defaults)
+
+
+class FRRNAField(CharField):
+    """
+    A :class:`~django.db.models.CharField` that checks that the value is a valid French RNA number.
+    """
+
+    description = _("RNA Number")
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 10
+        super().__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        from . import forms
+        defaults = {'form_class': forms.FRRNAField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -2,7 +2,7 @@ from django.test import SimpleTestCase
 
 from localflavor.fr.forms import (FRDepartmentField, FRDepartmentSelect, FRNationalIdentificationNumber,
                                   FRRegion2016Select, FRRegionField, FRRegionSelect, FRSIRENField, FRSIRETField,
-                                  FRZipCodeField)
+                                  FRZipCodeField, FRRNAField)
 
 
 DEP_SELECT_OUTPUT = '''
@@ -314,3 +314,17 @@ class FRLocalFlavorTests(SimpleTestCase):
         self.assertIsNone(siret_form_field.prepare_value(None))
         self.assertEqual(
             siret_form_field.clean('752 932 715 00010'), '75293271500010')
+
+    def test_FRRNANumber(self):
+        error_format = ['Enter a valid French RNA number.']
+        valid = {
+            'W442010167': 'W442010167',
+            'W-442010167': 'W442010167',
+            'W 442010167': 'W442010167',
+        }
+        invalid = {
+            '442010167': error_format,          # W Letter missing
+            'W4420101671': error_format,        # Too many numbers
+            '5142010167': error_format,         # W Letter missing and too many numbers
+        }
+        self.assertFieldOutput(FRRNAField, valid, invalid)


### PR DESCRIPTION
Added FRRNAField to allow the use of RNA French Association Identification Number.
More information on https://fr.wikipedia.org/wiki/R%C3%A9pertoire_national_des_associations or https://www.associations.gouv.fr/le-rna-repertoire-national-des-associations.html

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

**New Fields Only**

- [x] Prefix the country code to all fields.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [x] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [ ] Add documentation for all fields.
