### PR TITLE
Add support of Canadian models fields.

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -39,6 +39,7 @@ Authors
 * Diederik van der Boor
 * d.merc
 * Dmitry Dygalo
+* Dominick Rivard
 * Douglas Miranda
 * Elliott Fawcett
 * Erik Romijn

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ New fields for existing flavors:
 
 - Added permanent account number(PAN) field in Indian flavor.
   (`gh-457 <https://github.com/django/django-localflavor/pull/457>`_).
+- Added the Canadian Models fields.
+  (`gh-465 <https://github.com/django/django-localflavor/pull/465>`_).
 
 Modifications to existing flavors:
 

--- a/docs/localflavor/ca.rst
+++ b/docs/localflavor/ca.rst
@@ -7,6 +7,12 @@ Forms
 .. automodule:: localflavor.ca.forms
     :members:
 
+Models
+------
+
+.. automodule:: localflavor.ca.models
+    :members:
+
 Data
 ----
 

--- a/localflavor/ca/models.py
+++ b/localflavor/ca/models.py
@@ -11,6 +11,8 @@ class CAProvinceField(CharField):
     A model field that stores the two-letter Canadian province abbreviation in the database.
 
     Forms represent it as a ``forms.CAProvinceField`` field.
+
+    .. versionadded:: 4.0
     """
 
     description = _("Canadian Province (two uppercase letters)")
@@ -31,6 +33,8 @@ class CAPostalCodeField(CharField):
     A model field that stores the Canadian Postal code in the database.
 
     Forms represent it as a :class:`~localflavor.ca.forms.CAPostalCodeField` field.
+
+    .. versionadded:: 4.0
     """
 
     description = _("Canadian Postal Code")
@@ -50,6 +54,8 @@ class CASocialInsuranceNumberField(CharField):
     A model field that stores  the security number in the format ``XXX-XXX-XXX``.
 
     Forms represent it as ``forms.CASocialInsuranceNumberField`` field.
+
+    .. versionadded:: 4.0
     """
 
     description = _("Social security number")

--- a/localflavor/ca/models.py
+++ b/localflavor/ca/models.py
@@ -1,0 +1,64 @@
+from django.db.models import CharField
+from django.utils.translation import gettext_lazy as _
+
+from .forms import CASocialInsuranceNumberField as CASocialInsuranceNumberFormField
+from .forms import CAPostalCodeField as CAPostalCodeFormField
+from .ca_provinces import PROVINCE_CHOICES
+
+
+class CAProvinceField(CharField):
+    """
+    A model field that stores the two-letter Canadian province abbreviation in the database.
+
+    Forms represent it as a ``forms.CAProvinceField`` field.
+    """
+
+    description = _("Canadian Province (two uppercase letters)")
+
+    def __init__(self, *args, **kwargs):
+        kwargs['choices'] = PROVINCE_CHOICES
+        kwargs['max_length'] = 2
+        super().__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        del kwargs['choices']
+        return name, path, args, kwargs
+
+
+class CAPostalCodeField(CharField):
+    """
+    A model field that stores the Canadian Postal code in the database.
+
+    Forms represent it as a :class:`~localflavor.ca.forms.CAPostalCodeField` field.
+    """
+
+    description = _("Canadian Postal Code")
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 7
+        super().__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': CAPostalCodeFormField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
+
+
+class CASocialInsuranceNumberField(CharField):
+    """
+    A model field that stores  the security number in the format ``XXX-XXX-XXX``.
+
+    Forms represent it as ``forms.CASocialInsuranceNumberField`` field.
+    """
+
+    description = _("Social security number")
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 11
+        super().__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': CASocialInsuranceNumberFormField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = [
     'tests.test_cu',
     'tests.test_gh',
     'tests.test_np',
+    'tests.test_ca',
     'tests.test_generic',
 ]
 

--- a/tests/test_ca/forms.py
+++ b/tests/test_ca/forms.py
@@ -1,0 +1,10 @@
+from django.forms import ModelForm
+
+from .models import CAPlace
+
+
+class CAPlaceForm(ModelForm):
+
+    class Meta:
+        model = CAPlace
+        fields = '__all__'

--- a/tests/test_ca/models.py
+++ b/tests/test_ca/models.py
@@ -1,0 +1,12 @@
+from django.db import models
+
+from localflavor.ca.models import CAPostalCodeField, CAProvinceField, CASocialInsuranceNumberField
+
+
+class CAPlace(models.Model):
+    province = CAProvinceField(blank=True)
+    province_req = CAProvinceField()
+    province_default = CAProvinceField(default="AB", blank=True)
+    postal_code = CAPostalCodeField()
+    name = models.CharField(max_length=20)
+    ssn = CASocialInsuranceNumberField(blank=True)

--- a/tests/test_ca/tests.py
+++ b/tests/test_ca/tests.py
@@ -14,7 +14,6 @@ class CALocalFlavorTests(TestCase):
         self.form = CAPlaceForm({
             'province': 'QC',
             'province_req': 'ON',
-            'province_default': 'AB',
             'postal_code': 'H0H 0H0',
             'name': 'impossible',
             'ssn': '046-454-286'

--- a/tests/test_ca/tests.py
+++ b/tests/test_ca/tests.py
@@ -1,16 +1,34 @@
-from django.test.testcases import SimpleTestCase
+from django.test import TestCase
 from django.utils.translation import activate, deactivate, get_language
 
 from localflavor.ca.forms import CAPostalCodeField, CAProvinceField, CAProvinceSelect, CASocialInsuranceNumberField
 
+from .forms import CAPlaceForm
 
-class CALocalFlavorTests(SimpleTestCase):
+
+class CALocalFlavorTests(TestCase):
+
     def setUp(self):
         self.original_language = get_language()
         deactivate()
+        self.form = CAPlaceForm({
+            'province': 'QC',
+            'province_req': 'ON',
+            'province_default': 'AB',
+            'postal_code': 'H0H 0H0',
+            'name': 'impossible',
+            'ssn': '046-454-286'
+        })
 
     def tearDown(self):
         activate(self.original_language)
+
+    def test_get_display_methods(self):
+        """Test that the get_*_display() methods are added to the model instances."""
+        place = self.form.save()
+        self.assertEqual(place.get_province_display(), 'Quebec')
+        self.assertEqual(place.get_province_req_display(), 'Ontario')
+        self.assertEqual(place.get_province_default_display(), 'Alberta')
 
     def test_CAProvinceSelect(self):
         f = CAProvinceSelect()


### PR DESCRIPTION
**Please replace these instructions with a description of your change. The
'New Fields Only' section should be removed if your pull request
doesn't add any new fields.**

Thanks for your contribution!

A checklist is included below which helps us keep the code contributions
consistent and helps speed up the review process. You can add additional
commits to your pull request if you haven't met all of these points on your
first version.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

**New Fields Only**

- [x] Prefix the country code to all fields.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [x] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [x] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [x] Add documentation for all fields.
