### PR TITLE
Allow formatted IBANs longer than 26 chars to be saved

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -78,7 +78,8 @@ Modifications to existing flavors:
   - `NPZoneSelect`: dandaki was corrected to gandaki (fixed typo).
 
   (`gh-506 <https://github.com/django/django-localflavor/pull/506/files>`_).
-
+- Allow formatted IBANs longer than 26 chars to be saved in `IBANField`
+  (`gh-522 <https://github.com/django/django-localflavor/pull/522>`_).
 
 Other changes:
 

--- a/localflavor/generic/forms.py
+++ b/localflavor/generic/forms.py
@@ -22,8 +22,6 @@ DEFAULT_DATETIME_INPUT_FORMATS = (
     '%d/%m/%y',              # '25/10/06'
 )
 
-IBAN_MIN_LENGTH = min(IBAN_COUNTRY_CODE_LENGTH.values())
-
 
 class DateField(forms.DateField):
     """A date input field which uses non-US date input formats by default."""
@@ -80,10 +78,14 @@ class IBANFormField(forms.CharField):
     """
 
     def __init__(self, use_nordea_extensions=False, include_countries=None, **kwargs):
-        kwargs.setdefault('min_length', IBAN_MIN_LENGTH)
-        kwargs.setdefault('max_length', 34)
+        # The IBANValidator handles the length check, so we don't need to use the form min and max length validators.
+        kwargs.pop("max_length", None)
         self.default_validators = [IBANValidator(use_nordea_extensions, include_countries)]
         super().__init__(**kwargs)
+
+        # We still need to use max_length=42 in the <input ...> instead of max_length=34 (from the model) to
+        # account for the spaces in the formatted value.
+        self.widget.attrs["max_length"] = 42
 
     def to_python(self, value):
         value = super().to_python(value)


### PR DESCRIPTION
Only the IBAN field had the same problem as the FR SIREN and SIRET fields as far as I can tell.

Fixes #521 