### PR TITLE
Accept formatted values in for FR SIREN and SIRET

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,7 +54,8 @@ Modifications to existing flavors:
 - Fix validation of the Romanian CNP for years ending with `00`
   (`gh-515 <https://github.com/django/django-localflavor/pull/515>`_).
 - Allow formatted values in `FRSIRENField` and `FRSIRETField` to be saved
-  (`gh-518 <https://github.com/django/django-localflavor/pull/518>`_).
+  (`gh-518 <https://github.com/django/django-localflavor/pull/518>`_),
+  (`gh-520 <https://github.com/django/django-localflavor/pull/520>`_).
 - Add min and max length to brazilian Postal Code form field
   (`gh-490 <https://github.com/django/django-localflavor/pull/490>`_).
 - Brazilian model fields CPF, CNPJ and PostalCode create correct form

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -198,7 +198,13 @@ class FRSIRENField(CharField):
 
     default_error_messages = {
         'invalid': _('Enter a valid French SIREN number.'),
+        'max_length': _('Enter a valid French SIREN number.'),
     }
+
+    def __init__(self, **kwargs):
+        # Use max_length=11 instead of max_length=9 to account for the spaces in the formatted value.
+        kwargs["max_length"] = 11
+        super().__init__(**kwargs)
 
     def prepare_value(self, value):
         if value is None:
@@ -236,7 +242,13 @@ class FRSIRETField(CharField):
 
     default_error_messages = {
         'invalid': _('Enter a valid French SIRET number.'),
+        'max_length': _('Enter a valid French SIRET number.'),
     }
+
+    def __init__(self, **kwargs):
+        # Use max_length=17 instead of max_length=14 to account for the spaces in the formatted value.
+        kwargs["max_length"] = 17
+        super().__init__(**kwargs)
 
     def clean(self, value):
         value = super().clean(value)

--- a/localflavor/fr/forms.py
+++ b/localflavor/fr/forms.py
@@ -195,14 +195,15 @@ class FRSIRENField(CharField):
     """
 
     r_valid = re.compile(r'^\d{9}$')
+    _invalid_error_message = _('Enter a valid French SIREN number.')
 
     default_error_messages = {
-        'invalid': _('Enter a valid French SIREN number.'),
-        'max_length': _('Enter a valid French SIREN number.'),
+        'invalid': _invalid_error_message,
+        'max_length': _invalid_error_message,  # Overridden because the message isn't accurate.
     }
 
     def __init__(self, **kwargs):
-        # Use max_length=11 instead of max_length=9 to account for the spaces in the formatted value.
+        # Use max_length=11 instead of max_length=9 (from the model) to account for the spaces in the formatted value.
         kwargs["max_length"] = 11
         super().__init__(**kwargs)
 
@@ -239,14 +240,15 @@ class FRSIRETField(CharField):
     """
 
     r_valid = re.compile(r'^\d{14}$')
+    _invalid_error_message = _('Enter a valid French SIRET number.')
 
     default_error_messages = {
-        'invalid': _('Enter a valid French SIRET number.'),
-        'max_length': _('Enter a valid French SIRET number.'),
+        'invalid': _invalid_error_message,
+        'max_length': _invalid_error_message,  # Overridden because the message isn't accurate.
     }
 
     def __init__(self, **kwargs):
-        # Use max_length=17 instead of max_length=14 to account for the spaces in the formatted value.
+        # Use max_length=17 instead of max_length=14 (from the model) to account for the spaces in the formatted value.
         kwargs["max_length"] = 17
         super().__init__(**kwargs)
 

--- a/tests/test_fr/tests.py
+++ b/tests/test_fr/tests.py
@@ -277,9 +277,9 @@ class FRLocalFlavorTests(SimpleTestCase):
             '356000000': '356000000'
         }
         invalid = {
-            '1234': error_format,               # wrong size
-            '752932712': error_format,     # Bad luhn on SIREN
-            '35600000014597' : error_format
+            '1234': error_format,             # Wrong size
+            '752932712': error_format,        # Bad luhn on SIREN
+            '35600000014597' : error_format,  # Too long
         }
         self.assertFieldOutput(FRSIRENField, valid, invalid)
 
@@ -305,7 +305,8 @@ class FRLocalFlavorTests(SimpleTestCase):
             '1234': error_format,               # wrong size
             '75293271200017': error_format,     # Bad luhn on SIREN
             '75293271000010': error_format,     # Bad luhn on whole
-            '35600000014596' : error_format     # Special case La Poste
+            '35600000014596' : error_format,    # Special case La Poste
+            '356000000145966': error_format,    # Too long
         }
         self.assertFieldOutput(FRSIRETField, valid, invalid)
 
@@ -339,7 +340,7 @@ class FRLocalFlavorTests(SimpleTestCase):
 
 class FRModelTests(TestCase):
     def test_model_fields_allow_saving_formatted_values(self):
-        fr_form = FranceForm(     {
+        fr_form = FranceForm({
             'siren': '752 932 715',
             'siret': '752 932 715 00010',
         })
@@ -347,3 +348,11 @@ class FRModelTests(TestCase):
         obj = FranceModel.objects.get()
         self.assertEqual(obj.siren, '752932715')
         self.assertEqual(obj.siret, '75293271500010')
+
+    def test_model_form_input_max_length(self):
+        fr_form = FranceForm({
+            'siren': '752 932 715',
+            'siret': '752 932 715 00010',
+        })
+        self.assertEqual(11, fr_form.fields["siren"].max_length)
+        self.assertEqual(17, fr_form.fields["siret"].max_length)


### PR DESCRIPTION
This is an attempt at addressing the problems with accepting formatted values for SIREN and SIRET numbers in their form fields.

This change sets the `max_length` value with the extra spaces in the form and allows the model field to continue to use the compact representation. e.g. The version without spaces is stored. 

I think this problem is also present in the IBAN form and possibly others. I'll make an issue to investigate this.

Fixes #473 
