### PR TITLE
Allow FR Siren and Siret forms to save formatted values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,9 @@ Modifications to existing flavors:
   (`gh-511 <https://github.com/django/django-localflavor/pull/511>`_).
 - Fix validation of the Romanian CNP for years ending with `00`
   (`gh-515 <https://github.com/django/django-localflavor/pull/515>`_).
+- Allow formatted values in `FRSIRENField` and `FRSIRETField` to be saved
+  (`gh-518 <https://github.com/django/django-localflavor/pull/518>`_).
+
 
 Other changes:
 

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -211,9 +211,14 @@ class FRSIRENField(CharField):
         if value in self.empty_values:
             return value
 
-        value = value.replace(' ', '').replace('-', '')
         if not self.r_valid.match(value) or not luhn.is_valid(value):
             raise ValidationError(self.error_messages['invalid'], code='invalid')
+        return value
+
+    def to_python(self, value):
+        value = super().to_python(value)
+        if value is not None:
+            return value.upper().replace(' ', '').replace('-', '')
         return value
 
 
@@ -238,8 +243,6 @@ class FRSIRETField(CharField):
         if value in self.empty_values:
             return value
 
-        value = value.replace(' ', '').replace('-', '')
-
         if not self.r_valid.match(value) or not luhn.is_valid(value[:9]) or \
             (value.startswith("356000000") and sum(int(x) for x in value) % 5 != 0):
             raise ValidationError(self.error_messages['invalid'], code='invalid')
@@ -250,6 +253,12 @@ class FRSIRETField(CharField):
             return value
         value = value.replace(' ', '').replace('-', '')
         return ' '.join((value[:3], value[3:6], value[6:9], value[9:]))
+
+    def to_python(self, value):
+        value = super().to_python(value)
+        if value is not None:
+            return value.upper().replace(' ', '').replace('-', '')
+        return value
 
 
 class FRRNAField(CharField):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,21 +7,22 @@ DATABASES = {
 
 INSTALLED_APPS = [
     'localflavor',
+    'tests.test_au',
     'tests.test_br',
     'tests.test_by',
-    'tests.test_au',
+    'tests.test_ca',
+    'tests.test_cu',
     'tests.test_ec',
+    'tests.test_fr',
+    'tests.test_generic',
+    'tests.test_gh',
     'tests.test_md',
     'tests.test_mk',
     'tests.test_mx',
+    'tests.test_np',
+    'tests.test_pk',
     'tests.test_ua',
     'tests.test_us',
-    'tests.test_pk',
-    'tests.test_cu',
-    'tests.test_gh',
-    'tests.test_np',
-    'tests.test_ca',
-    'tests.test_generic',
 ]
 
 SECRET_KEY = 'spam-spam-spam-spam'

--- a/tests/test_fr/forms.py
+++ b/tests/test_fr/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from .models import FranceModel
+
+
+class FranceForm(forms.ModelForm):
+    class Meta:
+        model = FranceModel
+        fields = ("siren", "siret", "rna")

--- a/tests/test_fr/models.py
+++ b/tests/test_fr/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+from localflavor.fr.models import FRRNAField, FRSIRENField, FRSIRETField
+
+
+class FranceModel(models.Model):
+    siren = FRSIRENField(null=True, default=None, blank=True)
+    siret = FRSIRETField(null=True, default=None, blank=True)
+    rna = FRRNAField(null=True, default=None, blank=True)

--- a/tests/test_fr/tests.py
+++ b/tests/test_fr/tests.py
@@ -1,8 +1,11 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from localflavor.fr.forms import (FRDepartmentField, FRDepartmentSelect, FRNationalIdentificationNumber,
-                                  FRRegion2016Select, FRRegionField, FRRegionSelect, FRSIRENField, FRSIRETField,
-                                  FRZipCodeField, FRRNAField)
+                                  FRRegion2016Select, FRRegionField, FRRegionSelect, FRRNAField, FRSIRENField,
+                                  FRSIRETField, FRZipCodeField)
+
+from .forms import FranceForm
+from .models import FranceModel
 
 DEP_SELECT_OUTPUT = '''
     <select name="dep">
@@ -332,3 +335,15 @@ class FRLocalFlavorTests(SimpleTestCase):
             '5142010167': error_format,         # W Letter missing and too many numbers
         }
         self.assertFieldOutput(FRRNAField, valid, invalid)
+
+
+class FRModelTests(TestCase):
+    def test_model_fields_allow_saving_formatted_values(self):
+        fr_form = FranceForm(     {
+            'siren': '752 932 715',
+            'siret': '752 932 715 00010',
+        })
+        fr_form.save()  # No validation error raised.
+        obj = FranceModel.objects.get()
+        self.assertEqual(obj.siren, '752932715')
+        self.assertEqual(obj.siret, '75293271500010')


### PR DESCRIPTION
Ensures formatted values for FR Siren and Siret form fields to be saved. Without this, users need to remove the spaces to get the form fields to validate which is not correct.

Fixes #473