### PR TITLE
Added KW utils and extended civil ID validation

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -96,6 +96,7 @@ Authors
 * Matias Dinota
 * Michał Sałaban
 * Mike Lissner
+* Mohammed Al-Abdulhadi
 * Morgane Alonso
 * Naglis Jonaitis
 * Nishit Shah

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ Modifications to existing flavors:
 - Change `Kiev` to `Kyiv` 🇺🇦 according to ISO_3166-2:UA
 - Accept French Postal Services identifiers in forms
   (`gh-505 <https://github.com/django/django-localflavor/pull/505>`_).
+- Extended validation of Kuwaiti Civil ID to avoid allowing invalid century Civil IDs
+- Added birthdate extraction function from Kuwaiti Civil ID
 - Fix validation of the Romanian CNP for years ending with `00`
   (`gh-515 <https://github.com/django/django-localflavor/pull/515>`_).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,7 +20,9 @@ Modifications to existing flavors:
 - Accept French Postal Services identifiers in forms
   (`gh-505 <https://github.com/django/django-localflavor/pull/505>`_).
 - Extended validation of Kuwaiti Civil ID to avoid allowing invalid century Civil IDs
+  (`gh-511 <https://github.com/django/django-localflavor/pull/511>`_).
 - Added birthdate extraction function from Kuwaiti Civil ID
+  (`gh-511 <https://github.com/django/django-localflavor/pull/511>`_).
 - Fix validation of the Romanian CNP for years ending with `00`
   (`gh-515 <https://github.com/django/django-localflavor/pull/515>`_).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ Modifications to existing flavors:
   (`gh-511 <https://github.com/django/django-localflavor/pull/511>`_).
 - Added birthdate extraction function from Kuwaiti Civil ID
   (`gh-511 <https://github.com/django/django-localflavor/pull/511>`_).
+- Deprecated `kw.forms.is_valid_kw_civilid_checksum` in favor of `kw.utils.is_valid_civil_id`
+  (`gh-511 <https://github.com/django/django-localflavor/pull/511>`_).
 - Fix validation of the Romanian CNP for years ending with `00`
   (`gh-515 <https://github.com/django/django-localflavor/pull/515>`_).
 

--- a/localflavor/deprecation.py
+++ b/localflavor/deprecation.py
@@ -1,2 +1,2 @@
-class RemovedInLocalflavor30Warning(PendingDeprecationWarning):
+class RemovedInLocalflavor60Warning(PendingDeprecationWarning):
     pass

--- a/localflavor/kw/forms.py
+++ b/localflavor/kw/forms.py
@@ -1,9 +1,12 @@
 """Kuwait-specific Form helpers."""
 import re
+import warnings
 
 from django.forms import ValidationError
 from django.forms.fields import RegexField, Select
 from django.utils.translation import gettext_lazy as _
+
+from localflavor.deprecation import RemovedInLocalflavor60Warning
 
 from .kw_areas import AREA_CHOICES
 from .kw_governorates import GOVERNORATE_CHOICES
@@ -18,6 +21,14 @@ id_re = re.compile(r'''^(?P<initial>\d)
 
 
 def is_valid_kw_civilid_checksum(value):
+    """
+    .. deprecated:: 5.0
+       Use `localflavor.kw.utils.is_valid_civil_id()` instead.
+    """
+    warnings.warn(
+        'is_valid_kw_civilid_checksum is deprecated in favor of localflavor.kw.utils.is_valid_civil_id().',
+        RemovedInLocalflavor60Warning,
+    )
     return is_valid_civil_id(value)
 
 

--- a/localflavor/kw/utils.py
+++ b/localflavor/kw/utils.py
@@ -1,0 +1,46 @@
+from datetime import date
+
+
+def is_valid_civil_id(cid):
+    """
+    Checks the validity of a Kuwaiti Civil ID number
+    by verifying the following:
+      * The number should consist of 12 digits
+      * The first digit should be 1, 2, or 3
+      * The extracted birthdate should be a valid date
+      * The checksum should be equal to the last digit of the Civil ID
+    """
+    # Civil ID can only start with 1, 2, or 3 till year 2100
+    if len(cid) != 12 or not cid.isdigit() or cid[0] not in ('1', '2', '3'):
+        return False
+
+    # calculate the Civil ID checksum
+    weight = (2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2)
+    initial = sum(x * y for x, y in zip(weight, map(int, cid[:-1]))) % 11
+    checksum = 11 - initial
+
+    # extract birthdate to check if it's a valid date
+    try:
+        get_birthdate_from_civil_id(cid)
+    except ValueError:
+        return False
+
+    # verify if the checksum matches the last digit
+    return checksum == int(cid[11])
+
+
+def get_birthdate_from_civil_id(cid):
+    """
+    Extracts the birthdate from a Kuwaiti Civil ID number
+    """
+    by_century = {
+        '1': '18',
+        '2': '19',
+        '3': '20'
+    }
+    if cid[0] not in ('1', '2', '3'):
+        raise ValueError('Invalid first digit')
+    year = int('{}{}'.format(by_century[cid[0]], cid[1:3]))
+    month = int(cid[3:5])
+    day = int(cid[5:7])
+    return date(year, month, day)

--- a/tests/test_kw.py
+++ b/tests/test_kw.py
@@ -1,10 +1,38 @@
+from datetime import date
+
 from django.test import SimpleTestCase
 
 from localflavor.kw.forms import KWAreaSelect, KWCivilIDNumberField, KWGovernorateSelect
+from localflavor.kw.utils import is_valid_civil_id, get_birthdate_from_civil_id
 
 
 class KWLocalFlavorTests(SimpleTestCase):
     maxDiff = None
+
+    def test_civil_id_checksum_valid(self):
+        self.assertTrue(is_valid_civil_id('286101901541'))
+        self.assertTrue(is_valid_civil_id('300092400929'))
+        self.assertTrue(is_valid_civil_id('282040701483'))
+
+    def test_civil_id_checksum_invalid(self):
+        self.assertFalse(is_valid_civil_id('486101910006'))
+        self.assertFalse(is_valid_civil_id('289332013455'))
+        self.assertFalse(is_valid_civil_id('286191911111'))
+
+    def test_get_birthdate_from_civil_id(self):
+        self.assertEqual(
+            get_birthdate_from_civil_id('286101901541'),
+            date(1986, 10, 19)
+        )
+        self.assertEqual(
+            get_birthdate_from_civil_id('304022600325'),
+            date(2004, 2, 26)
+        )
+
+    def test_get_birthdate_from_civil_id_invalid_century(self):
+        self.assertRaises(ValueError, get_birthdate_from_civil_id, '486101910006')
+        self.assertRaises(ValueError, get_birthdate_from_civil_id, '886101910006')
+
     def test_KWCivilIDNumberField(self):
         error_invalid = ['Enter a valid Kuwaiti Civil ID number']
         valid = {
@@ -17,6 +45,8 @@ class KWLocalFlavorTests(SimpleTestCase):
             '300000000005': error_invalid,
             '289332Ol3455': error_invalid,
             '2*9332013455': error_invalid,
+            '486101911111': error_invalid,
+            '286191911111': error_invalid,
         }
         self.assertFieldOutput(KWCivilIDNumberField, valid, invalid)
 


### PR DESCRIPTION
**All Changes**

- [X] Add an entry to the docs/changelog.rst describing the change.

- [X] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

- Modified Kuwaiti Civil ID validation function because it used to allow invalid civil IDs (valid checksum but invalid century)
- Added a function to extract birth date from a Kuwaiti Civil ID
- Moved all the Civil ID validation logic from the form field to civil id validation function so it can be used anywhere not just in the form field