### PR TITLE
fix: Accept French Postal Services identifiers in forms

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -33,6 +33,7 @@ Authors
 * Ben Konrath
 * Bruno M. Custódio
 * Burhan Khalid
+* Célia Prat
 * Claude Paroz
 * Daniel Ampuero
 * Daniela Ponader

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,8 @@ Modifications to existing flavors:
 - Fix Belarus passport field description punctuation
   (`gh-484 <https://github.com/django/django-localflavor/pull/484>`_).
 - Change `Kiev` to `Kyiv` 🇺🇦 according to ISO_3166-2:UA
+- Accept French Postal Services identifiers in forms
+  (`gh-505 <https://github.com/django/django-localflavor/pull/505>`_).
 
 Other changes:
 

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -271,10 +271,12 @@ class FRLocalFlavorTests(SimpleTestCase):
             '752932715': '752932715',
             '752 932 715': '752932715',
             '752-932-715': '752932715',
+            '356000000': '356000000'
         }
         invalid = {
             '1234': error_format,               # wrong size
             '752932712': error_format,     # Bad luhn on SIREN
+            '35600000014597' : error_format
         }
         self.assertFieldOutput(FRSIRENField, valid, invalid)
 
@@ -294,11 +296,13 @@ class FRLocalFlavorTests(SimpleTestCase):
             '75293271500010': '75293271500010',
             '752 932 715 00010': '75293271500010',
             '752-932-715-00010': '75293271500010',
+            '35600000014597' : '35600000014597', # Special case La Poste
         }
         invalid = {
             '1234': error_format,               # wrong size
             '75293271200017': error_format,     # Bad luhn on SIREN
             '75293271000010': error_format,     # Bad luhn on whole
+            '35600000014596' : error_format     # Special case La Poste
         }
         self.assertFieldOutput(FRSIRETField, valid, invalid)
 


### PR DESCRIPTION
This PR is intended to fix the following issue : https://github.com/django/django-localflavor/issues/504

The form validation in `FRSIRENENumberMixin`  is missing a special case from the SIRENE register.

The identifiers for Postal Services need a special validation process and are not currently validated.

Source (in french) : [https://www.sirene.fr/static-resources/doc/lettres/lettre-16-novembre-2013.pdf](https://www.sirene.fr/static-resources/doc/lettres/lettre-16-novembre-2013.pdf)

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.