### PR TITLE
feat(localization): Add ukrainian 🇺🇦 localization for IBAN functionality

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,7 @@ Modifications to existing flavors:
 
 Other changes:
 
-- None
+- Added Ukrainian 🇺🇦 localization for IBAN functionality
 
 
 5.0   (2025-05-21)

--- a/localflavor/locale/uk/LC_MESSAGES/django.po
+++ b/localflavor/locale/uk/LC_MESSAGES/django.po
@@ -3826,22 +3826,22 @@ msgstr ""
 
 #, python-format
 msgid "%s is not a valid character for IBAN."
-msgstr ""
+msgstr "%s не є допустимим символом для IBAN."
 
 #, python-format
 msgid "%(country_code)s IBANs must contain %(number)s characters."
-msgstr ""
+msgstr "IBAN-коди %(country_code)s повинні містити %(number)s символів."
 
 #, python-format
 msgid "%s is not a valid country code for IBAN."
-msgstr ""
+msgstr "%s не є дійсним кодом країни для IBAN."
 
 #, python-format
 msgid "%s IBANs are not allowed in this field."
-msgstr ""
+msgstr "%s IBAN не допускаються в цьому полі."
 
 msgid "Not a valid IBAN."
-msgstr ""
+msgstr "Недійсний IBAN."
 
 msgid "BIC codes have either 8 or 11 characters."
 msgstr ""
@@ -3852,7 +3852,7 @@ msgstr ""
 
 #, python-format
 msgid "%s is not a valid country code."
-msgstr ""
+msgstr "%s не є дійсним кодом країни."
 
 msgid "Not a valid EAN code."
 msgstr ""


### PR DESCRIPTION
Hi there,
I've already fixed some issue on ukrainian localization like in that PR https://github.com/django/django-localflavor/pull/508
This PR brings localization for some IBAN functionality.

The only think I did not do is compilemessages. If you can instruct me how to do in that repo - I will do with pleasure :) 

**All Changes**

- [X] Add an entry to the docs/changelog.rst describing the change.

