### PR TITLE
Kyiv - not Kiev 🇺🇦 

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -43,6 +43,7 @@ Authors
 * Diederik van der Boor
 * d.merc
 * Dmitry Dygalo
+* Dmytro Litvinov
 * Dominick Rivard
 * Douglas Miranda
 * Elliott Fawcett

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Modifications to existing flavors:
 
 - Fix Belarus passport field description punctuation
   (`gh-484 <https://github.com/django/django-localflavor/pull/484>`_).
+- Change `Kiev` to `Kyiv` 🇺🇦 according to ISO_3166-2:UA
 
 Other changes:
 

--- a/localflavor/ua/ua_regions.py
+++ b/localflavor/ua/ua_regions.py
@@ -13,7 +13,7 @@ UA_REGION_CHOICES = (
     ('UA-65', _('Kherson Oblast')),
     ('UA-68', _('Khmelnytskyi Oblast')),
     ('UA-35', _('Kirovohrad Oblast')),
-    ('UA-32', _('Kiev Oblast')),
+    ('UA-32', _('Kyiv Oblast')),
     ('UA-09', _('Luhansk Oblast')),
     ('UA-46', _('Lviv Oblast')),
     ('UA-48', _('Mykolaiv Oblast')),
@@ -28,6 +28,6 @@ UA_REGION_CHOICES = (
     ('UA-23', _('Zaporizhia Oblast')),
     ('UA-18', _('Zhytomyr Oblast')),
     ('UA-43', _('Autonomous Republic of Crimea')),
-    ('UA-30', _('Kiev')),
+    ('UA-30', _('Kyiv')),
     ('UA-40', _('Sevastopol'))
 )


### PR DESCRIPTION
**All Changes**
- [X] Change `Kiev` to `Kyiv` 🇺🇦 according to ISO_3166-2:UA. More context about [a problem](https://en.wikipedia.org/wiki/KyivNotKiev)

- [X] Add an entry to the docs/changelog.rst describing the change.

- [X] Add an entry for your name in the docs/authors.rst file if it's not
      already there.
