### PR TITLE
add more project urls

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -76,6 +76,7 @@ Authors
 * Jannis Leidel
 * Jan Pieter Waagmeester
 * Jarmo van Lenthe
+* Jens Nistler
 * Jérémie Ferry
 * Jernej Porenta
 * Jocelyn Delalande

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,8 @@ Modifications to existing flavors:
 
 Other changes:
 
-- None
+- Add more project links to pyproject.toml
+  (`gh-551 <https://github.com/django/django-localflavor/pull/551>`_).
 
 
 5.1   (2026-08-01)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://django-localflavor.readthedocs.io/en/latest/"
+Documentation = "https://django-localflavor.readthedocs.io/en/latest/"
 Source = "https://github.com/django/django-localflavor"
+Issues = "https://github.com/django/django-localflavor/issues"
+Changelog = "https://django-localflavor.readthedocs.io/en/latest/changelog.html"
 
 [tool.setuptools.dynamic]
 version = { attr = "localflavor.__version__" }


### PR DESCRIPTION
Added more project URLs to make finding relevant links easier:

* Add link to `Documentation` (even though `Homepage` also links to the documentation, it makes it easier to find it by label)
* Add link to `Issues` (to check if an issue has already been reported or to create a new one)
* Add link to `Changelog` (makes it easier to find the changes when updating and allow tools like [renovate](https://github.com/renovatebot/renovate) to link to them)

The designations were selected in accordance with https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels

**All Changes**

- [x] Add an entry to the docs/changelog.rst describing the change.

- [x] Add an entry for your name in the docs/authors.rst file if it's not
      already there.

