### PR TITLE
Add US ITIN, ATIN, and combined TIN form and model fields

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -5,6 +5,7 @@ Authors
 * Abdellah El Youssfi Alaoui
 * Adam Rurański
 * Adam Taylor
+* Adam Yuhasz
 * Adnane Belmadiaf
 * Adonys Alea Boffill
 * Adrian Holovaty

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,11 @@ New flavors:
 
 New fields for existing flavors:
 
-- None
+- US: Added ``USIndividualTaxpayerIdentificationNumberField``,
+  ``USAdoptionTaxpayerIdentificationNumberField``, and
+  ``USTaxpayerIdentificationNumberField`` form and model fields for validating
+  ITINs, ATINs, and any valid U.S. taxpayer identification number (SSN, ITIN,
+  or ATIN).
 
 Modifications to existing flavors:
 

--- a/localflavor/us/forms.py
+++ b/localflavor/us/forms.py
@@ -8,6 +8,16 @@ from django.utils.translation import gettext_lazy as _
 
 ssn_re = re.compile(r"^(?P<area>\d{3})[-\ ]?(?P<group>\d{2})[-\ ]?(?P<serial>\d{4})$")
 
+_ITIN_GROUP_RANGES = (
+    range(70, 89),   # 70–88
+    range(90, 93),   # 90–92
+    range(94, 100),  # 94–99
+)
+
+
+def _is_itin_group(group_int):
+    return any(group_int in r for r in _ITIN_GROUP_RANGES)
+
 
 class USZipCodeField(RegexField):
     """
@@ -39,7 +49,39 @@ class USZipCodeField(RegexField):
         return value.strip()
 
 
-class USSocialSecurityNumberField(CharField):
+class _USFederalIDBaseField(CharField):
+    """
+    Private base class for US federal identification numbers (SSN, ITIN, ATIN).
+
+    Handles shared validation:
+
+        * Conforms to the XXX-XX-XXXX format.
+        * No group consists entirely of zeroes.
+        * Normalizes output to XXX-XX-XXXX.
+
+    Subclasses must implement ``_validate_components(area, group, serial) -> bool``.
+    """
+
+    def clean(self, value):
+        value = super().clean(value)
+        if value in self.empty_values:
+            return value
+        match = re.match(ssn_re, value)
+        if not match:
+            raise ValidationError(self.error_messages['invalid'], code='invalid')
+        area, group, serial = match.group('area'), match.group('group'), match.group('serial')
+
+        # No blocks of all zeroes.
+        if area == '000' or group == '00' or serial == '0000':
+            raise ValidationError(self.error_messages['invalid'], code='invalid')
+
+        if not self._validate_components(area, group, serial):
+            raise ValidationError(self.error_messages['invalid'], code='invalid')
+
+        return '%s-%s-%s' % (area, group, serial)
+
+
+class USSocialSecurityNumberField(_USFederalIDBaseField):
     """
     A United States Social Security number.
 
@@ -61,27 +103,95 @@ class USSocialSecurityNumberField(CharField):
         'invalid': _('Enter a valid U.S. Social Security number in XXX-XX-XXXX format.'),
     }
 
-    def clean(self, value):
-        value = super().clean(value)
-        if value in self.empty_values:
-            return value
-        match = re.match(ssn_re, value)
-        if not match:
-            raise ValidationError(self.error_messages['invalid'], code='invalid')
-        area, group, serial = match.groupdict()['area'], match.groupdict()['group'], match.groupdict()['serial']
-
-        # First pass: no blocks of all zeroes.
-        if area == '000' or group == '00' or serial == '0000':
-            raise ValidationError(self.error_messages['invalid'], code='invalid')
-
-        # Second pass: promotional and otherwise permanently invalid numbers.
+    def _validate_components(self, area, group, serial):
         # pylint: disable=too-many-boolean-expressions
         if (area == '666' or
                 area.startswith('9') or
                 (area == '078' and group == '05' and serial == '1120') or
                 (area == '219' and group == '09' and serial == '9999')):
-            raise ValidationError(self.error_messages['invalid'], code='invalid')
-        return '%s-%s-%s' % (area, group, serial)
+            return False
+        return True
+
+
+class _USTINBaseField(_USFederalIDBaseField):
+    """
+    Private base class for US taxpayer identification numbers (ITIN, ATIN).
+
+    Area number must start with 9. Subclasses must implement
+    ``_validate_group(group_int) -> bool``.
+    """
+
+    def _validate_components(self, area, group, serial):
+        if not area.startswith('9'):
+            return False
+        return self._validate_group(int(group))
+
+
+class USIndividualTaxpayerIdentificationNumberField(_USTINBaseField):
+    """
+    A United States Individual Taxpayer Identification Number (ITIN).
+
+    Checks the following rules to determine whether the number is valid:
+
+        * Conforms to the XXX-XX-XXXX format.
+        * No group consists entirely of zeroes.
+        * The area number starts with 9 (range 900-999).
+        * The group number falls within IRS-defined ITIN ranges:
+          70-88, 90-92, or 94-99.
+
+    .. versionadded:: 5.1
+    """
+
+    default_error_messages = {
+        'invalid': _('Enter a valid U.S. Individual Taxpayer Identification Number in XXX-XX-XXXX format.'),
+    }
+
+    def _validate_group(self, group_int):
+        return _is_itin_group(group_int)
+
+
+class USAdoptionTaxpayerIdentificationNumberField(_USTINBaseField):
+    """
+    A United States Adoption Taxpayer Identification Number (ATIN).
+
+    Checks the following rules to determine whether the number is valid:
+
+        * Conforms to the XXX-XX-XXXX format.
+        * No group consists entirely of zeroes.
+        * The area number starts with 9 (range 900-999).
+        * The group number is exactly 93 (range 900-93-0000 through 999-93-9999).
+
+    .. versionadded:: 5.1
+    """
+
+    default_error_messages = {
+        'invalid': _('Enter a valid U.S. Adoption Taxpayer Identification Number in XXX-XX-XXXX format.'),
+    }
+
+    def _validate_group(self, group_int):
+        return group_int == 93
+
+
+class USTaxpayerIdentificationNumberField(_USFederalIDBaseField):
+    """
+    A United States taxpayer identification number (SSN, ITIN, or ATIN).
+
+    Accepts any number that is a valid Social Security number, Individual
+    Taxpayer Identification Number, or Adoption Taxpayer Identification Number.
+
+    .. versionadded:: 5.1
+    """
+
+    default_error_messages = {
+        'invalid': _('Enter a valid U.S. taxpayer identification number in XXX-XX-XXXX format.'),
+    }
+
+    def _validate_components(self, area, group, serial):
+        return (
+            USSocialSecurityNumberField()._validate_components(area, group, serial) or
+            USIndividualTaxpayerIdentificationNumberField()._validate_components(area, group, serial) or
+            USAdoptionTaxpayerIdentificationNumberField()._validate_components(area, group, serial)
+        )
 
 
 class USStateField(CharField):

--- a/localflavor/us/models.py
+++ b/localflavor/us/models.py
@@ -1,7 +1,10 @@
 from django.db.models import CharField
 from django.utils.translation import gettext_lazy as _
 
+from .forms import USAdoptionTaxpayerIdentificationNumberField as USATINFormField
+from .forms import USIndividualTaxpayerIdentificationNumberField as USITINFormField
 from .forms import USSocialSecurityNumberField as USSocialSecurityNumberFieldFormField
+from .forms import USTaxpayerIdentificationNumberField as USTINFormField
 from .forms import USZipCodeField as USZipCodeFormField
 from .us_states import STATE_CHOICES, USPS_CHOICES
 
@@ -95,5 +98,69 @@ class USSocialSecurityNumberField(CharField):
 
     def formfield(self, **kwargs):
         defaults = {'form_class': USSocialSecurityNumberFieldFormField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
+
+
+class USIndividualTaxpayerIdentificationNumberField(CharField):
+    """
+    A model field that stores an ITIN in the format ``XXX-XX-XXXX``.
+
+    Forms represent it as a ``forms.USIndividualTaxpayerIdentificationNumberField`` field.
+
+    .. versionadded:: 5.1
+    """
+
+    description = _("Individual Taxpayer Identification Number")
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 11
+        super().__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': USITINFormField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
+
+
+class USAdoptionTaxpayerIdentificationNumberField(CharField):
+    """
+    A model field that stores an ATIN in the format ``XXX-XX-XXXX``.
+
+    Forms represent it as a ``forms.USAdoptionTaxpayerIdentificationNumberField`` field.
+
+    .. versionadded:: 5.1
+    """
+
+    description = _("Adoption Taxpayer Identification Number")
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 11
+        super().__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': USATINFormField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
+
+
+class USTaxpayerIdentificationNumberField(CharField):
+    """
+    A model field that stores any valid U.S. taxpayer identification number
+    (SSN, ITIN, or ATIN) in the format ``XXX-XX-XXXX``.
+
+    Forms represent it as a ``forms.USTaxpayerIdentificationNumberField`` field.
+
+    .. versionadded:: 5.1
+    """
+
+    description = _("Taxpayer Identification Number")
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 11
+        super().__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': USTINFormField}
         defaults.update(kwargs)
         return super().formfield(**defaults)

--- a/tests/test_us/tests.py
+++ b/tests/test_us/tests.py
@@ -297,3 +297,59 @@ class USLocalFlavorTests(TestCase):
             '999987652': error_invalid,
         }
         self.assertFieldOutput(forms.USSocialSecurityNumberField, valid, invalid)
+
+    def test_USIndividualTaxpayerIdentificationNumberField(self):
+        error_invalid = ['Enter a valid U.S. Individual Taxpayer Identification Number in XXX-XX-XXXX format.']
+        valid = {
+            '900-70-5678': '900-70-5678',   # group 70 (lower bound of 70–88 range)
+            '900-88-1234': '900-88-1234',   # group 88 (upper bound of 70–88 range)
+            '912701234': '912-70-1234',      # no separators
+            '950-90-9999': '950-90-9999',   # group 90 (lower bound of 90–92 range)
+            '950-92-9999': '950-92-9999',   # group 92 (upper bound of 90–92 range)
+            '950-94-9999': '950-94-9999',   # group 94 (lower bound of 94–99 range)
+            '950-99-1234': '950-99-1234',   # group 99 (upper bound of 94–99 range)
+        }
+        invalid = {
+            '123-70-1234': error_invalid,   # area doesn't start with 9
+            '900-00-1234': error_invalid,   # group 00
+            '900-70-0000': error_invalid,   # serial 0000
+            '900-50-1234': error_invalid,   # group 50 (not an ITIN range)
+            '900-69-1234': error_invalid,   # group 69 (below 70–88 range)
+            '900-89-1234': error_invalid,   # group 89 (gap between 70–88 and 90–92)
+            '900-93-1234': error_invalid,   # group 93 (ATIN, not ITIN)
+        }
+        self.assertFieldOutput(forms.USIndividualTaxpayerIdentificationNumberField, valid, invalid)
+
+    def test_USAdoptionTaxpayerIdentificationNumberField(self):
+        error_invalid = ['Enter a valid U.S. Adoption Taxpayer Identification Number in XXX-XX-XXXX format.']
+        valid = {
+            '900-93-1234': '900-93-1234',   # group 93 (only valid ATIN group)
+            '912-93-5678': '912-93-5678',   # group 93, different area
+            '999931234': '999-93-1234',     # no separators
+        }
+        invalid = {
+            '123-93-1234': error_invalid,   # area doesn't start with 9
+            '900-93-0000': error_invalid,   # serial 0000
+            '900-70-1234': error_invalid,   # group 70 (ITIN range, not ATIN)
+            '900-92-5678': error_invalid,   # group 92 (ITIN range, not ATIN)
+            '900-30-1234': error_invalid,   # group 30 (neither ITIN nor ATIN)
+            '900-94-5678': error_invalid,   # group 94 (ITIN range, not ATIN)
+        }
+        self.assertFieldOutput(forms.USAdoptionTaxpayerIdentificationNumberField, valid, invalid)
+
+    def test_USTaxpayerIdentificationNumberField(self):
+        error_invalid = ['Enter a valid U.S. taxpayer identification number in XXX-XX-XXXX format.']
+        valid = {
+            '123-45-6789': '123-45-6789',   # valid SSN
+            '900-70-5678': '900-70-5678',   # valid ITIN
+            '900-93-1234': '900-93-1234',   # valid ATIN
+        }
+        invalid = {
+            '000-45-6789': error_invalid,   # area all zeros
+            '666-45-6789': error_invalid,   # area 666 (invalid SSN block)
+            '078-05-1120': error_invalid,   # blocked SSN
+            '900-89-1234': error_invalid,   # 9xx with invalid group (not ITIN or ATIN)
+            '123-45-0000': error_invalid,   # serial all zeros
+            '123-00-6789': error_invalid,   # group all zeros
+        }
+        self.assertFieldOutput(forms.USTaxpayerIdentificationNumberField, valid, invalid)


### PR DESCRIPTION
Adds form and model fields for two IRS taxpayer identification number types that were previously unsupported: ITIN (Individual Taxpayer Identification Number) and ATIN (Adoption Taxpayer Identification Number). Also adds a combined `USTaxpayerIdentificationNumberField` that accepts any valid SSN, ITIN, or ATIN.

The existing `USSocialSecurityNumberField` has been refactored to extend a new private base class (`_USFederalIDBaseField`) that handles the shared `XXX-XX-XXXX` format validation and normalization, eliminating duplication across the three field types.

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

**New Fields Only**

- [x] Prefix the country code to all fields.

- [x] Field names should be easily understood by developers from the target
      localflavor country. This means that English translations are usually
      not the best name unless it's for something standard like postal code,
      tax / VAT ID etc.

- [x] Prefer '<country code>PostalCodeField' for postal codes as it's
      international English; ZipCode is a term specific to the United
      States postal system.

- [x] Add meaningful tests. 100% test coverage is not required but all
      validation edge cases should be covered.

- [x] Add `.. versionadded:: 5.1` comment markers to new
      localflavors.

- [x] Add documentation for all fields.

**References**

- [IRS ITIN overview](https://www.irs.gov/individuals/individual-taxpayer-identification-number)
- [IRS ATIN overview](https://www.irs.gov/individuals/adoption-taxpayer-identification-number)
- [TaxAct: What is an ITIN?](https://www.taxact.com/tax-information/what-is-an-itin) — source for ITIN group ranges (70–88, 90–92, 94–99)
- [TaxAct: What is an ATIN?](https://www.taxact.com/tax-information/what-is-an-atin) — source for ATIN group range (93 only)
