### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -292,7 +292,7 @@ epub_copyright = u'Django Software Foundation and individual contributors'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/localflavor/za/forms.py
+++ b/localflavor/za/forms.py
@@ -14,7 +14,7 @@ class ZAIDField(CharField):
     """
     A form field for South African ID numbers.
 
-    The checksum is validated using the Luhn checksum, and uses a simlistic (read: not entirely accurate)
+    The checksum is validated using the Luhn checksum, and uses a simplistic (read: not entirely accurate)
     check for the birth date.
     """
 

--- a/tests/test_bg.py
+++ b/tests/test_bg.py
@@ -52,7 +52,7 @@ INVALID_EIKS = (
     '1111111111111',
     '123456789',
     '1234567890123',
-    '176040024',  # Invalid cheksum
+    '176040024',  # Invalid checksum
     '1760400230152',  # Valid first checksum invalid second checksum
     'aaaaaaaaaa',
 )


### PR DESCRIPTION
There are small typos in:
- docs/conf.py
- localflavor/za/forms.py
- tests/test_bg.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `simplistic` rather than `simlistic`.
- Should read `checksum` rather than `cheksum`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md