### PR TITLE
CIF spanish starting with 'U' bug resolved 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ New fields for existing flavors:
 
 Modifications to existing flavors:
 
+- CIF spanish starting with 'U' bug resolved
+  (`gh-469 <https://github.com/django/django-localflavor/pull/469>`_).
 - Fix error code for BRPostalCodeValidator
   (`gh-448 <https://github.com/django/django-localflavor/pull/448>`_).
 - Fix spelling of the India state of Chhattisgarh

--- a/localflavor/es/forms.py
+++ b/localflavor/es/forms.py
@@ -63,7 +63,7 @@ class ESIdentityCardNumberField(RegexField):
         self.only_nif = only_nif
         self.nif_control = 'TRWAGMYFPDXBNJZSQVHLCKE'
         self.cif_control = 'JABCDEFGHI'
-        self.cif_types = 'ABCDEFGHJKLMNPQRSVW'
+        self.cif_types = 'ABCDEFGHJKLMNPQRSUVW'
         self.nie_types = 'XYZ'
         self.id_card_pattern = r'^([%s]?)[ -]?(\d+)[ -]?([%s]?)$'
         id_card_re = re.compile(self.id_card_pattern %


### PR DESCRIPTION
**Please replace these instructions with a description of your change. The
'New Fields Only' section should be removed if your pull request
doesn't add any new fields.**

Thanks for your contribution!

Issue : (https://github.com/django/django-localflavor/issues/464)

A checklist is included below which helps us keep the code contributions
consistent and helps speed up the review process. You can add additional
commits to your pull request if you haven't met all of these points on your
first version.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

**New Fields Only**

- [ ] Prefix the country code to all fields.

- [ ] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [ ] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [ ] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [ ] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [ ] Add documentation for all fields.
