### PR TITLE
fix error code on BRPostalCodeValidator

### DIFF
--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -18,16 +18,12 @@ process_digits_re = re.compile(
 
 class BRZipCodeField(CharField):
     """
-    A form field that validates input as a Brazilian zip code, with the format XXXXX-XXX.
+    A form field that validates input as a Brazilian zip code, with the format 00000-000.
 
     .. versionchanged:: 2.2
         Use BRPostalCodeValidator to centralize validation logic and share with equivalent model field.
         More details at: https://github.com/django/django-localflavor/issues/334
     """
-
-    default_error_messages = {
-        'invalid': _('Enter a zip code in the format XXXXX-XXX.'),
-    }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/localflavor/br/validators.py
+++ b/localflavor/br/validators.py
@@ -24,7 +24,6 @@ class BRPostalCodeValidator(RegexValidator):
 
     def __init__(self, *args, **kwargs):
         self.message = _('Enter a postal code in the format 00000-000.')
-        self.code = _('Invalid Postal Code')
         super().__init__(postal_code_re, *args, **kwargs)
 
 


### PR DESCRIPTION
**Changes:**

The `BRPostalCodeValidator` was using `_('Invalid Postal Code')` as an error code. But error codes should be in snakecase and not translatable.
With this change the error code used is the default one (`invalid`).

---

**Please replace these instructions with a description of your change. The
'New Fields Only' section should be removed if your pull request
doesn't add any new fields.**

Thanks for your contribution!

A checklist is included below which helps us keep the code contributions
consistent and helps speed up the review process. You can add additional
commits to your pull request if you haven't met all of these points on your
first version.

**All Changes**

- [ ] Add an entry to the docs/changelog.rst describing the change.

- [ ] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

---
Questions:

* Shouldn't `BRZipCodeField` be renamed to `BRPostalCodeField` to be more consistent? (`BRZipCodeField` is the only BR field that has `Zip` in it, all other use `Postal`)
* Should I delete the translations that my change makes unnecessary?
