### PR TITLE
Update validator to allow new Brazilian CNPJ alphanumeric format

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -117,6 +117,7 @@ Authors
 * Rael Max
 * Ramiro Morales
 * Raphael Michel
+* Renne Rocha
 * Rolf Erik Lekang
 * Russell Keith-Magee
 * Santosh Bhattarai

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ Modifications to existing flavors:
   (`gh-529 <https://github.com/django/django-localflavor/pull/529>`_).
 - Update SI postal codes
   (`gh-531 <https://github.com/django/django-localflavor/pull/531>`_).
+- Update BR CNPJ validator to accept new alphanumeric format
+  (`gh-533 <https://github.com/django/django-localflavor/pull/533>`_).
 - Added Falkland Islands (Malvinas), Honduras, Oman, Somalia and Yemen to IBAN_COUNTRY_CODE_LENGTH dict based on
   version 101 of the IBAN registry document from December 2025. The minium version of python-stdnum is now 2.2.
   (`gh-538 <https://github.com/django/django-localflavor/pull/538>`_),

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -88,15 +88,7 @@ class BRCNPJField(CharField):
     A form field that validates input as `Brazilian CNPJ`_.
 
     Input can either be of the format XX.XXX.XXX/XXXX-XX or be a group of 14
-    digits.
-
-    If you want to use the long format only, you can specify:
-        brcnpj_field = BRCNPJField(min_length=16)
-
-    If you want to use the short format, you can specify:
-        brcnpj_field = BRCNPJField(max_length=14)
-
-    Otherwise both formats will be valid.
+    digits or upper case letters.
 
     .. _Brazilian CNPJ: http://en.wikipedia.org/wiki/National_identification_number#Brazil
     .. versionchanged:: 1.4
@@ -106,12 +98,11 @@ class BRCNPJField(CharField):
     """
 
     default_error_messages = {
-        'invalid': _("Invalid CNPJ number."),
-        'max_digits': _("This field requires at least 14 digits"),
+        "invalid": _("Invalid CNPJ number."),
     }
 
-    def __init__(self, min_length=14, max_length=18, **kwargs):
-        super().__init__(max_length=max_length, min_length=min_length, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.validators.append(BRCNPJValidator())
 
 

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -101,8 +101,8 @@ class BRCNPJField(CharField):
         "invalid": _("Invalid CNPJ number."),
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, min_length=14, max_length=18, **kwargs):
+        super().__init__(max_length=max_length, min_length=min_length, **kwargs)
         self.validators.append(BRCNPJValidator())
 
 

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -88,17 +88,27 @@ class BRCNPJField(CharField):
     A form field that validates input as `Brazilian CNPJ`_.
 
     Input can either be of the format XX.XXX.XXX/XXXX-XX or be a group of 14
-    digits or upper case letters.
+    digits or upper case letters. This field is already compliant with the `July 2026`_
+    change that allows the use of alphanumeric characters in the CNPJ.
+
+    If you want to use the long format only (XXXXXXX/XXXX-XX or XX.XXX.XXX/XXXX-XX), you can specify:
+        brcnpj_field = BRCNPJField(min_length=16)
+
+    If you want to use the short format only (XXXXXXXXXXXXXX), you can specify:
+        brcnpj_field = BRCNPJField(max_length=14)
+
+    Otherwise all formats will be valid.
 
     .. _Brazilian CNPJ: http://en.wikipedia.org/wiki/National_identification_number#Brazil
+    .. _July 2026: https://www.gov.br/receitafederal/pt-br/acesso-a-informacao/acoes-e-programas/programas-e-atividades/cnpj-alfanumerico
     .. versionchanged:: 1.4
     .. versionchanged:: 2.2
         Use BRCNPJValidator to centralize validation logic and share with equivalent model field.
         More details at: https://github.com/django/django-localflavor/issues/334
     """
-
     default_error_messages = {
-        "invalid": _("Invalid CNPJ number."),
+        'invalid': _("Invalid CNPJ number."),
+        'max_digits': _("This field requires at least 14 digits"),
     }
 
     def __init__(self, min_length=14, max_length=18, **kwargs):

--- a/localflavor/br/forms.py
+++ b/localflavor/br/forms.py
@@ -105,6 +105,8 @@ class BRCNPJField(CharField):
     .. versionchanged:: 2.2
         Use BRCNPJValidator to centralize validation logic and share with equivalent model field.
         More details at: https://github.com/django/django-localflavor/issues/334
+    .. versionchanged:: 5.1
+        Updated to allow the use of alphanumeric characters.
     """
     default_error_messages = {
         'invalid': _("Invalid CNPJ number."),
@@ -114,6 +116,12 @@ class BRCNPJField(CharField):
     def __init__(self, min_length=14, max_length=18, **kwargs):
         super().__init__(max_length=max_length, min_length=min_length, **kwargs)
         self.validators.append(BRCNPJValidator())
+
+    def to_python(self, value):
+        value = super().to_python(value)
+        if value is not None:
+            return value.upper()
+        return value
 
 
 def mod_97_base10(value):

--- a/localflavor/br/models.py
+++ b/localflavor/br/models.py
@@ -11,7 +11,7 @@ class BRStateField(CharField):
     A model field for states of Brazil.
 
     Forms represent it as a :class:`~localflavor.br.forms.BRStateSelect` field.
-    
+
     """
 
     description = _("State of Brazil (two uppercase letters)")
@@ -47,7 +47,7 @@ class BRCPFField(CharField):
         kwargs['max_length'] = 14
         super().__init__(*args, **kwargs)
         self.validators.append(validators.BRCPFValidator())
-    
+
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.BRCPFField}
         defaults.update(kwargs)
@@ -62,6 +62,8 @@ class BRCNPJField(CharField):
     Forms represent it as a :class:`~localflavor.br.forms.BRCNPJField` field.
 
     .. versionadded:: 2.2
+    .. versionchanged:: 5.1
+        Updated to allow the use of alphanumeric characters.
     """
 
     description = _("CNPJ Document")
@@ -75,6 +77,13 @@ class BRCNPJField(CharField):
         defaults = {'form_class': forms.BRCNPJField}
         defaults.update(kwargs)
         return super().formfield(**defaults)
+
+    def to_python(self, value):
+        value = super().to_python(value)
+        if value is not None:
+            return value.upper()
+        return value
+
 
 class BRPostalCodeField(CharField):
     """

--- a/localflavor/br/validators.py
+++ b/localflavor/br/validators.py
@@ -1,3 +1,4 @@
+import itertools
 import re
 
 from django.core.exceptions import ValidationError
@@ -5,7 +6,6 @@ from django.core.validators import RegexValidator
 from django.utils.translation import gettext_lazy as _
 
 postal_code_re = re.compile(r'^\d{5}-\d{3}$')
-cnpj_digits_re = re.compile(r'^(\d{2})[.-]?(\d{3})[.-]?(\d{3})/(\d{4})-(\d{2})$')
 cpf_digits_re = re.compile(r'^(\d{3})\.(\d{3})\.(\d{3})-(\d{2})$')
 
 
@@ -34,35 +34,46 @@ class BRCNPJValidator(RegexValidator):
     .. versionadded:: 2.2
     """
 
+    CNPJ_RE = re.compile(r'^([A-Z0-9]{2}).?([A-Z0-9]{3}).?([A-Z0-9]{3})\/?([A-Z0-9]{4})-?(\d{2})$')
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args,
-            regex=cnpj_digits_re,
+            regex=self.CNPJ_RE,
             message=_("Invalid CNPJ number."),
             **kwargs
         )
 
+    def _get_check_digit(self, cnpj):
+        '''
+        Based on official documentation at:
+        https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/documentos-tecnicos/cnpj
+        '''
+        def _get_digit(value):
+            values = [ord(c) - 48 for c in value][::-1]
+            remainder = (
+                sum(
+                    [x * y for x, y in list(zip(values, itertools.cycle(range(2, 10))))]
+                )
+                % 11
+            )
+            check_digit = 0 if remainder in (0, 1) else 11 - remainder
+            return str(check_digit)
+
+        first_check_digit = _get_digit(cnpj)
+        second_check_digit = _get_digit(cnpj + first_check_digit)
+        return f"{first_check_digit}{second_check_digit}"
+
     def __call__(self, value):
-        orig_dv = value[-2:]
+        super().__call__(value)
 
-        if not value.isdigit():
-            cnpj = cnpj_digits_re.search(value)
-            if cnpj:
-                value = ''.join(cnpj.groups())
-            else:
-                raise ValidationError(self.message, code='invalid')
+        # After this point, only digits and uppercase letters are important
+        cleaned_value = re.sub(r"[^A-Z0-9]", "", value)
 
-        if len(value) != 14:
-            raise ValidationError(self.message, code='max_digits')
-
-        new_1dv = sum([i * int(value[idx]) for idx, i in enumerate(list(range(5, 1, -1)) + list(range(9, 1, -1)))])
-        new_1dv = dv_maker(new_1dv % 11)
-        value = value[:-2] + str(new_1dv) + value[-1]
-        new_2dv = sum([i * int(value[idx]) for idx, i in enumerate(list(range(6, 1, -1)) + list(range(9, 1, -1)))])
-        new_2dv = dv_maker(new_2dv % 11)
-        value = value[:-1] + str(new_2dv)
-        if value[-2:] != orig_dv:
-            raise ValidationError(self.message, code='invalid')
+        input_check_digit = cleaned_value[-2:]
+        calculated_check_digit = self._get_check_digit(cleaned_value[:-2])
+        if input_check_digit != calculated_check_digit:
+            raise ValidationError(self.message, code="invalid")
 
 
 class BRCPFValidator(RegexValidator):

--- a/localflavor/br/validators.py
+++ b/localflavor/br/validators.py
@@ -32,6 +32,8 @@ class BRCNPJValidator(RegexValidator):
     Validator for brazilian CNPJ.
 
     .. versionadded:: 2.2
+    .. versionchanged:: 5.1
+        Updated to allow the use of alphanumeric characters.
     """
 
     CNPJ_RE = re.compile(r'^([A-Z0-9]{2}).?([A-Z0-9]{3}).?([A-Z0-9]{3})\/?([A-Z0-9]{4})-?(\d{2})$')
@@ -45,10 +47,10 @@ class BRCNPJValidator(RegexValidator):
         )
 
     def _get_check_digit(self, cnpj):
-        '''
+        """
         Based on official documentation at:
         https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/documentos-tecnicos/cnpj
-        '''
+        """
         def _get_digit(value):
             values = [ord(c) - 48 for c in value][::-1]
             remainder = (

--- a/tests/test_br/test_br.py
+++ b/tests/test_br/test_br.py
@@ -32,6 +32,7 @@ class BRLocalFlavorTests(SimpleTestCase):
 
     def test_BRCNPJField(self):
         valid_inputs = {
+            '64132916/0001-88': '64132916/0001-88',
             '64.132.916/0001-88': '64.132.916/0001-88',
             '12.ABC.345/01DE-35': '12.ABC.345/01DE-35',
             'AB.CCC.DEF/GHIJ-08': 'AB.CCC.DEF/GHIJ-08',
@@ -43,6 +44,11 @@ class BRLocalFlavorTests(SimpleTestCase):
             '03634711000106': '03634711000106',
         }
         invalid_inputs = {
+            '../-12345678901234': [BRCNPJField.default_error_messages['invalid'], ],
+            '12-345-678/9012-10': [BRCNPJField.default_error_messages['invalid'], ],
+            '12.345.678/9012-10': [BRCNPJField.default_error_messages['invalid'], ],
+            '12345678/9012-10': [BRCNPJField.default_error_messages['invalid'], ],
+            '64.132.916/0001-XX': [BRCNPJField.default_error_messages['invalid'], ],
             '64.132.916/0001-80': [BRCNPJField.default_error_messages['invalid'], ],
             '64,132,916/0001-80': [BRCNPJField.default_error_messages['invalid'], ],
             '641329160001AA': [BRCNPJField.default_error_messages['invalid'], ],

--- a/tests/test_br/test_br.py
+++ b/tests/test_br/test_br.py
@@ -31,50 +31,31 @@ class BRLocalFlavorTests(SimpleTestCase):
                 self.assertEqual(form.errors['postal_code'], error)
 
     def test_BRCNPJField(self):
-        error_format = {
-            'invalid': ['Invalid CNPJ number.'],
-            'only_long_version': ['Ensure this value has at least 16 characters (it has 14).'],
-            # The long version can be 16 or 18 characters long so actual error message is set dynamically when the
-            # invalid_long dict is generated.
-            'only_short_version': ['Ensure this value has at most 14 characters (it has %s).'],
-        }
-
-        long_version_valid = {
+        valid_inputs = {
             '64.132.916/0001-88': '64.132.916/0001-88',
-            '64-132-916/0001-88': '64-132-916/0001-88',
-            '64132916/0001-88': '64132916/0001-88',
-        }
-        short_version_valid = {
+            '12.ABC.345/01DE-35': '12.ABC.345/01DE-35',
+            'AB.CCC.DEF/GHIJ-08': 'AB.CCC.DEF/GHIJ-08',
             '64132916000188': '64132916000188',
+            '12ABC34501DE35': '12ABC34501DE35',
+            'ABCDEFGHIJKL80': 'ABCDEFGHIJKL80',
+            'MNOPQRSTUVWX50': 'MNOPQRSTUVWX50',
+            'YZOPQRSTUVWX76': 'YZOPQRSTUVWX76',
+            '03634711000106': '03634711000106',
         }
-        valid = long_version_valid.copy()
-        valid.update(short_version_valid)
-
-        invalid = {
-            '../-12345678901234': error_format['invalid'],
-            '12-345-678/9012-10': error_format['invalid'],
-            '12.345.678/9012-10': error_format['invalid'],
-            '12345678/9012-10': error_format['invalid'],
-            '64.132.916/0001-XX': error_format['invalid'],
+        invalid_inputs = {
+            '64.132.916/0001-80': [BRCNPJField.default_error_messages['invalid'], ],
+            '64,132,916/0001-80': [BRCNPJField.default_error_messages['invalid'], ],
+            '641329160001AA': [BRCNPJField.default_error_messages['invalid'], ],
+            '2ABC34501DE35': [BRCNPJField.default_error_messages['invalid'], ],
+            '2ABC34501DE35': [BRCNPJField.default_error_messages['invalid'], ],
+            '3634711000106': [BRCNPJField.default_error_messages['invalid'], ],
+            '12.abc.345/01de-35': [BRCNPJField.default_error_messages['invalid'], ],
         }
-        self.assertFieldOutput(BRCNPJField, valid, invalid)
-
-        # The short versions should be invalid when 'min_length=16' passed to the field.
-        invalid_short = dict([(k, error_format['only_long_version']) for k in short_version_valid.keys()])
-        self.assertFieldOutput(BRCNPJField, long_version_valid, invalid_short, field_kwargs={'min_length': 16})
-
-        # The long versions should be invalid when 'max_length=14' passed to the field.
-        invalid_long = dict([(k, [error_format['only_short_version'][0] % len(k)]) for k in long_version_valid.keys()])
-        self.assertFieldOutput(BRCNPJField, short_version_valid, invalid_long, field_kwargs={'max_length': 14})
-
-        for cnpj, invalid_msg in invalid.items():
-            with self.subTest(cnpj=cnpj, invalid_msg=invalid_msg):
-                form = BRPersonProfileForm({
-                    'cnpj': cnpj
-                })
-
-                self.assertFalse(form.is_valid())
-                self.assertEqual(form.errors['cnpj'], invalid_msg)
+        self.assertFieldOutput(
+            BRCNPJField,
+            valid=valid_inputs,
+            invalid=invalid_inputs,
+        )
 
     def test_BRCPFField(self):
         error_format = ['Invalid CPF number.']

--- a/tests/test_br/test_br.py
+++ b/tests/test_br/test_br.py
@@ -43,14 +43,14 @@ class BRLocalFlavorTests(SimpleTestCase):
             '64.132.916/0001-88': '64.132.916/0001-88',
             '64132916/0001-88': '64132916/0001-88',
             '12.ABC.345/01DE-35': '12.ABC.345/01DE-35',
+            '12.abc.345/01de-35': '12.ABC.345/01DE-35',
             'AB.CCC.DEF/GHIJ-08': 'AB.CCC.DEF/GHIJ-08',
-
         }
         short_version_valid = {
             '64132916000188': '64132916000188',
-            '64132916000188': '64132916000188',
             '12ABC34501DE35': '12ABC34501DE35',
             'ABCDEFGHIJKL80': 'ABCDEFGHIJKL80',
+            'abcdefghijkl80': 'ABCDEFGHIJKL80',
             'MNOPQRSTUVWX50': 'MNOPQRSTUVWX50',
             'YZOPQRSTUVWX76': 'YZOPQRSTUVWX76',
             '03634711000106': '03634711000106',
@@ -66,11 +66,15 @@ class BRLocalFlavorTests(SimpleTestCase):
             '64.132.916/0001-XX': error_format['invalid'],
             '64.132.916/0001-80': error_format['invalid'],
             '64,132,916/0001-80': error_format['invalid'],
-            '641329160001aa': error_format['invalid'],
             '2ABC34501DEF35': error_format['invalid'],
-            '12.abc.345/01de-35': error_format['invalid'],
         }
         self.assertFieldOutput(BRCNPJField, valid, invalid)
+
+        # Test valid inputs for model field.
+        cnpj_model_field = models.BRCNPJField()
+        for input, output in valid.items():
+            with self.subTest(input=input, output=output):
+                self.assertEqual(cnpj_model_field.clean(input, None), output)
 
         # The short versions should be invalid when 'min_length=16' passed to the field.
         invalid_short = dict([(k, error_format['only_long_version']) for k in short_version_valid.keys()])
@@ -241,6 +245,7 @@ class BRLocalFlavorTests(SimpleTestCase):
                 form = BRPersonProfileForm(case)
                 self.assertTrue(form.is_valid())
 
+
 class BRLocalFlavorModelFormTests (TestCase):
     def setUp(self):
         self.form = BRPersonProfileForm({
@@ -249,7 +254,7 @@ class BRLocalFlavorModelFormTests (TestCase):
             'postal_code':'12345-123',
         })
 
-    def test_BRCPFFiedlHtml(self):
+    def test_BRCPFFieldHtml(self):
         name = 'cpf'
         value = '111.111.111-11'
         model_form_field = self.form.fields[name]
@@ -257,7 +262,7 @@ class BRLocalFlavorModelFormTests (TestCase):
         self.assertTrue('minlength="11"' in model_form_field_render)
         self.assertTrue('maxlength="14"' in model_form_field_render)
 
-    def test_BRCNPJFiedlHtml(self):
+    def test_BRCNPJFieldHtml(self):
         name = 'cnpj'
         value = '64-132-916/0001-88'
         model_form_field = self.form.fields[name]
@@ -265,13 +270,14 @@ class BRLocalFlavorModelFormTests (TestCase):
         self.assertTrue('minlength="14"' in model_form_field_render)
         self.assertTrue('maxlength="18"' in model_form_field_render)
 
-    def test_BRPostalCodeFiedlHtml(self):
+    def test_BRPostalCodeFieldHtml(self):
         name = 'postal_code'
         value = '12345-123'
         model_form_field = self.form.fields[name]
         model_form_field_render = model_form_field.widget.render(name,value)
         self.assertTrue('minlength="8"' in model_form_field_render)
         self.assertTrue('maxlength="9"' in model_form_field_render)
+
 
 class BRLocalFlavorModelTests(SimpleTestCase):
 

--- a/tests/test_br/test_br.py
+++ b/tests/test_br/test_br.py
@@ -31,11 +31,23 @@ class BRLocalFlavorTests(SimpleTestCase):
                 self.assertEqual(form.errors['postal_code'], error)
 
     def test_BRCNPJField(self):
-        valid_inputs = {
-            '64132916/0001-88': '64132916/0001-88',
+        error_format = {
+            'invalid': ['Invalid CNPJ number.'],
+            'only_long_version': ['Ensure this value has at least 16 characters (it has 14).'],
+            # The long version can be 16 or 18 characters long so actual error message is set dynamically when the
+            # invalid_long dict is generated.
+            'only_short_version': ['Ensure this value has at most 14 characters (it has %s).'],
+        }
+
+        long_version_valid = {
             '64.132.916/0001-88': '64.132.916/0001-88',
+            '64132916/0001-88': '64132916/0001-88',
             '12.ABC.345/01DE-35': '12.ABC.345/01DE-35',
             'AB.CCC.DEF/GHIJ-08': 'AB.CCC.DEF/GHIJ-08',
+
+        }
+        short_version_valid = {
+            '64132916000188': '64132916000188',
             '64132916000188': '64132916000188',
             '12ABC34501DE35': '12ABC34501DE35',
             'ABCDEFGHIJKL80': 'ABCDEFGHIJKL80',
@@ -43,25 +55,39 @@ class BRLocalFlavorTests(SimpleTestCase):
             'YZOPQRSTUVWX76': 'YZOPQRSTUVWX76',
             '03634711000106': '03634711000106',
         }
-        invalid_inputs = {
-            '../-12345678901234': [BRCNPJField.default_error_messages['invalid'], ],
-            '12-345-678/9012-10': [BRCNPJField.default_error_messages['invalid'], ],
-            '12.345.678/9012-10': [BRCNPJField.default_error_messages['invalid'], ],
-            '12345678/9012-10': [BRCNPJField.default_error_messages['invalid'], ],
-            '64.132.916/0001-XX': [BRCNPJField.default_error_messages['invalid'], ],
-            '64.132.916/0001-80': [BRCNPJField.default_error_messages['invalid'], ],
-            '64,132,916/0001-80': [BRCNPJField.default_error_messages['invalid'], ],
-            '641329160001AA': [BRCNPJField.default_error_messages['invalid'], ],
-            '2ABC34501DE35': [BRCNPJField.default_error_messages['invalid'], ],
-            '2ABC34501DE35': [BRCNPJField.default_error_messages['invalid'], ],
-            '3634711000106': [BRCNPJField.default_error_messages['invalid'], ],
-            '12.abc.345/01de-35': [BRCNPJField.default_error_messages['invalid'], ],
+        valid = long_version_valid.copy()
+        valid.update(short_version_valid)
+
+        invalid = {
+            '../-12345678901234': error_format['invalid'],
+            '12-345-678/9012-10': error_format['invalid'],
+            '12.345.678/9012-10': error_format['invalid'],
+            '12345678/9012-10': error_format['invalid'],
+            '64.132.916/0001-XX': error_format['invalid'],
+            '64.132.916/0001-80': error_format['invalid'],
+            '64,132,916/0001-80': error_format['invalid'],
+            '641329160001aa': error_format['invalid'],
+            '2ABC34501DEF35': error_format['invalid'],
+            '12.abc.345/01de-35': error_format['invalid'],
         }
-        self.assertFieldOutput(
-            BRCNPJField,
-            valid=valid_inputs,
-            invalid=invalid_inputs,
-        )
+        self.assertFieldOutput(BRCNPJField, valid, invalid)
+
+        # The short versions should be invalid when 'min_length=16' passed to the field.
+        invalid_short = dict([(k, error_format['only_long_version']) for k in short_version_valid.keys()])
+        self.assertFieldOutput(BRCNPJField, long_version_valid, invalid_short, field_kwargs={'min_length': 16})
+
+        # The long versions should be invalid when 'max_length=14' passed to the field.
+        invalid_long = dict([(k, [error_format['only_short_version'][0] % len(k)]) for k in long_version_valid.keys()])
+        self.assertFieldOutput(BRCNPJField, short_version_valid, invalid_long, field_kwargs={'max_length': 14})
+
+        for cnpj, invalid_msg in invalid.items():
+            with self.subTest(cnpj=cnpj, invalid_msg=invalid_msg):
+                form = BRPersonProfileForm({
+                    'cnpj': cnpj
+                })
+
+                self.assertFalse(form.is_valid())
+                self.assertEqual(form.errors['cnpj'], invalid_msg)
 
     def test_BRCPFField(self):
         error_format = ['Invalid CPF number.']


### PR DESCRIPTION
In July-2026, alphanumeric CNPJ will be allowed:
https://www.gov.br/receitafederal/pt-br/acesso-a-informacao/acoes-e-programas/programas-e-atividades/cnpj-alfanumerico

Given that the new format is 100% compatible with the current format, we can update the validators now, making the transition smoother for users of the library.

Thanks for your contribution!

A checklist is included below which helps us keep the code contributions
consistent and helps speed up the review process. You can add additional
commits to your pull request if you haven't met all of these points on your
first version.

**All Changes**

- [X] Add an entry to the docs/changelog.rst describing the change.

- [X] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

**New Fields Only**

- [ ] Prefix the country code to all fields.

- [ ] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [ ] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [ ] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [ ] Add `.. versionadded:: <next-version>` comment markers to new
      localflavors.

- [ ] Add documentation for all fields.
