### PR TITLE
fFx mx curp field

### DIFF
--- a/localflavor/mx/forms.py
+++ b/localflavor/mx/forms.py
@@ -237,7 +237,7 @@ class MXCURPField(RegexField):
         states_re = r'(AS|BC|BS|CC|CL|CM|CS|CH|DF|DG|GT|GR|HG|JC|MC|MN|' \
                     r'MS|NT|NL|OC|PL|QT|QR|SP|SL|SR|TC|TS|TL|VZ|YN|ZS|NE)'
         consonants_re = r'[B-DF-HJ-NP-TV-Z]'
-        curp_re = (r'^[A-Z][AEIOU][A-Z]{2}%s[HM]%s%s{3}[0-9A-Z]\d$' %
+        curp_re = (r'^[A-Z][AEIOUX][A-Z]{2}%s[HM]%s%s{3}[0-9A-Z]\d$' %
                    (DATE_RE, states_re, consonants_re))
         curp_re = re.compile(curp_re, re.IGNORECASE)
         super().__init__(curp_re, min_length=min_length, max_length=max_length, **kwargs)


### PR DESCRIPTION
Correct regex to validate MX CURP is:

```
curp_re = (r'^[A-Z][AEIOUX][A-Z]{2}%s[HM]%s%s{3}[0-9A-Z]\d$' %
                   (DATE_RE, states_re, consonants_re))
```

It needs an X because the second character is the first vowel of the first last name(surname), in the case that there is no vowel, CURP comes with an X, e.g: For example mayan last name ['OY'()](https://www.mayas.uady.mx/articulos/patronimicos.html#:~:text=Oy%20(oy)%20En%20palabras%20compuestas,Temor.) second char is a consonant, not vowel, so the the beginning of the curp it's OX and it's not valid with actual regex.