### PR TITLE
Fix typo in Lithuanian county name

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -92,6 +92,7 @@ Authors
 * Michał Sałaban
 * Mike Lissner
 * Morgane Alonso
+* Naglis Jonaitis
 * Nishit Shah
 * Olivier Sels
 * Olle Vidner

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ New fields for existing flavors:
 
 Modifications to existing flavors:
 
+- Fix typo in Marijampolė county name in LTCountySelect
+  (`gh-480 <https://github.com/django/django-localflavor/pull/480>`_).
 - CIF spanish starting with 'U' bug resolved
   (`gh-469 <https://github.com/django/django-localflavor/pull/469>`_).
 - Fix error code for BRPostalCodeValidator

--- a/localflavor/lt/lt_choices.py
+++ b/localflavor/lt/lt_choices.py
@@ -5,7 +5,7 @@ COUNTY_CHOICES = (
     ('alytus', _('Alytus')),
     ('kaunas', _('Kaunas')),
     ('klaipeda', _('Klaipėda')),
-    ('mariampole', _('Mariampolė')),
+    ('marijampole', _('Marijampolė')),
     ('panevezys', _('Panevėžys')),
     ('siauliai', _('Šiauliai')),
     ('taurage', _('Tauragė')),

--- a/tests/test_lt.py
+++ b/tests/test_lt.py
@@ -52,7 +52,7 @@ class LTLocalFlavorTests(SimpleTestCase):
             <option value="alytus">Alytus</option>
             <option value="kaunas">Kaunas</option>
             <option value="klaipeda">Klaipėda</option>
-            <option value="mariampole">Mariampolė</option>
+            <option value="marijampole">Marijampolė</option>
             <option value="panevezys">Panevėžys</option>
             <option value="siauliai">Šiauliai</option>
             <option value="taurage">Tauragė</option>


### PR DESCRIPTION
There is a `j` missing in the county name of _Marijampolė_. Sources to verify:
- [LT customs classification of counties](https://lrmuitine.lt/mport/failai/verslui/prekyba_su_es/klasifikatoriai/counties_ofLT.pdf)
- [Administrative territorial division in Lithuanian Government Statistics Portal](https://osp.stat.gov.lt/en/regionine-statistika-pagal-statistikos-sritis)
- [Wikipedia entry](https://en.wikipedia.org/wiki/Counties_of_Lithuania)