### PR TITLE
Removed curp inconvenient word from mx flavor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -69,6 +69,7 @@ Modifications to existing flavors:
   - `ro.forms.ROCountyField`
   - `tr.forms.TRIdentificationNumberField`
   - `us.forms.USStateField`
+- Removed inconvenient word from CURP_INCONVENIENT_WORDS for MX flavor
 
 Other changes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -69,7 +69,7 @@ Modifications to existing flavors:
   - `ro.forms.ROCountyField`
   - `tr.forms.TRIdentificationNumberField`
   - `us.forms.USStateField`
-- Removed inconvenient word from CURP_INCONVENIENT_WORDS for MX flavor
+- Removed inconvenient word VACA from CURP_INCONVENIENT_WORDS for MX flavor
 
 Other changes:
 

--- a/localflavor/mx/forms.py
+++ b/localflavor/mx/forms.py
@@ -35,8 +35,7 @@ CURP_INCONVENIENT_WORDS = [
     'MEON', 'MIAR', 'MION', 'MOCO', 'MOKO', 'MULA', 'MULO', 'NACA',
     'NACO', 'PEDA', 'PEDO', 'PENE', 'PIPI', 'PITO', 'POPO', 'PUTA',
     'PUTO', 'QULO', 'RATA', 'ROBA', 'ROBE', 'ROBO', 'RUIN', 'SENO',
-    'TETA', 'VACA', 'VAGA', 'VAGO', 'VAKA', 'VUEI', 'VUEY', 'WUEI',
-    'WUEY',
+    'TETA', 'VAGA', 'VAGO', 'VAKA', 'VUEI', 'VUEY', 'WUEI', 'WUEY',
 ]
 
 

--- a/tests/test_mx/tests.py
+++ b/tests/test_mx/tests.py
@@ -195,6 +195,7 @@ class MXLocalFlavorTests(TestCase):
             'OOMG890727HMNRSR06': 'OOMG890727HMNRSR06',
             'AAAA000101HDFCCC09': 'AAAA000101HDFCCC09',
             'OXCJ810522MQRYHL08': 'OXCJ810522MQRYHL08',
+            'VACA711211HYNRMN02': 'VACA711211HYNRMN02',
         }
         invalid = {
             'AAAA000000HDFCCC09': error_format,


### PR DESCRIPTION
Removed "VACA" from CURP_INCONVENIENT_WORDS for MX flavor.

Added valid curp to test case.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.


