### PR TITLE
Require stdnum>=2.2 and add example IBANs from IBAN registry v101

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,6 @@ Changelog
 
 New flavors:
 
-- Added Falkland Islands (Malvinas), Honduras, Oman, Somalia and Yemen to IBAN_COUNTRY_CODE_LENGTH dict based on
-  version 101 of the IBAN registry document from December 2025.
 - Added local flavor for Qatar
   (`gh-544 <https://github.com/django/django-localflavor/pull/544>`_).
 - Added local flavor for Taiwan
@@ -29,6 +27,10 @@ Modifications to existing flavors:
   (`gh-529 <https://github.com/django/django-localflavor/pull/529>`_).
 - Update SI postal codes
   (`gh-531 <https://github.com/django/django-localflavor/pull/531>`_).
+- Added Falkland Islands (Malvinas), Honduras, Oman, Somalia and Yemen to IBAN_COUNTRY_CODE_LENGTH dict based on
+  version 101 of the IBAN registry document from December 2025
+  (`gh-538 <https://github.com/django/django-localflavor/pull/538>`_),
+  (`gh-xxx <https://github.com/django/django-localflavor/pull/xxx>`_).
 - Updated NORDEA_COUNTRY_CODE_LENGTH with data from nordea-country-and-currency-list.pdf v2.2
   (`gh-546 <https://github.com/django/django-localflavor/pull/546>`_).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,9 +28,9 @@ Modifications to existing flavors:
 - Update SI postal codes
   (`gh-531 <https://github.com/django/django-localflavor/pull/531>`_).
 - Added Falkland Islands (Malvinas), Honduras, Oman, Somalia and Yemen to IBAN_COUNTRY_CODE_LENGTH dict based on
-  version 101 of the IBAN registry document from December 2025
+  version 101 of the IBAN registry document from December 2025. The minium version of python-stdnum is now 2.2.
   (`gh-538 <https://github.com/django/django-localflavor/pull/538>`_),
-  (`gh-547 <https://github.com/django/django-localflavor/pull/547>`_).
+  (`gh-547 <https://github.com/django/django-localflavor/pull/547>`_)
 - Updated NORDEA_COUNTRY_CODE_LENGTH with data from nordea-country-and-currency-list.pdf v2.2
   (`gh-546 <https://github.com/django/django-localflavor/pull/546>`_).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,7 +30,7 @@ Modifications to existing flavors:
 - Added Falkland Islands (Malvinas), Honduras, Oman, Somalia and Yemen to IBAN_COUNTRY_CODE_LENGTH dict based on
   version 101 of the IBAN registry document from December 2025
   (`gh-538 <https://github.com/django/django-localflavor/pull/538>`_),
-  (`gh-xxx <https://github.com/django/django-localflavor/pull/xxx>`_).
+  (`gh-547 <https://github.com/django/django-localflavor/pull/547>`_).
 - Updated NORDEA_COUNTRY_CODE_LENGTH with data from nordea-country-and-currency-list.pdf v2.2
   (`gh-546 <https://github.com/django/django-localflavor/pull/546>`_).
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 Django
 Jinja2
-python-stdnum>=1.6
+python-stdnum>=2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "django>=4.2",
-    "python-stdnum>=1.6",
+    "python-stdnum>=2.2",
 ]
 authors = [
   { name="Django Software Foundation", email="foundation@djangoproject.com" },

--- a/tests/test_generic/tests.py
+++ b/tests/test_generic/tests.py
@@ -94,6 +94,106 @@ class SplitDateTimeFieldTests(DateTimeFieldTestCase):
 
 
 class IBANTests(TestCase):
+    def test_iban_validator__example_ibans(self):
+        # Example IBANs are from the official IBAN Registry (TXT) document available here:
+        # https://www.swift.com/swift-resource/11971/download
+        valid_ibans = [
+            "AD12 0001 2030 2003 5910 0100",
+            "AE07 0331 2345 6789 0123 456",
+            "AL47 2121 1009 0000 0002 3569 8741",
+            "AT61 1904 3002 3457 3201",
+            "AZ21 NABZ 0000 0000 1370 1000 1944",
+            "BA39 1290 0794 0102 8494",
+            # "BE68 5390 0754 7034", - Can't use example from the IBAN registry because 539 is not a valid bank code.
+            "BE41 0630 1234 5610",  # Alternate example with a valid bank.
+            "BG80 BNBG 9661 1020 3456 78",
+            "BH67 BMAG 0000 1299 1234 56",
+            "BI42 10000 10001 00003320451 81",
+            "BR18 0036 0305 0000 1000 9795 493C 1",
+            "BY13 NBRB 3600 9000 0000 2Z00 AB00",
+            "CH93 0076 2011 6238 5295 7",
+            "CR05 0152 0200 1026 2840 66",
+            "CY17 0020 0128 0000 0012 0052 7600",
+            "CZ65 0800 0000 1920 0014 5399",
+            "DE89 3704 0044 0532 0130 00",
+            "DJ21 0001 0000 0001 5400 0100 186",
+            "DK50 0040 0440 1162 43",
+            "DO28 BAGR 0000 0001 2124 5361 1324",
+            "EE38 2200 2210 2014 5685",
+            "EG38 0019 0005 0000 0000 2631 8000 2",
+            "ES91 2100 0418 4502 0005 1332",
+            "FI21 1234 5600 0007 85",
+            "FK88 SC12 3456 7890 12",
+            "FO62 6460 0001 6316 34",
+            "FR14 2004 1010 0505 0001 3M02 606",
+            "GB29 NWBK 6016 1331 9268 19",
+            "GE29 NB00 0000 0101 9049 17",
+            "GI75 NWBK 0000 0000 7099 453",
+            "GL89 6471 0001 0002 06",
+            "GR16 0110 1250 0000 0001 2300 695",
+            "GT82 TRAJ 0102 0000 0012 1002 9690",
+            "HN88 CABF 0000 0000 0002 5000 5469",
+            "HR12 1001 0051 8630 0016 0",
+            "HU42 1177 3016 1111 1018 0000 0000",
+            "IE29 AIBK 9311 5212 3456 78",
+            "IL62 0108 0000 0009 9999 999",
+            "IQ98 NBIQ 8501 2345 6789 012",
+            "IS14 0159 2600 7654 5510 7303 39",
+            "IT60 X054 2811 1010 0000 0123 456",
+            "JO94 CBJO 0010 0000 0000 0131 0003 02",
+            "KW81 CBKU 0000 0000 0000 1234 5601 01",
+            "KZ86 125K ZT50 0410 0100",
+            "LB62 0999 0000 0001 0019 0122 9114",
+            "LC55 HEMM 0001 0001 0012 0012 0002 3015",
+            "LI21 0881 0000 2324 013A A",
+            "LT12 1000 0111 0100 1000",
+            "LU28 0019 4006 4475 0000",
+            "LV80 BANK 0000 4351 9500 1",
+            "LY83 002 048 000020100120361",
+            "MC58 1122 2000 0101 2345 6789 030",
+            "MD24 AG00 0225 1000 1310 4168",
+            "ME25 5050 0001 2345 6789 51",
+            "MK07 2501 2000 0058 984",
+            "MN12 1234 1234 5678 9123",
+            "MR13 0002 0001 0100 0012 3456 753",
+            "MT84 MALT 0110 0001 2345 MTLC AST0 01S",
+            "MU17 BOMM 0101 1010 3030 0200 000M UR",
+            "NI45 BAPR 0000 0013 0000 0355 8124",
+            "NL91 ABNA 0417 1643 00",
+            "NO93 8601 1117 947",
+            "OM81 0180 0000 0129 9123 456",
+            "PK36 SCBL 0000 0011 2345 6702",
+            "PL61 1090 1014 0000 0712 1981 2874",
+            "PS92 PALS 0000 0000 0400 1234 5670 2",
+            "PT50 0002 0123 1234 5678 9015 4",
+            "QA58 DOHB 0000 1234 5678 90AB CDEF G",
+            "RO49 AAAA 1B31 0075 9384 0000",
+            "RS35 2600 0560 1001 6113 79",
+            "RU03 0445 2522 5408 1781 0538 0913 1041 9",
+            "SA03 8000 0000 6080 1016 7519",
+            "SC18 SSCB 1101 0000 0000 0000 1497 USD",
+            "SD21 2901 0501 2340 01",
+            "SE45 5000 0000 0583 9825 7466",
+            "SI56 2633 0001 2039 086",
+            "SK31 1200 0000 1987 4263 7541",
+            "SM86 U032 2509 8000 0000 0270 100",
+            "SO21 1000 0010 0100 0100 141",
+            "ST23 0001 0001 0051 8453 1014 6",
+            "SV62 CENR 0000 0000 0000 0070 0025",
+            "TL38 0080 0123 4567 8910 157",
+            "TN59 1000 6035 1835 9847 8831",
+            "TR33 0006 1005 1978 6457 8413 26",
+            "UA21 3223 1300 0002 6007 2335 6600 1",
+            "VA59 001 1230 0001 2345 678",
+            "VG96 VPVG 0000 0123 4567 8901",
+            "XK05 1212 0123 4567 8906",
+            "YE15 CBYE 0001 0188 6123 4567 8912 34",
+        ]
+        iban_validator = IBANValidator()
+        for iban in valid_ibans:
+            with self.subTest(iban=iban):
+                iban_validator(iban)  # No exception raised.
+
     def test_iban_validator(self):
         valid = [
             'GB82WeST12345698765432',
@@ -359,10 +459,12 @@ class BICTests(TestCase):
 
         bic_validator = BICValidator()
         for bic in valid:
-            bic_validator(bic)
+            with self.subTest():
+                bic_validator(bic)
 
         for bic in invalid:
-            self.assertRaisesMessage(ValidationError,  invalid[bic], BICValidator(), bic)
+            with self.subTest():
+                self.assertRaisesMessage(ValidationError,  invalid[bic], BICValidator(), bic)
 
     def test_bic_validator_deconstruct(self):
         bic1 = BICValidator()

--- a/tests/test_generic/tests.py
+++ b/tests/test_generic/tests.py
@@ -95,7 +95,7 @@ class SplitDateTimeFieldTests(DateTimeFieldTestCase):
 
 class IBANTests(TestCase):
     def test_iban_validator__example_ibans(self):
-        # Example IBANs are from the official IBAN Registry (TXT) document available here:
+        # IBAN Registry v101 example IBANs published here:
         # https://www.swift.com/swift-resource/11971/download
         valid_ibans = [
             "AD12 0001 2030 2003 5910 0100",


### PR DESCRIPTION
We need to require stdnum >= 2.2 so that all the IBANs from registry v101 validated correctly. 