### PR TITLE
feat(tw): init tw with administrative division select

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -97,6 +97,7 @@ Authors
 * Martin Ogden
 * Marti Raudsepp
 * Matias Dinota
+* Matt Wang
 * Michał Sałaban
 * Mike Lissner
 * Mohammed Al-Abdulhadi

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,8 @@ Changelog
 
 New flavors:
 
-- None
+- Added local flavor for Taiwan
+  (`gh-530 <https://github.com/django/django-localflavor/pull/530>`_).
 
 New fields for existing flavors:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,6 +75,7 @@ validate Finnish social security numbers.
    * :doc:`localflavor/sk`
    * :doc:`localflavor/tn`
    * :doc:`localflavor/tr`
+   * :doc:`localflavor/tw`
    * :doc:`localflavor/us`
    * :doc:`localflavor/uy`
    * :doc:`localflavor/za`

--- a/docs/localflavor/tw.rst
+++ b/docs/localflavor/tw.rst
@@ -1,0 +1,10 @@
+Taiwan (``tw``)
+===============
+
+Forms
+-----
+
+.. automodule:: localflavor.tw.forms
+    :members:
+
+.. autodata:: localflavor.tw.tw_choices.TW_ADMINISTRATIVE_DIVISION_CHOICES

--- a/localflavor/tw/forms.py
+++ b/localflavor/tw/forms.py
@@ -1,0 +1,20 @@
+"""Taiwan-specific Form helpers."""
+
+from django.forms.fields import Select
+
+from .tw_choices import TW_ADMINISTRATIVE_DIVISION_CHOICES
+
+__all__ = (
+    'TWAdministrativeDivisionSelect',
+)
+
+
+class TWAdministrativeDivisionSelect(Select):
+    """
+    A select widget providing the list of administrative divisions in Taiwan as choices.
+
+    .. versionadded:: 5.1
+    """
+
+    def __init__(self, attrs=None):
+        super().__init__(attrs, choices=TW_ADMINISTRATIVE_DIVISION_CHOICES)

--- a/localflavor/tw/tw_choices.py
+++ b/localflavor/tw/tw_choices.py
@@ -1,0 +1,28 @@
+#: An alphabetical list of cities and counties for use as `choices` in a formfield.
+#: Based on the administrative divisions of Taiwan.
+#: https://en.wikipedia.org/wiki/List_of_administrative_divisions_of_Taiwan
+
+TW_ADMINISTRATIVE_DIVISION_CHOICES = (
+    ("changhua_county", "彰化縣"),
+    ("chiayi_city", "嘉義市"),
+    ("chiayi_county", "嘉義縣"),
+    ("hsinchu_city", "新竹市"),
+    ("hsinchu_county", "新竹縣"),
+    ("hualien_county", "花蓮縣"),
+    ("kaohsiung_city", "高雄市"),
+    ("keelung_city", "基隆市"),
+    ("kinmen_county", "金門縣"),
+    ("lienchiang_county", "連江縣"),
+    ("miaoli_county", "苗栗縣"),
+    ("nantou_county", "南投縣"),
+    ("new_taipei_city", "新北市"),
+    ("penghu_county", "澎湖縣"),
+    ("pingtung_county", "屏東縣"),
+    ("taichung_city", "台中市"),
+    ("tainan_city", "台南市"),
+    ("taipei_city", "台北市"),
+    ("taitung_county", "台東縣"),
+    ("taoyuan_city", "桃園市"),
+    ("yilan_county", "宜蘭縣"),
+    ("yunlin_county", "雲林縣"),
+)

--- a/localflavor/tw/tw_choices.py
+++ b/localflavor/tw/tw_choices.py
@@ -1,28 +1,29 @@
+from django.utils.translation import gettext_lazy as _
+
 #: An alphabetical list of cities and counties for use as `choices` in a formfield.
 #: Based on the administrative divisions of Taiwan.
 #: https://en.wikipedia.org/wiki/List_of_administrative_divisions_of_Taiwan
-
 TW_ADMINISTRATIVE_DIVISION_CHOICES = (
-    ("changhua_county", "彰化縣"),
-    ("chiayi_city", "嘉義市"),
-    ("chiayi_county", "嘉義縣"),
-    ("hsinchu_city", "新竹市"),
-    ("hsinchu_county", "新竹縣"),
-    ("hualien_county", "花蓮縣"),
-    ("kaohsiung_city", "高雄市"),
-    ("keelung_city", "基隆市"),
-    ("kinmen_county", "金門縣"),
-    ("lienchiang_county", "連江縣"),
-    ("miaoli_county", "苗栗縣"),
-    ("nantou_county", "南投縣"),
-    ("new_taipei_city", "新北市"),
-    ("penghu_county", "澎湖縣"),
-    ("pingtung_county", "屏東縣"),
-    ("taichung_city", "台中市"),
-    ("tainan_city", "台南市"),
-    ("taipei_city", "台北市"),
-    ("taitung_county", "台東縣"),
-    ("taoyuan_city", "桃園市"),
-    ("yilan_county", "宜蘭縣"),
-    ("yunlin_county", "雲林縣"),
+    ("changhua_county", _("Changhua County")),  # 彰化縣
+    ("chiayi_city", _("Chiayi City")),  # 嘉義市
+    ("chiayi_county", _("Chiayi County")),  # 嘉義縣
+    ("hsinchu_city", _("Hsinchu City")),  # 新竹市
+    ("hsinchu_county", _("Hsinchu County")),  # 新竹縣
+    ("hualien_county", _("Hualien County")),  # 花蓮縣
+    ("kaohsiung_city", _("Kaohsiung City")),  # 高雄市
+    ("keelung_city", _("Keelung City")),  # 基隆市
+    ("kinmen_county", _("Kinmen County")),  # 金門縣
+    ("lienchiang_county", _("Lienchiang County")),  # 連江縣
+    ("miaoli_county", _("Miaoli County")),  # 苗栗縣
+    ("nantou_county", _("Nantou County")),  # 南投縣
+    ("new_taipei_city", _("New Taipei City")),  # 新北市
+    ("penghu_county", _("Penghu County")),  # 澎湖縣
+    ("pingtung_county", _("Pingtung County")),  # 屏東縣
+    ("taichung_city", _("Taichung City")),  # 台中市
+    ("tainan_city", _("Tainan City")),  # 台南市
+    ("taipei_city", _("Taipei City")),  # 台北市
+    ("taitung_county", _("Taitung County")),  # 台東縣
+    ("taoyuan_city", _("Taoyuan City")),  # 桃園市
+    ("yilan_county", _("Yilan County")),  # 宜蘭縣
+    ("yunlin_county", _("Yunlin County")),  # 雲林縣
 )

--- a/tests/test_tw.py
+++ b/tests/test_tw.py
@@ -1,0 +1,33 @@
+from django.test import SimpleTestCase
+
+from localflavor.tw.forms import TWAdministrativeDivisionSelect
+
+
+class TWLocalFlavorTests(SimpleTestCase):
+    def test_TWAdministrativeDivisionSelect(self):
+        f = TWAdministrativeDivisionSelect()
+        correct_output = '''<select name="administrative_divisions">
+<option value="changhua_county">\u5f70\u5316\u7e23</option>
+<option value="chiayi_city">\u5609\u7fa9\u5e02</option>
+<option value="chiayi_county">\u5609\u7fa9\u7e23</option>
+<option value="hsinchu_city">\u65b0\u7af9\u5e02</option>
+<option value="hsinchu_county">\u65b0\u7af9\u7e23</option>
+<option value="hualien_county">\u82b1\u84ee\u7e23</option>
+<option value="kaohsiung_city">\u9ad8\u96c4\u5e02</option>
+<option value="keelung_city">\u57fa\u9686\u5e02</option>
+<option value="kinmen_county">\u91d1\u9580\u7e23</option>
+<option value="lienchiang_county">\u9023\u6c5f\u7e23</option>
+<option value="miaoli_county">\u82d7\u6817\u7e23</option>
+<option value="nantou_county">\u5357\u6295\u7e23</option>
+<option value="new_taipei_city">\u65b0\u5317\u5e02</option>
+<option value="penghu_county">\u6f8e\u6e56\u7e23</option>
+<option value="pingtung_county">\u5c4f\u6771\u7e23</option>
+<option value="taichung_city">\u53f0\u4e2d\u5e02</option>
+<option value="tainan_city">\u53f0\u5357\u5e02</option>
+<option value="taipei_city" selected="selected">\u53f0\u5317\u5e02</option>
+<option value="taitung_county">\u53f0\u6771\u7e23</option>
+<option value="taoyuan_city">\u6843\u5712\u5e02</option>
+<option value="yilan_county">\u5b9c\u862d\u7e23</option>
+<option value="yunlin_county">\u96f2\u6797\u7e23</option>
+</select>'''
+        self.assertHTMLEqual(f.render('administrative_divisions', 'taipei_city'), correct_output)

--- a/tests/test_tw.py
+++ b/tests/test_tw.py
@@ -7,27 +7,27 @@ class TWLocalFlavorTests(SimpleTestCase):
     def test_TWAdministrativeDivisionSelect(self):
         f = TWAdministrativeDivisionSelect()
         correct_output = '''<select name="administrative_divisions">
-<option value="changhua_county">\u5f70\u5316\u7e23</option>
-<option value="chiayi_city">\u5609\u7fa9\u5e02</option>
-<option value="chiayi_county">\u5609\u7fa9\u7e23</option>
-<option value="hsinchu_city">\u65b0\u7af9\u5e02</option>
-<option value="hsinchu_county">\u65b0\u7af9\u7e23</option>
-<option value="hualien_county">\u82b1\u84ee\u7e23</option>
-<option value="kaohsiung_city">\u9ad8\u96c4\u5e02</option>
-<option value="keelung_city">\u57fa\u9686\u5e02</option>
-<option value="kinmen_county">\u91d1\u9580\u7e23</option>
-<option value="lienchiang_county">\u9023\u6c5f\u7e23</option>
-<option value="miaoli_county">\u82d7\u6817\u7e23</option>
-<option value="nantou_county">\u5357\u6295\u7e23</option>
-<option value="new_taipei_city">\u65b0\u5317\u5e02</option>
-<option value="penghu_county">\u6f8e\u6e56\u7e23</option>
-<option value="pingtung_county">\u5c4f\u6771\u7e23</option>
-<option value="taichung_city">\u53f0\u4e2d\u5e02</option>
-<option value="tainan_city">\u53f0\u5357\u5e02</option>
-<option value="taipei_city" selected="selected">\u53f0\u5317\u5e02</option>
-<option value="taitung_county">\u53f0\u6771\u7e23</option>
-<option value="taoyuan_city">\u6843\u5712\u5e02</option>
-<option value="yilan_county">\u5b9c\u862d\u7e23</option>
-<option value="yunlin_county">\u96f2\u6797\u7e23</option>
+<option value="changhua_county">Changhua County</option>
+<option value="chiayi_city">Chiayi City</option>
+<option value="chiayi_county">Chiayi County</option>
+<option value="hsinchu_city">Hsinchu City</option>
+<option value="hsinchu_county">Hsinchu County</option>
+<option value="hualien_county">Hualien County</option>
+<option value="kaohsiung_city">Kaohsiung City</option>
+<option value="keelung_city">Keelung City</option>
+<option value="kinmen_county">Kinmen County</option>
+<option value="lienchiang_county">Lienchiang County</option>
+<option value="miaoli_county">Miaoli County</option>
+<option value="nantou_county">Nantou County</option>
+<option value="new_taipei_city">New Taipei City</option>
+<option value="penghu_county">Penghu County</option>
+<option value="pingtung_county">Pingtung County</option>
+<option value="taichung_city">Taichung City</option>
+<option value="tainan_city">Tainan City</option>
+<option value="taipei_city" selected="selected">Taipei City</option>
+<option value="taitung_county">Taitung County</option>
+<option value="taoyuan_city">Taoyuan City</option>
+<option value="yilan_county">Yilan County</option>
+<option value="yunlin_county">Yunlin County</option>
 </select>'''
         self.assertHTMLEqual(f.render('administrative_divisions', 'taipei_city'), correct_output)


### PR DESCRIPTION
- Add new flavor for Taiwan (`tw`)
- Add `TWAdministrativeDivisionSelect`

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

**New Fields Only**

- [x] Prefix the country code to all fields.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [ ] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [x] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [x] Add documentation for all fields.
