### PR TITLE
Fix typo in docstring

### DIFF
--- a/localflavor/lt/forms.py
+++ b/localflavor/lt/forms.py
@@ -88,7 +88,7 @@ class LTIDCodeField(RegexField):
 
 class LTPostalCodeField(CharField):
     """
-    A form field that validates and normalizes Lithanuan postal codes.
+    A form field that validates and normalizes Lithuanian postal codes.
 
     Lithuanian postal codes in following forms accepted:
         * XXXXX


### PR DESCRIPTION
Did not add `authors.rst` / `changelog.rst` entry as I saw other typo fix PRs did not include it.