### PR TITLE
Overrides formfield method on Brazilian CPF, CNPJ and PostalCode model field.

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -85,6 +85,7 @@ Authors
 * Kevin Ramirez Zavalza
 * László Ratskó
 * Lefteris Nikoltsios
+* Lucas Dantas Gueiros
 * Luis Alberto Santana
 * Łukasz Langa
 * Luke Benstead

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,7 +30,11 @@ Modifications to existing flavors:
   (`gh-515 <https://github.com/django/django-localflavor/pull/515>`_).
 - Allow formatted values in `FRSIRENField` and `FRSIRETField` to be saved
   (`gh-518 <https://github.com/django/django-localflavor/pull/518>`_).
-
+- Add min and max length to brazilian Postal Code form field
+  (`gh-490 <https://github.com/django/django-localflavor/pull/490>`_).
+- Brazilian model fields CPF, CNPJ and PostalCode create correct form
+  field when used by DjangoModelForm
+  (`gh-490 <https://github.com/django/django-localflavor/pull/490>`_).
 
 Other changes:
 

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -25,8 +25,8 @@ class BRZipCodeField(CharField):
         More details at: https://github.com/django/django-localflavor/issues/334
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, max_length=9, min_length=8, **kwargs):
+        super().__init__(max_length=max_length, min_length=min_length, **kwargs)
         self.validators.append(BRPostalCodeValidator())
 
 

--- a/localflavor/br/models.py
+++ b/localflavor/br/models.py
@@ -3,10 +3,16 @@ from django.utils.translation import gettext_lazy as _
 
 from . import validators
 from .br_states import STATE_CHOICES
+from . import forms
 
 
 class BRStateField(CharField):
-    """A model field for states of Brazil."""
+    """
+    A model field for states of Brazil.
+
+    Forms represent it as a :class:`~localflavor.br.forms.BRStateSelect` field.
+    
+    """
 
     description = _("State of Brazil (two uppercase letters)")
 
@@ -25,6 +31,8 @@ class BRCPFField(CharField):
     """
     A model field for the brazilian document named of CPF (Cadastro de Pessoa Física)
 
+    Forms represent it as a :class:`~localflavor.br.forms.BRCPFField` field.
+
     .. versionadded:: 2.2
     """
 
@@ -39,11 +47,19 @@ class BRCPFField(CharField):
         kwargs['max_length'] = 14
         super().__init__(*args, **kwargs)
         self.validators.append(validators.BRCPFValidator())
+    
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.BRCPFField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
+
 
 
 class BRCNPJField(CharField):
     """
     A model field for the brazilian document named of CNPJ (Cadastro Nacional de Pessoa Jurídica)
+
+    Forms represent it as a :class:`~localflavor.br.forms.BRCNPJField` field.
 
     .. versionadded:: 2.2
     """
@@ -55,10 +71,16 @@ class BRCNPJField(CharField):
         super().__init__(*args, **kwargs)
         self.validators.append(validators.BRCNPJValidator())
 
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.BRCNPJField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
 
 class BRPostalCodeField(CharField):
     """
     A model field for the brazilian zip code
+
+    Forms represent it as a :class:`~localflavor.br.forms.BRZipCOdeField` field.
 
     .. versionadded:: 2.2
     """
@@ -69,3 +91,8 @@ class BRPostalCodeField(CharField):
         kwargs['max_length'] = 9
         super().__init__(*args, **kwargs)
         self.validators.append(validators.BRPostalCodeValidator())
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.BRZipCodeField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)


### PR DESCRIPTION
**Overrides formfield method on Brazilian CPF, CNPJ and PostalCode model field. #489 **

Thanks for your contribution!

A checklist is included below which helps us keep the code contributions
consistent and helps speed up the review process. You can add additional
commits to your pull request if you haven't met all of these points on your
first version.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

**New Fields Only**

- [x] Prefix the country code to all fields.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [x] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [x] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [x] Add documentation for all fields.
