### PR TITLE
Fix REGON validation

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -138,3 +138,4 @@ Authors
 * Abhineet Tamrakar
 * Tudor Amariei
 * Dishan Sachin
+* Kacper Urbański

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,8 @@ New fields for existing flavors:
 
 Modifications to existing flavors:
 
-- None
+- Fix REGON validation for PL
+  (`gh-529 <https://github.com/django/django-localflavor/pull/529>`_).
 
 Other changes:
 
@@ -101,8 +102,6 @@ Modifications to existing flavors:
   (`gh-506 <https://github.com/django/django-localflavor/pull/506/files>`_).
 - Allow formatted IBANs longer than 26 chars to be saved in `IBANField`
   (`gh-522 <https://github.com/django/django-localflavor/pull/522>`_).
-- Fix REGON validation for PL
-  (`gh-529 <https://github.com/django/django-localflavor/pull/529>`_).
 
 Other changes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -101,6 +101,8 @@ Modifications to existing flavors:
   (`gh-506 <https://github.com/django/django-localflavor/pull/506/files>`_).
 - Allow formatted IBANs longer than 26 chars to be saved in `IBANField`
   (`gh-522 <https://github.com/django/django-localflavor/pull/522>`_).
+- Fix REGON validation for PL
+  (`gh-529 <https://github.com/django/django-localflavor/pull/529>`_).
 
 Other changes:
 

--- a/localflavor/pl/forms.py
+++ b/localflavor/pl/forms.py
@@ -192,7 +192,7 @@ class PLREGONField(RegexField):
     }
 
     def __init__(self, **kwargs):
-        super().__init__(r'^\d{9,14}$', **kwargs)
+        super().__init__(r'^(\d{9}|\d{14})$', **kwargs)
 
     def clean(self, value):
         value = super().clean(value)
@@ -204,6 +204,8 @@ class PLREGONField(RegexField):
 
     def has_valid_checksum(self, number):
         """Calculates a checksum with the provided algorithm."""
+        # the 14 digits number must firstly pass 9 digits too
+        CHECKSUM_POS_9_DIGIT = 8 
         weights = (
             (8, 9, 2, 3, 4, 5, 6, 7, -1),
             (2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8, -1),
@@ -217,7 +219,7 @@ class PLREGONField(RegexField):
 
             mod_result = checksum % 11
 
-            if mod_result == 10 and number[-1] != '0':
+            if mod_result == 10 and number[CHECKSUM_POS_9_DIGIT] != '0':
                 return False
 
             if mod_result % 10:

--- a/localflavor/pl/forms.py
+++ b/localflavor/pl/forms.py
@@ -205,7 +205,6 @@ class PLREGONField(RegexField):
     def has_valid_checksum(self, number):
         """Calculates a checksum with the provided algorithm."""
         # the 14 digits number must firstly pass 9 digits too
-        CHECKSUM_POS_9_DIGIT = 8 
         weights = (
             (8, 9, 2, 3, 4, 5, 6, 7, -1),
             (2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8, -1),
@@ -219,7 +218,7 @@ class PLREGONField(RegexField):
 
             mod_result = checksum % 11
 
-            if mod_result == 10 and number[CHECKSUM_POS_9_DIGIT] != '0':
+            if mod_result == 10 and number[table.index(-1)] != '0':
                 return False
 
             if mod_result % 10:

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -1,13 +1,20 @@
 from django.test import SimpleTestCase
 
-from localflavor.pl.forms import (PLCountySelect, PLNationalIDCardNumberField, PLNIPField, PLPESELField,
-                                  PLPostalCodeField, PLProvinceSelect, PLREGONField)
+from localflavor.pl.forms import (
+    PLCountySelect,
+    PLNationalIDCardNumberField,
+    PLNIPField,
+    PLPESELField,
+    PLPostalCodeField,
+    PLProvinceSelect,
+    PLREGONField,
+)
 
 
 class PLLocalFlavorTests(SimpleTestCase):
     def test_PLProvinceSelect(self):
         f = PLProvinceSelect()
-        out = '''<select name="voivodeships">
+        out = """<select name="voivodeships">
 <option value="lower_silesia">Lower Silesian</option>
 <option value="kuyavia-pomerania">Kuyavian-Pomeranian</option>
 <option value="lublin">Lublin</option>
@@ -24,12 +31,12 @@ class PLLocalFlavorTests(SimpleTestCase):
 <option value="warmia-masuria">Warmian-Masurian</option>
 <option value="greater_poland">Greater Poland</option>
 <option value="west_pomerania">West Pomeranian</option>
-</select>'''
-        self.assertHTMLEqual(f.render('voivodeships', 'pomerania'), out)
+</select>"""
+        self.assertHTMLEqual(f.render("voivodeships", "pomerania"), out)
 
     def test_PLCountrySelect(self):
         f = PLCountySelect()
-        out = '''<select name="administrativeunit">
+        out = """<select name="administrativeunit">
 <option value="wroclaw">Wroc\u0142aw</option>
 <option value="jeleniagora">Jelenia G\xf3ra</option>
 <option value="legnica">Legnica</option>
@@ -406,84 +413,94 @@ class PLLocalFlavorTests(SimpleTestCase):
 <option value="szczecinecki">szczecinecki</option>
 <option value="swidwinski">\u015bwidwi\u0144ski</option>
 <option value="walecki">wa\u0142ecki</option>
-</select>'''
-        self.assertHTMLEqual(f.render('administrativeunit', 'katowice'), out)
+</select>"""
+        self.assertHTMLEqual(f.render("administrativeunit", "katowice"), out)
 
     def test_PLPostalCodeField(self):
-        error_format = ['Enter a postal code in the format XX-XXX.']
+        error_format = ["Enter a postal code in the format XX-XXX."]
         valid = {
-            '41-403': '41-403',
+            "41-403": "41-403",
         }
         invalid = {
-            '43--434': error_format,
+            "43--434": error_format,
         }
         self.assertFieldOutput(PLPostalCodeField, valid, invalid)
 
     def test_PLNIPField(self):
-        error_format = ['Enter a tax number field (NIP) in the format XXX-XXX-XX-XX, XXX-XX-XX-XXX or XXXXXXXXXX.']
-        error_checksum = ['Wrong checksum for the Tax Number (NIP).']
+        error_format = [
+            "Enter a tax number field (NIP) in the format XXX-XXX-XX-XX, XXX-XX-XX-XXX or XXXXXXXXXX."
+        ]
+        error_checksum = ["Wrong checksum for the Tax Number (NIP)."]
         valid = {
-            '646-241-41-24': '6462414124',
-            '646-24-14-124': '6462414124',
-            '6462414124': '6462414124',
+            "646-241-41-24": "6462414124",
+            "646-24-14-124": "6462414124",
+            "6462414124": "6462414124",
         }
         invalid = {
-            '43-343-234-323': error_format,
-            '64-62-414-124': error_format,
-            '646-241-41-23': error_checksum,
+            "43-343-234-323": error_format,
+            "64-62-414-124": error_format,
+            "646-241-41-23": error_checksum,
         }
         self.assertFieldOutput(PLNIPField, valid, invalid)
 
     def test_PLPESELField(self):
-        error_checksum = ['Wrong checksum for the National Identification Number.']
-        error_format = ['National Identification Number consists of 11 digits.']
-        error_birthdate = ['The National Identification Number contains an invalid birth date.']
+        error_checksum = ["Wrong checksum for the National Identification Number."]
+        error_format = ["National Identification Number consists of 11 digits."]
+        error_birthdate = [
+            "The National Identification Number contains an invalid birth date."
+        ]
         valid = {
-            '80071610614': '80071610614',
+            "80071610614": "80071610614",
         }
         invalid = {
-            '80071610610': error_checksum,
-            '80': error_format,
-            '800716106AA': error_format,
-            '98765432121': error_birthdate,
+            "80071610610": error_checksum,
+            "80": error_format,
+            "800716106AA": error_format,
+            "98765432121": error_birthdate,
         }
         self.assertFieldOutput(PLPESELField, valid, invalid)
 
     def test_PLNationalIDCardNumberField(self):
-        error_checksum = ['Wrong checksum for the National ID Card Number.']
-        error_format = ['National ID Card Number consists of 3 letters and 6 digits.']
+        error_checksum = ["Wrong checksum for the National ID Card Number."]
+        error_format = ["National ID Card Number consists of 3 letters and 6 digits."]
         valid = {
-            'ABC123458': 'ABC123458',
-            'abc123458': 'ABC123458',
+            "ABC123458": "ABC123458",
+            "abc123458": "ABC123458",
         }
         invalid = {
-            'ABC123457': error_checksum,
-            'abc123457': error_checksum,
-            'a12Aaaaaa': error_format,
-            'AA1234443': error_format,
+            "ABC123457": error_checksum,
+            "abc123457": error_checksum,
+            "a12Aaaaaa": error_format,
+            "AA1234443": error_format,
         }
         self.assertFieldOutput(PLNationalIDCardNumberField, valid, invalid)
 
     def test_PLREGONField(self):
-        error_checksum = ['Wrong checksum for the National Business Register Number (REGON).']
-        error_format = ['National Business Register Number (REGON) consists of 9 or 14 digits.']
-        valid = {
-            '12345678512347': '12345678512347',
-            '590096454': '590096454',
+        VALID_LENGTHS = (9, 14)
 
+        error_checksum = [
+            "Wrong checksum for the National Business Register Number (REGON)."
+        ]
+        error_format = [
+            "National Business Register Number (REGON) consists of 9 or 14 digits."
+        ]
+        valid = {
+            "12345678512347": "12345678512347",
+            "590096454": "590096454",
             # A special case where the checksum == 10 and the control
             # digit == '0'
-            '391023200': '391023200',
+            "391023200": "391023200",
+            "00102110000342": "00102110000342",
         }
         invalid = {
-            '123456784': error_checksum,
-            '12345678412342': error_checksum,
-            '590096453': error_checksum,
-
+            "123456784": error_checksum,
+            "12345678412342": error_checksum,
+            "590096453": error_checksum,
             # A special case where the checksum == 10,
             # but the control digit != '0'
-            '111111111': error_checksum,
-
-            '590096': error_format,
+            "111111111": error_checksum,
+            "590096": error_format,
+            # 8, 10, 11, 12, 13, 15 digits
+            **{"1" * i: error_format for i in range(8, 16) if i not in VALID_LENGTHS},
         }
         self.assertFieldOutput(PLREGONField, valid, invalid)

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -14,7 +14,7 @@ from localflavor.pl.forms import (
 class PLLocalFlavorTests(SimpleTestCase):
     def test_PLProvinceSelect(self):
         f = PLProvinceSelect()
-        out = """<select name="voivodeships">
+        out = '''<select name="voivodeships">
 <option value="lower_silesia">Lower Silesian</option>
 <option value="kuyavia-pomerania">Kuyavian-Pomeranian</option>
 <option value="lublin">Lublin</option>
@@ -31,12 +31,12 @@ class PLLocalFlavorTests(SimpleTestCase):
 <option value="warmia-masuria">Warmian-Masurian</option>
 <option value="greater_poland">Greater Poland</option>
 <option value="west_pomerania">West Pomeranian</option>
-</select>"""
-        self.assertHTMLEqual(f.render("voivodeships", "pomerania"), out)
+</select>'''
+        self.assertHTMLEqual(f.render('voivodeships', 'pomerania'), out)
 
     def test_PLCountrySelect(self):
         f = PLCountySelect()
-        out = """<select name="administrativeunit">
+        out = '''<select name="administrativeunit">
 <option value="wroclaw">Wroc\u0142aw</option>
 <option value="jeleniagora">Jelenia G\xf3ra</option>
 <option value="legnica">Legnica</option>
@@ -413,65 +413,65 @@ class PLLocalFlavorTests(SimpleTestCase):
 <option value="szczecinecki">szczecinecki</option>
 <option value="swidwinski">\u015bwidwi\u0144ski</option>
 <option value="walecki">wa\u0142ecki</option>
-</select>"""
-        self.assertHTMLEqual(f.render("administrativeunit", "katowice"), out)
+</select>'''
+        self.assertHTMLEqual(f.render('administrativeunit', 'katowice'), out)
 
     def test_PLPostalCodeField(self):
-        error_format = ["Enter a postal code in the format XX-XXX."]
+        error_format = ['Enter a postal code in the format XX-XXX.']
         valid = {
-            "41-403": "41-403",
+            '41-403': '41-403',
         }
         invalid = {
-            "43--434": error_format,
+            '43--434': error_format,
         }
         self.assertFieldOutput(PLPostalCodeField, valid, invalid)
 
     def test_PLNIPField(self):
         error_format = [
-            "Enter a tax number field (NIP) in the format XXX-XXX-XX-XX, XXX-XX-XX-XXX or XXXXXXXXXX."
+            'Enter a tax number field (NIP) in the format XXX-XXX-XX-XX, XXX-XX-XX-XXX or XXXXXXXXXX.'
         ]
-        error_checksum = ["Wrong checksum for the Tax Number (NIP)."]
+        error_checksum = ['Wrong checksum for the Tax Number (NIP).']
         valid = {
-            "646-241-41-24": "6462414124",
-            "646-24-14-124": "6462414124",
-            "6462414124": "6462414124",
+            '646-241-41-24': '6462414124',
+            '646-24-14-124': '6462414124',
+            '6462414124': '6462414124',
         }
         invalid = {
-            "43-343-234-323": error_format,
-            "64-62-414-124": error_format,
-            "646-241-41-23": error_checksum,
+            '43-343-234-323': error_format,
+            '64-62-414-124': error_format,
+            '646-241-41-23': error_checksum,
         }
         self.assertFieldOutput(PLNIPField, valid, invalid)
 
     def test_PLPESELField(self):
-        error_checksum = ["Wrong checksum for the National Identification Number."]
-        error_format = ["National Identification Number consists of 11 digits."]
+        error_checksum = ['Wrong checksum for the National Identification Number.']
+        error_format = ['National Identification Number consists of 11 digits.']
         error_birthdate = [
-            "The National Identification Number contains an invalid birth date."
+            'The National Identification Number contains an invalid birth date.'
         ]
         valid = {
-            "80071610614": "80071610614",
+            '80071610614': '80071610614',
         }
         invalid = {
-            "80071610610": error_checksum,
-            "80": error_format,
-            "800716106AA": error_format,
-            "98765432121": error_birthdate,
+            '80071610610': error_checksum,
+            '80': error_format,
+            '800716106AA': error_format,
+            '98765432121': error_birthdate,
         }
         self.assertFieldOutput(PLPESELField, valid, invalid)
 
     def test_PLNationalIDCardNumberField(self):
-        error_checksum = ["Wrong checksum for the National ID Card Number."]
-        error_format = ["National ID Card Number consists of 3 letters and 6 digits."]
+        error_checksum = ['Wrong checksum for the National ID Card Number.']
+        error_format = ['National ID Card Number consists of 3 letters and 6 digits.']
         valid = {
-            "ABC123458": "ABC123458",
-            "abc123458": "ABC123458",
+            'ABC123458': 'ABC123458',
+            'abc123458': 'ABC123458',
         }
         invalid = {
-            "ABC123457": error_checksum,
-            "abc123457": error_checksum,
-            "a12Aaaaaa": error_format,
-            "AA1234443": error_format,
+            'ABC123457': error_checksum,
+            'abc123457': error_checksum,
+            'a12Aaaaaa': error_format,
+            'AA1234443': error_format,
         }
         self.assertFieldOutput(PLNationalIDCardNumberField, valid, invalid)
 
@@ -479,28 +479,28 @@ class PLLocalFlavorTests(SimpleTestCase):
         VALID_LENGTHS = (9, 14)
 
         error_checksum = [
-            "Wrong checksum for the National Business Register Number (REGON)."
+            'Wrong checksum for the National Business Register Number (REGON).'
         ]
         error_format = [
-            "National Business Register Number (REGON) consists of 9 or 14 digits."
+            'National Business Register Number (REGON) consists of 9 or 14 digits.'
         ]
         valid = {
-            "12345678512347": "12345678512347",
-            "590096454": "590096454",
+            '12345678512347': '12345678512347',
+            '590096454': '590096454',
             # A special case where the checksum == 10 and the control
             # digit == '0'
-            "391023200": "391023200",
-            "00102110000342": "00102110000342",
+            '391023200': '391023200',
+            '00102110000342': '00102110000342',
         }
         invalid = {
-            "123456784": error_checksum,
-            "12345678412342": error_checksum,
-            "590096453": error_checksum,
+            '123456784': error_checksum,
+            '12345678412342': error_checksum,
+            '590096453': error_checksum,
             # A special case where the checksum == 10,
             # but the control digit != '0'
-            "111111111": error_checksum,
-            "590096": error_format,
+            '111111111': error_checksum,
+            '590096': error_format,
             # 8, 10, 11, 12, 13, 15 digits
-            **{"1" * i: error_format for i in range(8, 16) if i not in VALID_LENGTHS},
+            **{'1' * i: error_format for i in range(8, 16) if i not in VALID_LENGTHS},
         }
         self.assertFieldOutput(PLREGONField, valid, invalid)

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -491,6 +491,9 @@ class PLLocalFlavorTests(SimpleTestCase):
             # digit == '0'
             '391023200': '391023200',
             '00102110000342': '00102110000342',
+            # A special case where the 14 digits checksum == 10 
+            # but then 9 digits checksum is not required to be 0
+            '00202110146340': '00202110146340', 
         }
         invalid = {
             '123456784': error_checksum,


### PR DESCRIPTION
- Fix regon length regex
- Fix regon validation for 14 digits

Fixed validation, because regex currently allows for strings from 9 to 14 digits, but only fixed 9 digits or 14 digits should be allowed. Additionally the checksum validation for last digit case (where modulo of checksum is equal 10) is handled incorrectly for 14 digits length string.